### PR TITLE
Rollback PDL to r818844

### DIFF
--- a/chromiumoxide_cdp/browser_protocol.pdl
+++ b/chromiumoxide_cdp/browser_protocol.pdl
@@ -53,7 +53,6 @@ experimental domain Accessibility
       labelfor
       labelwrapped
       legend
-      rubyannotation
       tablecaption
       title
       other
@@ -203,20 +202,8 @@ experimental domain Accessibility
       # children, if requested.
       array of AXNode nodes
 
-  # Fetches the entire accessibility tree for the root Document
+  # Fetches the entire accessibility tree
   experimental command getFullAXTree
-    parameters
-      # The maximum depth at which descendants of the root node should be retrieved.
-      # If omitted, the full tree is returned.
-      optional integer max_depth
-    returns
-      array of AXNode nodes
-
-  # Fetches a particular accessibility node by AXNodeId.
-  # Requires `enable()` to have been called previously.
-  experimental command getChildAXNodes
-    parameters
-      AXNodeId id
     returns
       array of AXNode nodes
 
@@ -661,14 +648,6 @@ experimental domain Audits
       optional SourceCodeLocation sourceCodeLocation
       optional DOM.BackendNodeId violatingNodeId
 
-  # Details for a request that has been blocked with the BLOCKED_BY_RESPONSE
-  # code. Currently only used for COEP/COOP, but may be extended to include
-  # some CSP errors in the future.
-  type SharedArrayBufferTransferIssueDetails extends object
-    properties
-      SourceCodeLocation sourceCodeLocation
-      boolean isWarning
-
   # A unique identifier for the type of issue. Each type may use one of the
   # optional fields in InspectorIssueDetails to convey more specific
   # information about the kind of issue.
@@ -679,7 +658,6 @@ experimental domain Audits
       BlockedByResponseIssue
       HeavyAdIssue
       ContentSecurityPolicyIssue
-      SharedArrayBufferTransferIssue
 
   # This struct holds a list of optional fields with additional information
   # specific to the kind of issue. When adding a new issue code, please also
@@ -691,7 +669,6 @@ experimental domain Audits
       optional BlockedByResponseIssueDetails blockedByResponseIssueDetails
       optional HeavyAdIssueDetails heavyAdIssueDetails
       optional ContentSecurityPolicyIssueDetails contentSecurityPolicyIssueDetails
-      optional SharedArrayBufferTransferIssueDetails sharedArrayBufferTransferIssueDetails
 
   # An inspector issue reported from the back-end.
   type InspectorIssue extends object
@@ -838,7 +815,6 @@ domain Browser
       backgroundFetch
       clipboardReadWrite
       clipboardSanitizedWrite
-      displayCapture
       durableStorage
       flash
       geolocation
@@ -878,12 +854,6 @@ domain Browser
       optional boolean allowWithoutSanitization
       # For "camera" permission, may specify panTiltZoom.
       optional boolean panTiltZoom
-
-  # Browser command ids used by executeBrowserCommand.
-  experimental type BrowserCommandId extends string
-    enum
-      openTabSearch
-      closeTabSearch
 
   # Set permission settings for given origin.
   experimental command setPermission
@@ -1043,11 +1013,6 @@ domain Browser
       optional string badgeLabel
       # Png encoded image.
       optional binary image
-
-  # Invoke custom browser commands used by telemetry.
-  experimental command executeBrowserCommand
-    parameters
-      BrowserCommandId commandId
 
 # This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and styles)
 # have an associated `id` used in subsequent operations on the related object. Each object type has
@@ -1814,9 +1779,6 @@ domain DOM
       marker
       backdrop
       selection
-      target-text
-      spelling-error
-      grammar-error
       first-line-inherited
       scrollbar
       scrollbar-thumb
@@ -2548,12 +2510,6 @@ domain DOMDebugger
       attribute-modified
       node-removed
 
-  # CSP Violation type.
-  experimental type CSPViolationType extends string
-    enum
-      trustedtype-sink-violation
-      trustedtype-policy-violation
-
   # Object event listener.
   type EventListener extends object
     properties
@@ -2620,12 +2576,6 @@ domain DOMDebugger
     parameters
       # Resource URL substring.
       string url
