### PR TITLE
Better javascript evaluation support

### DIFF
--- a/chromiumoxide_cdp/src/lib.rs
+++ b/chromiumoxide_cdp/src/lib.rs
@@ -2,7 +2,9 @@ use std::fmt;
 
 use crate::cdp::browser_protocol::network::{CookieParam, DeleteCookiesParams};
 use crate::cdp::browser_protocol::target::CreateTargetParams;
-use crate::cdp::js_protocol::runtime::{ExceptionDetails, StackTrace};
+use crate::cdp::js_protocol::runtime::{
+    CallFunctionOnParams, EvaluateParams, ExceptionDetails, StackTrace,
+};
 
 // Include all the types
 include!(concat!(env!("OUT_DIR"), "/cdp.rs"));
@@ -22,6 +24,23 @@ impl DeleteCookiesParams {
             url: param.url.clone(),
             domain: param.domain.clone(),
             path: param.path.clone(),
+        }
+    }
+}
+
+impl Into<CallFunctionOnParams> for EvaluateParams {
+    fn into(self) -> CallFunctionOnParams {
+        CallFunctionOnParams {
+            function_declaration: self.expression,
+            object_id: None,
+            arguments: None,
+            silent: self.silent,
+            return_by_value: self.return_by_value,
+            generate_preview: self.generate_preview,
+            user_gesture: self.user_gesture,
+            await_promise: self.await_promise,
+            execution_context_id: self.context_id,
+            object_group: self.object_group,
         }
     }
 }

--- a/examples/evaluate.rs
+++ b/examples/evaluate.rs
@@ -18,6 +18,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sum: usize = page.evaluate("1 + 2").await?.into_value()?;
     assert_eq!(sum, 3);
