### PR TITLE
update Readme with correct dependency line

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ By default `chromiumoxide` is configured with `async-std`.
 Use `chromiumoxide` with the `async-std` runtime:
 
 ```toml
-chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide" }
+chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", branch = "main"}
 ```
 
 To use the `tokio` runtime instead add `features = ["tokio-runtime"]` and set `default-features = false` to disable the default runtime (`async-std`):
 
 ```toml
-chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", features = ["tokio-runtime"], default-features = false }
+chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", features = ["tokio-runtime"], default-features = false, branch = "main"}
 ```
 
 This configuration is made possible primarily by the websocket crate of choice: [`async-tungstenite`](https://github.com/sdroege/async-tungstenite).


### PR DESCRIPTION
Because cargo --git still assumes "master" branch instead of HEAD and because github has changed all repositories over to main the dependency lines in the README will fail with:
```bash
cannot locate remote-tracking branch 'origin/master'; class=Reference (4); code=NotFound
```
I had to specify the branch with:
`chromiumoxide = { git = "https://github.com/mattsse/chromiumoxide", branch = "main"}`