-
-  # Sets breakpoint on particular CSP violations.
-  experimental command setBreakOnCSPViolation
-    parameters
-      # CSP Violations to stop upon.
-      array of CSPViolationType violationTypes
 
   # Sets breakpoint on particular operation with DOM.
   command setDOMBreakpoint
@@ -3349,17 +3299,6 @@ domain Emulation
   # Notification sent after the virtual time budget for the current VirtualTimePolicy has run out.
   experimental event virtualTimeBudgetExpired
 
-  # Enum of image types that can be disabled.
-  experimental type DisabledImageType extends string
-    enum
-      avif
-      webp
-
-  experimental command setDisabledImageTypes
-    parameters
-      # Image types to disable.
-      array of DisabledImageType imageTypes
-
   # Allows overriding user agent with the given string.
   command setUserAgentOverride
     parameters
@@ -3669,14 +3608,6 @@ domain Input
       optional number rotationAngle
       # Force (default: 1.0).
       optional number force
-      # The normalized tangential pressure, which has a range of [-1,1] (default: 0).
-      experimental optional number tangentialPressure
-      # The plane angle between the Y-Z plane and the plane containing both the stylus axis and the Y axis, in degrees of the range [-90,90], a positive tiltX is to the right (default: 0)
-      experimental optional integer tiltX
-      # The plane angle between the X-Z plane and the plane containing both the stylus axis and the X axis, in degrees of the range [-90,90], a positive tiltY is towards the user (default: 0).
-      experimental optional integer tiltY
-      # The clockwise rotation of a pen stylus around its own major axis, in degrees in the range [0,359] (default: 0).
-      experimental optional integer twist
       # Identifier used to track touch sources between events, must be unique within an event.
       optional number id
 
@@ -3776,16 +3707,6 @@ domain Input
       optional integer buttons
       # Number of times the mouse button was clicked (default: 0).
       optional integer clickCount
-      # The normalized pressure, which has a range of [0,1] (default: 0).
-      experimental optional number force
-      # The normalized tangential pressure, which has a range of [-1,1] (default: 0).
-      experimental optional number tangentialPressure
-      # The plane angle between the Y-Z plane and the plane containing both the stylus axis and the Y axis, in degrees of the range [-90,90], a positive tiltX is to the right (default: 0).
-      experimental optional integer tiltX
-      # The plane angle between the X-Z plane and the plane containing both the stylus axis and the X axis, in degrees of the range [-90,90], a positive tiltY is towards the user (default: 0).
-      experimental optional integer tiltY
-      # The clockwise rotation of a pen stylus around its own major axis, in degrees in the range [0,359] (default: 0).
-      experimental optional integer twist
       # X delta in CSS pixels for mouse wheel event (default: 0).
       optional number deltaX
       # Y delta in CSS pixels for mouse wheel event (default: 0).
@@ -4302,7 +4223,6 @@ domain Network
       SignedExchange
       Ping
       CSPViolationReport
-      Preflight
       Other
 
   # Unique loader identifier.
@@ -4536,40 +4456,6 @@ domain Network
       corp-not-same-origin-after-defaulted-to-same-origin-by-coep
       corp-not-same-site
 
-  # The reason why request was blocked.
-  type CorsError extends string
-    enum
-      DisallowedByMode
-      InvalidResponse
-      WildcardOriginNotAllowed
-      MissingAllowOriginHeader
-      MultipleAllowOriginValues
-      InvalidAllowOriginValue
-      AllowOriginMismatch
-      InvalidAllowCredentials
-      CorsDisabledScheme
-      PreflightInvalidStatus
-      PreflightDisallowedRedirect
-      PreflightWildcardOriginNotAllowed
-      PreflightMissingAllowOriginHeader
-      PreflightMultipleAllowOriginValues
-      PreflightInvalidAllowOriginValue
-      PreflightAllowOriginMismatch
-      PreflightInvalidAllowCredentials
-      PreflightMissingAllowExternal
-      PreflightInvalidAllowExternal
-      InvalidAllowMethodsPreflightResponse
-      InvalidAllowHeadersPreflightResponse
-      MethodDisallowedByPreflightResponse
-      HeaderDisallowedByPreflightResponse
-      RedirectContainsCredentials
-      InsecurePrivateNetwork
-
-  type CorsErrorStatus extends object
-    properties
-      CorsError corsError
-      string failedParameter
-
   # Source of serviceworker response.
   type ServiceWorkerResponseSource extends string
     enum