+    println!("1 + 2 = {}", sum);
+
+    let mult: usize = page
+        .evaluate("() => { return 21 * 2; }")
+        .await?
+        .into_value()?;
+    assert_eq!(mult, 42);
+    println!("21 * 2 = {}", mult);
+
+    let promise_div: usize = page
+        .evaluate("() => Promise.resolve(100 / 25)")
+        .await?
+        .into_value()?;
+    assert_eq!(promise_div, 4);
+    println!("100 / 25 = {}", promise_div);
 
     handle.await;
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ pub enum CdpError {
     /// Detailed information about exception (or error) that was thrown during
     /// script compilation or execution
     #[error("{0:?}")]
-    JavascriptException(#[from] ExceptionDetails),
+    JavascriptException(Box<ExceptionDetails>),
 }
 impl CdpError {
     pub fn msg(msg: impl Into<String>) -> Self {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -33,7 +33,7 @@ use crate::page::Page;
 pub const REQUEST_TIMEOUT: u64 = 30_000;
 
 pub mod browser;
-mod domworld;
+pub mod domworld;
 pub mod emulation;
 pub mod frame;
 mod job;

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -285,6 +285,12 @@ impl PageInner {
         Ok(self.execution_context_for_world(DOMWorldKind::Main).await?)
     }
 
+    pub async fn secondary_execution_context(&self) -> Result<Option<ExecutionContextId>> {
+        Ok(self
+            .execution_context_for_world(DOMWorldKind::Secondary)
+            .await?)
+    }
+
     pub async fn execution_context_for_world(
         &self,
         dom_world: DOMWorldKind,

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -253,7 +253,7 @@ impl PageInner {
 
         let resp = self.execute(evaluate).await?.result;
         if let Some(exception) = resp.exception_details {
-            return Err(exception.into());
+            return Err(CdpError::JavascriptException(Box::new(exception)));
         }
 
         Ok(EvaluationResult::new(resp.result))
@@ -276,7 +276,7 @@ impl PageInner {
 
         let resp = self.execute(evaluate).await?.result;
         if let Some(exception) = resp.exception_details {
-            return Err(exception.into());
+            return Err(CdpError::JavascriptException(Box::new(exception)));
         }
         Ok(EvaluationResult::new(resp.result))
     }

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use serde::de::DeserializeOwned;
 
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{
@@ -7,15 +5,6 @@ use chromiumoxide_cdp::cdp::js_protocol::runtime::{
 };
 
 use crate::utils::is_likely_js_function;
-
-#[derive(Debug, Clone)]
-pub struct JsFunction {}
-
-impl fmt::Display for JsFunction {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unimplemented!()
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct EvaluationResult {

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,6 +1,12 @@
-use chromiumoxide_cdp::cdp::js_protocol::runtime::RemoteObject;
-use serde::de::DeserializeOwned;
 use std::fmt;
+
+use serde::de::DeserializeOwned;
+
+use chromiumoxide_cdp::cdp::js_protocol::runtime::{
+    CallFunctionOnParams, EvaluateParams, RemoteObject,
+};
+
+use crate::utils::is_likely_js_function;
 
 #[derive(Debug, Clone)]
 pub struct JsFunction {}
@@ -26,6 +32,10 @@ impl EvaluationResult {
         &self.inner
     }
 
+    pub fn value(&self) -> Option<&serde_json::Value> {
+        self.object().value.as_ref()
+    }
+
     /// Attempts to deserialize the value into the given type
     pub fn into_value<T: DeserializeOwned>(self) -> serde_json::Result<T> {
         let value = self
@@ -33,5 +43,39 @@ impl EvaluationResult {
             .value
             .ok_or_else(|| serde::de::Error::custom("No value found"))?;
         serde_json::from_value(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Evaluation {
+    Expression(EvaluateParams),
+    Function(CallFunctionOnParams),
+}
+
+impl From<&str> for Evaluation {
+    fn from(expression: &str) -> Self {
+        if is_likely_js_function(expression) {
+            CallFunctionOnParams::from(expression).into()
+        } else {
+            EvaluateParams::from(expression).into()
+        }
+    }
+}
+
+impl From<String> for Evaluation {
+    fn from(expression: String) -> Self {
+        expression.as_str().into()
+    }
+}
+
+impl From<EvaluateParams> for Evaluation {
+    fn from(params: EvaluateParams) -> Self {
+        Evaluation::Expression(params)
+    }
+}
+
+impl From<CallFunctionOnParams> for Evaluation {
+    fn from(params: CallFunctionOnParams) -> Self {
+        Evaluation::Function(params)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use chromiumoxide_types::{self as types, Binary, Command, Method, MethodType
 pub use crate::browser::{Browser, BrowserConfig};
 pub use crate::conn::Connection;
 pub use crate::element::Element;
+pub use crate::error::Result;
 pub use crate::handler::Handler;
 pub use crate::page::Page;
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -883,7 +883,7 @@ impl Page {
             .execution_context_for_world(DOMWorldKind::Secondary)
             .await?;
 
-        let resp = self.evaluate_function(call).await?;
+        self.evaluate_function(call).await?;
         // relying that document.open() will reset frame lifecycle with "init"
         // lifecycle event. @see https://crrev.com/608658
         Ok(self.wait_for_navigation().await?)
@@ -930,9 +930,9 @@ impl From<Arc<PageInner>> for Page {
 fn validate_cookie_url(url: &str) -> Result<()> {
     if url.starts_with("data:") {
         Err(CdpError::msg("Data URL page can not have cookie"))
-    } else if url != "about:blank" {
-        Err(CdpError::msg("Blank page can not have cookie"))
-    } else {
+    } else if url == "about:blank" {
         Ok(())
+    } else {
+        Err(CdpError::msg("Blank page can not have cookie"))
     }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -649,7 +649,28 @@ impl Page {
         Ok(self.inner.layout_metrics().await?)
     }
 
-    /// This evaluates strictly as expression
+    /// This evaluates strictly as expression.
+    ///
+    /// Same as `Page::evaluate` but no fallback or any attempts to detect
+    /// whether the expression is actually a function. However you can
+    /// submit a function evaluation string:
+    ///
+    /// # Example Evaluate function call as expression
+    ///
+    /// This will take the arguments `(1,2)` and will call the function
+    ///
+    /// ```no_run
+    /// # use chromiumoxide::page::Page;
+    /// # use chromiumoxide::error::Result;
+    /// # async fn demo(page: Page) -> Result<()> {
+    ///     let sum: usize = page
+    ///         .evaluate_expression("((a,b) => {return a + b;})(1,2)")
+    ///         .await?
+    ///         .into_value()?;
+    ///     assert_eq!(sum, 3);
+    ///     # Ok(())
+    /// # }
+    /// ```
     pub async fn evaluate_expression(
         &self,
         evaluate: impl Into<EvaluateParams>,
@@ -657,8 +678,57 @@ impl Page {
         Ok(self.inner.evaluate_expression(evaluate).await?)
     }
 
-    /// Evaluates an expression in the page's context and returns the result.
-    /// # Example
+    /// Evaluates an expression or function in the page's context and returns
+    /// the result.
+    ///
+    /// In contrast to `Page::evaluate_expression` this is capable of handling
+    /// function calls and expressions alike. This takes anything that is
+    /// `Into<Evaluation>`. When passing a `String` or `str`, this will try to
+    /// detect whether it is a function or an expression. JS function detection
+    /// is not very sophisticated but works for general cases (`(async)
+    /// functions` and arrow functions). If you want a string statement
+    /// specifically evaluated as expression or function either use the
+    /// designated functions `Page::evaluate_function` or
+    /// `Page::evaluate_expression` or use the proper parameter type for
+    /// `Page::execute`:  `EvaluateParams` for strict expression evaluation or
+    /// `CallFunctionOnParams` for strict function evaluation.
+    ///
+    /// If you don't trust the js function detection and are not sure whether
+    /// the statement is an expression or of type function (arrow functions: `()
+    /// => {..}`), you should pass it as `EvaluateParams` and set the
+    /// `EvaluateParams::eval_as_function_fallback` option. This will first
+    /// try to evaluate it as expression and if the result comes back
+    /// evaluated as `RemoteObjectType::Function` it will submit the
+    /// statement again but as function:
+    ///
+    ///  # Example Evaluate function statement as expression with fallback
+    /// option
+    ///
+    /// ```no_run
+    /// # use chromiumoxide::page::Page;
+    /// # use chromiumoxide::error::Result;
+    /// # use chromiumoxide_cdp::cdp::js_protocol::runtime::{EvaluateParams, RemoteObjectType};
+    /// # async fn demo(page: Page) -> Result<()> {
+    ///     let eval = EvaluateParams::builder().expression("() => {return 42;}");
+    ///     // this will fail because the `EvaluationResult` returned by the browser will be
+    ///     // of type `Function`
+    ///     let result = page
+    ///                 .evaluate(eval.clone().build().unwrap())
+    ///                 .await?;
+    ///     assert_eq!(result.object().r#type, RemoteObjectType::Function);
+    ///     assert!(result.into_value::<usize>().is_err());
+    ///
+    ///     // This will also fail on the first try but it detects that the browser evaluated the
+    ///     // statement as function and then evaluate it again but as function
+    ///     let sum: usize = page
+    ///         .evaluate(eval.eval_as_function_fallback(true).build().unwrap())
+    ///         .await?
+    ///         .into_value()?;
+    ///     # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Example Evaluate basic expression
     /// ```no_run
     /// # use chromiumoxide::page::Page;
     /// # use chromiumoxide::error::Result;
@@ -695,6 +765,58 @@ impl Page {
         }
     }
 
+    /// Eexecutes a function withinthe page's context and returns the result.
+    ///
+    /// # Example Evaluate a promise
+    /// This will wait until the promise resolves and then returns the result.
+    /// ```no_run
+    /// # use chromiumoxide::page::Page;
+    /// # use chromiumoxide::error::Result;
+    /// # async fn demo(page: Page) -> Result<()> {
+    ///     let sum:usize = page.evaluate_function("() => Promise.resolve(1 + 2)").await?.into_value()?;
+    ///     assert_eq!(sum, 3);
+    ///     # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Example Evaluate an async function
+    /// ```no_run
+    /// # use chromiumoxide::page::Page;
+    /// # use chromiumoxide::error::Result;
+    /// # async fn demo(page: Page) -> Result<()> {
+    ///     let val:usize = page.evaluate_function("async function() {return 42;}").await?.into_value()?;
+    ///     assert_eq!(val, 42);
+    ///     # Ok(())
+    /// # }
+    /// ```
+    /// # Example Construct a function call
+    ///
+    /// ```no_run
+    /// # use chromiumoxide::page::Page;
+    /// # use chromiumoxide::error::Result;
+    /// # use chromiumoxide_cdp::cdp::js_protocol::runtime::{CallFunctionOnParams, CallArgument};
+    /// # async fn demo(page: Page) -> Result<()> {
+    ///     let call = CallFunctionOnParams::builder()
+    ///            .function_declaration(
+    ///                "(a,b) => { return a + b;}"
+    ///            )
+    ///            .argument(
+    ///                CallArgument::builder()
+    ///                    .value(serde_json::json!(1))
+    ///                    .build(),
+    ///            )
+    ///            .argument(
+    ///                CallArgument::builder()
+    ///                    .value(serde_json::json!(2))
+    ///                    .build(),
+    ///            )
+    ///            .build()
+    ///            .unwrap();
+    ///     let sum:usize = page.evaluate_function(call).await?.into_value()?;
+    ///     assert_eq!(sum, 3);
+    ///     # Ok(())
+    /// # }
+    /// ```
     pub async fn evaluate_function(
         &self,
         evaluate: impl Into<CallFunctionOnParams>,
@@ -717,6 +839,19 @@ impl Page {
         Ok(self.execute(script.into()).await?.result.identifier)
     }
 
+    /// Set the content of the frame.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use chromiumoxide::page::Page;
+    /// # use chromiumoxide::error::Result;
+    /// # async fn demo(page: Page) -> Result<()> {
+    ///     page.set_content("<body>
+    ///  <h1>This was set via chromiumoxide</h1>
+    ///  </body>").await?;
+    ///     # Ok(())
+    /// # }
+    /// ```
     pub async fn set_content(&self, html: impl AsRef<str>) -> Result<&Self> {
         let mut call = CallFunctionOnParams::builder()
             .function_declaration(

--- a/src/page.rs
+++ b/src/page.rs
@@ -830,6 +830,15 @@ impl Page {
         Ok(self.inner.execution_context().await?)
     }
 
+    /// Returns the secondary execution context identifier of this page that
+    /// represents the context for JavaScript execution for manipulating the
+    /// DOM.
+    ///
+    /// See `Page::set_contents`
+    pub async fn secondary_execution_context(&self) -> Result<Option<ExecutionContextId>> {
+        Ok(self.inner.secondary_execution_context().await?)
+    }
+
     /// Evaluates given script in every frame upon creation (before loading
     /// frame's scripts)
     pub async fn evaluate_on_new_document(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,3 +24,69 @@ pub fn evaluation_string(function: impl AsRef<str>, params: &[impl AsRef<str>]) 
         .join(",");
     format!("({})({})", function.as_ref(), params)
 }
+
+/// Tries to identify whether this a javascript function
+pub fn is_likely_js_function(function: impl AsRef<str>) -> bool {
+    let mut fun = function.as_ref().trim_start();
+    if fun.is_empty() {
+        return false;
+    }
+    let mut offset = 0;
+
+    if fun.starts_with("async ") {
+        offset = "async ".len() - 1
+    }
+
+    if fun[offset..].trim_start().starts_with("function ") {
+        return true;
+    } else if skip_args(&mut fun) {
+        // attempt to detect arrow functions by stripping the leading arguments and
+        // looking for the arrow
+        if fun.trim_start().starts_with("=>") {
+            return true;
+        }
+    }
+    false
+}
+
+/// This attempts to strip any leading pair of parentheses from the input
+///
+/// `()=>` -> `=>`
+/// `(abc, def)=>` -> `=>`
+fn skip_args(input: &mut &str) -> bool {
+    if !input.starts_with('(') {
+        return false;
+    }
+    let mut open = 1;
+    let mut closed = 0;
+    *input = &input[1..];
+    while !input.is_empty() && open != closed {
+        if let Some(idx) = input.find(&['(', ')'] as &[_]) {
+            if &input[idx..=idx] == ")" {
+                closed += 1;
+            } else {
+                open += 1;
+            }
+            *input = &input[idx + 1..];
+        } else {
+            break;
+        }
+    }
+
+    open == closed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_js_function() {
+        assert!(is_likely_js_function("function abc() {}"));
+        assert!(is_likely_js_function("async function abc() {}"));
+        assert!(is_likely_js_function("() => {}"));
+        assert!(is_likely_js_function("(abc, def) => {}"));
+        assert!(is_likely_js_function("((abc), (def)) => {}"));
+        assert!(is_likely_js_function("() => Promise.resolve(100 / 25)"));
+    }
+}


### PR DESCRIPTION
This provides better support for evaluating JS expressions and functions alike and closes #8 .
* designated API function for expressions (`Page::evaluate_expression`) and functions (`Page::evaluate_functions`)
* General API function that can handle both `Page::evaluate`
* Bunch of docs
* fixes the broken `set_contents` function