@@ -4579,13 +4465,12 @@ domain Network
       network
 
   # Determines what type of Trust Token operation is executed and
-  # depending on the type, some additional parameters. The values
-  # are specified in third_party/blink/renderer/core/fetch/trust_token.idl.
+  # depending on the type, some additional parameters.
   experimental type TrustTokenParams extends object
     properties
       TrustTokenOperationType type
 
-      # Only set for "token-redemption" type and determine whether
+      # Only set for "srr-token-redemption" type and determine whether
       # to request a fresh SRR or use a still valid cached SRR.
       enum refreshPolicy
         UseCached
@@ -4599,9 +4484,9 @@ domain Network
     enum
       # Type "token-request" in the Trust Token API.
       Issuance
-      # Type "token-redemption" in the Trust Token API.
+      # Type "srr-token-redemption" in the Trust Token API.
       Redemption
-      # Type "send-redemption-record" in the Trust Token API.
+      # Type "send-srr" in the Trust Token API.
       Signing
 
   # HTTP response data.
@@ -4709,7 +4594,6 @@ domain Network
         script
         preload
         SignedExchange
-        preflight
         other
       # Initiator JavaScript stack trace, set for Script only.
       optional Runtime.StackTrace stack
@@ -4721,8 +4605,6 @@ domain Network
       # Initiator column number, set for Parser type or for Script type (when script is importing
       # module) (0-based).
       optional number columnNumber
-      # Set if another request triggered this request (e.g. preflight).
-      optional RequestId requestId
 
   # Cookie object
   type Cookie extends object
@@ -4749,8 +4631,6 @@ domain Network
       optional CookieSameSite sameSite
       # Cookie Priority
       experimental CookiePriority priority
-      # True if cookie is SameParty.
-      experimental boolean sameParty
 
   # Types of reasons why a cookie may not be stored from a response.
   experimental type SetCookieBlockedReason extends string
@@ -5257,10 +5137,10 @@ domain Network
       # Map with extra HTTP headers.
       Headers headers
 
-  # Specifies whether to attach a page script stack id in requests
-  experimental command setAttachDebugStack
+  # Specifies whether to sned a debug header to all outgoing requests.
+  experimental command setAttachDebugHeader
     parameters
-      # Whether to attach a page script stack for debugging purpose.
+      # Whether to send a debug header.
       boolean enabled
 
   # Sets the requests to intercept that match the provided patterns and optionally resource types.
@@ -5326,8 +5206,6 @@ domain Network
       optional boolean canceled
       # The reason why loading was blocked, if any.
       optional BlockedReason blockedReason
-       # The reason why loading was blocked by CORS, if any.
-      optional CorsErrorStatus corsErrorStatus
 
   # Fired when HTTP request has finished loading.
   event loadingFinished
@@ -5515,43 +5393,6 @@ domain Network
       # WebSocket request data.
       WebSocketRequest request
 
-  # Fired upon WebTransport creation.
-  event webTransportCreated
-    parameters
-      # WebTransport identifier.
-      RequestId transportId
-      # WebTransport request URL.
-      string url
-      # Timestamp.
-      MonotonicTime timestamp
-      # Request initiator.
-      optional Initiator initiator
-
-  event webTransportClosed
-    parameters
-      # WebTransport identifier.
-      RequestId transportId
-      # Timestamp.
-      MonotonicTime timestamp
-
-  experimental type PrivateNetworkRequestPolicy extends string
-    enum
-      Allow
-      BlockFromInsecureToMorePrivate
-
-  experimental type IPAddressSpace extends string
-    enum
-      Local
-      Private
-      Public
-      Unknown
-
-  experimental type ClientSecurityState extends object
-    properties
-      boolean initiatorIsSecureContext
-      IPAddressSpace initiatorIPAddressSpace
-      PrivateNetworkRequestPolicy privateNetworkRequestPolicy
-
   # Fired when additional information about a requestWillBeSent event is available from the
   # network stack. Not every requestWillBeSent event will have an additional
   # requestWillBeSentExtraInfo fired for it, and there is no guarantee whether requestWillBeSent
@@ -5565,8 +5406,6 @@ domain Network
       array of BlockedCookieWithReason associatedCookies
       # Raw request headers as they will be sent over the wire.
       Headers headers
-      # The client security state set for the request.
-      optional ClientSecurityState clientSecurityState
 
   # Fired when additional information about a responseReceived event is available from the network
   # stack. Not every responseReceived event will have an additional responseReceivedExtraInfo for
@@ -5584,36 +5423,6 @@ domain Network
       # Raw response header text as it was received over the wire. The raw text may not always be
       # available, such as in the case of HTTP/2 or QUIC.
       optional string headersText
-
-  # Fired exactly once for each Trust Token operation. Depending on
-  # the type of the operation and whether the operation succeeded or
-  # failed, the event is fired before the corresponding request was sent
-  # or after the response was received.
-  experimental event trustTokenOperationDone
-    parameters
-      # Detailed success or error status of the operation.
-      # 'AlreadyExists' also signifies a successful operation, as the result
-      # of the operation already exists und thus, the operation was abort
-      # preemptively (e.g. a cache hit).
-      enum status
-        Ok
-        InvalidArgument
-        FailedPrecondition
-        ResourceExhausted
-        AlreadyExists
-        Unavailable
-        BadResponse
-        InternalError
-        UnknownError
-        FulfilledLocally
-      TrustTokenOperationType type
-      RequestId requestId
-      # Top level origin. The context in which the operation was attempted.
-      optional string topLevelOrigin
-      # Origin of the issuer in case of a "Issuance" or "Redemption" operation.
-      optional string issuerOrigin
-      # The number of obtained Trust Tokens on a successful "Issuance" operation.
-      optional integer issuedTokenCount
 
   experimental type CrossOriginOpenerPolicyValue extends string
     enum
@@ -5643,8 +5452,8 @@ domain Network
 
   experimental type SecurityIsolationStatus extends object
     properties
-      optional CrossOriginOpenerPolicyStatus coop
-      optional CrossOriginEmbedderPolicyStatus coep
+      CrossOriginOpenerPolicyStatus coop
+      CrossOriginEmbedderPolicyStatus coep
 
   # Returns information about the COEP/COOP isolation status.
   experimental command getSecurityIsolationStatus
@@ -5744,50 +5553,6 @@ experimental domain Overlay
       # The grid container background color (Default: transparent).
       optional DOM.RGBA gridBackgroundColor
 
-  # Configuration data for the highlighting of Flex container elements.
-  type FlexContainerHighlightConfig extends object
-    properties
-      # The style of the container border
-      optional LineStyle containerBorder
-      # The style of the separator between lines
-      optional LineStyle lineSeparator
-      # The style of the separator between items
-      optional LineStyle itemSeparator
-      # Style of content-distribution space on the main axis (justify-content).
-      optional BoxStyle mainDistributedSpace
-      # Style of content-distribution space on the cross axis (align-content).
-      optional BoxStyle crossDistributedSpace
-      # Style of empty space caused by row gaps (gap/row-gap).
-      optional BoxStyle rowGapSpace
-      # Style of empty space caused by columns gaps (gap/column-gap).
-      optional BoxStyle columnGapSpace
-      # Style of the self-alignment line (align-items).
-      optional LineStyle crossAlignment
-
-  # Style information for drawing a line.
-  type LineStyle extends object
-    properties
-      # The color of the line (default: transparent)
-      optional DOM.RGBA color
-      # The line pattern (default: solid)
-      optional enum pattern
-        dashed
-        dotted
-
-  # Style information for drawing a box.
-  type BoxStyle extends object
-    properties
-      # The background color for the box (default: transparent)
-      optional DOM.RGBA fillColor
-      # The hatching color for the box (default: transparent)
-      optional DOM.RGBA hatchColor
-
-  type ContrastAlgorithm extends string
-    enum
-      aa
-      aaa
-      apca
-
   # Configuration data for the highlighting of page elements.
   type HighlightConfig extends object
     properties
@@ -5821,10 +5586,6 @@ experimental domain Overlay
       optional ColorFormat colorFormat
       # The grid layout highlight configuration (default: all transparent).
       optional GridHighlightConfig gridHighlightConfig
-      # The flex container highlight configuration (default: all transparent).
-      optional FlexContainerHighlightConfig flexContainerHighlightConfig
-      # The contrast algorithm to use for the contrast ratio (default: aa).
-      optional ContrastAlgorithm contrastAlgorithm
 
   type ColorFormat extends string
     enum
@@ -5837,13 +5598,6 @@ experimental domain Overlay
     properties
       # A descriptor for the highlight appearance.
       GridHighlightConfig gridHighlightConfig
-      # Identifier of the node to highlight.
-      DOM.NodeId nodeId
-
-  type FlexNodeHighlightConfig extends object
-    properties
-      # A descriptor for the highlight appearance of flex containers.
-      FlexContainerHighlightConfig flexContainerHighlightConfig
       # Identifier of the node to highlight.
       DOM.NodeId nodeId
 
@@ -6012,11 +5766,6 @@ experimental domain Overlay
       # An array of node identifiers and descriptors for the highlight appearance.
       array of GridNodeHighlightConfig gridNodeHighlightConfigs
 
-  command setShowFlexOverlays
-    parameters
-      # An array of node identifiers and descriptors for the highlight appearance.
-      array of FlexNodeHighlightConfig flexNodeHighlightConfigs
-
   # Requests that backend shows paint rectangles
   command setShowPaintRects
     parameters
@@ -6116,13 +5865,6 @@ domain Page
       # The cross-origin isolation feature is disabled.
       NotIsolatedFeatureDisabled
 
-  experimental type GatedAPIFeatures extends string
-    enum
-      SharedArrayBuffers
-      SharedArrayBuffersTransferAllowed
-      PerformanceMeasureMemory
-      PerformanceProfile
-
   # Information about the Frame on the page.
   type Frame extends object
     properties
@@ -6155,8 +5897,6 @@ domain Page
       experimental SecureContextType secureContextType
       # Indicates whether this is a cross origin isolated context.
       experimental CrossOriginIsolatedContextType crossOriginIsolatedContextType
-      # Indicated which gated APIs / features are available.
-      experimental array of GatedAPIFeatures gatedAPIFeatures
 
   # Information about the Resource on the page.
   experimental type FrameResource extends object
@@ -6425,8 +6165,6 @@ domain Page
       optional Viewport clip
       # Capture the screenshot from the surface, rather than the view. Defaults to true.
       experimental optional boolean fromSurface
-      # Capture the screenshot beyond the viewport. Defaults to false.
-      experimental optional boolean captureBeyondViewport
     returns
       # Base64-encoded image data.
       binary data
@@ -6921,21 +6659,9 @@ domain Page
     parameters
       # Id of the frame that has been detached.
       FrameId frameId
-      experimental enum reason
-        # The frame is removed from the DOM.
-        remove
-        # The frame is being swapped out in favor of an out-of-process iframe.
-        # A new frame target will be created (see Target.attachedToTarget).
-        swap
 
   # Fired once navigation of the frame has completed. Frame is now associated with the new loader.
   event frameNavigated
-    parameters
-      # Frame object.
-      Frame frame
-
-  # Fired when opening document to write to.
-  experimental event documentOpened
     parameters
       # Frame object.
       Frame frame
@@ -7146,72 +6872,6 @@ domain Performance
       array of Metric metrics
       # Timestamp title.
       string title
-
-# Reporting of performance timeline events, as specified in
-# https://w3c.github.io/performance-timeline/#dom-performanceobserver.
-experimental domain PerformanceTimeline
-  depends on DOM
-  depends on Network
-
-  # See https://github.com/WICG/LargestContentfulPaint and largest_contentful_paint.idl
-  type LargestContentfulPaint extends object
-    properties
-      Network.TimeSinceEpoch renderTime
-      Network.TimeSinceEpoch loadTime
-      # The number of pixels being painted.
-      number size
-      # The id attribute of the element, if available.
-      optional string elementId
-      # The URL of the image (may be trimmed).
-      optional string url
-      optional DOM.BackendNodeId nodeId
-
-  type LayoutShiftAttribution extends object
-    properties
-      DOM.Rect previousRect
-      DOM.Rect currentRect
-      optional DOM.BackendNodeId nodeId
-
-  # See https://wicg.github.io/layout-instability/#sec-layout-shift and layout_shift.idl
-  type LayoutShift extends object
-    properties
-      # Score increment produced by this event.
-      number value
-      boolean hadRecentInput
-      Network.TimeSinceEpoch lastInputTime
-      array of LayoutShiftAttribution sources
-
-  type TimelineEvent extends object
-    properties
-      # Identifies the frame that this event is related to. Empty for non-frame targets.
-      Page.FrameId frameId
-      # The event type, as specified in https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype
-      # This determines which of the optional "details" fiedls is present.
-      string type
-      # Name may be empty depending on the type.
-      string name
-      # Time in seconds since Epoch, monotonically increasing within document lifetime.
-      Network.TimeSinceEpoch time
-      # Event duration, if applicable.
-      optional number duration
-      optional LargestContentfulPaint lcpDetails
-      optional LayoutShift layoutShiftDetails
-
-  # Previously buffered events would be reported before method returns.
-  # See also: timelineEventAdded
-  command enable
-    parameters
-      # The types of event to report, as specified in
-      # https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype
-      # The specified filter overrides any previous filters, passing empty
-      # filter disables recording.
-      # Note that not all types exposed to the web platform are currently supported.
-      array of string eventTypes
-
-  # Sent when a performance timeline event is added. See reportPerformanceTimeline method.
-  event timelineEventAdded
-    parameters
-      TimelineEvent event
 
 # Security
 domain Security
@@ -8100,15 +7760,6 @@ experimental domain Tracing
       none
       gzip
 
-  # Details exposed when memory request explicitly declared.
-  # Keep consistent with memory_dump_request_args.h and
-  # memory_instrumentation.mojom
-  type MemoryDumpLevelOfDetail extends string
-    enum
-      background
-      light
-      detailed
-
   # Stop trace events collection.
   command end
 
@@ -8129,8 +7780,6 @@ experimental domain Tracing
     parameters
       # Enables more deterministic results by forcing garbage collection
       optional boolean deterministic
-      # Specifies level of details in memory dump. Defaults to "detailed".
-      optional MemoryDumpLevelOfDetail levelOfDetail
     returns
       # GUID of the resulting global memory dump.
       string dumpGuid
@@ -8158,10 +7807,6 @@ experimental domain Tracing
       # transfer mode (defaults to `none`)
       optional StreamCompression streamCompression
       optional TraceConfig traceConfig
-      # Base64-encoded serialized perfetto.protos.TraceConfig protobuf message
-      # When specified, the parameters `categories`, `options`, `traceConfig`
-      # are ignored.
-      optional binary perfettoConfig
 
   event bufferUsage
     parameters
@@ -8609,11 +8254,6 @@ experimental domain WebAuthn
       # Client To Authenticator Protocol 2.
       ctap2
 
-  type Ctap2Version extends string
-    enum
-      ctap2_0
-      ctap2_1
-
   type AuthenticatorTransport extends string
     enum
       # Cross-Platform authenticator attachments:
@@ -8627,8 +8267,6 @@ experimental domain WebAuthn
   type VirtualAuthenticatorOptions extends object
     properties
       AuthenticatorProtocol protocol
-      # Defaults to ctap2_0. Ignored if |protocol| == u2f.
-      optional Ctap2Version ctap2Version
       AuthenticatorTransport transport
       # Defaults to false.
       optional boolean hasResidentKey
@@ -8661,9 +8299,6 @@ experimental domain WebAuthn
       # assertion.
       # See https://w3c.github.io/webauthn/#signature-counter
       integer signCount
-      # The large blob associated with the credential.
-      # See https://w3c.github.io/webauthn/#sctn-large-blob-extension
-      optional binary largeBlob
 
   # Enable the WebAuthn domain and start intercepting credential storage and
   # retrieval with a virtual authenticator.


### PR DESCRIPTION
I am terribly sorry. I broke things with PDLs from #23. Specifically, opening a new page never resolves. This PR rolls back to [the same revision that `puppeteer` uses](https://github.com/puppeteer/puppeteer/blob/ebd087a31661a1b701650d0be3e123cc5a813bd8/package.json#L50), which is this commit: https://github.com/ChromeDevTools/devtools-protocol/tree/1feb20417e573fdc9ec1213dd1eff8f258edf41a.