### PR TITLE
Initial support for browser.on events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["chrome", "chromedriver", "puppeteer", "automation"]
 categories = ["web-programming", "api-bindings", "development-tools::testing"]
 
 [dependencies]
-async-tungstenite = { git = "https://github.com/sdroege/async-tungstenite" }
+async-tungstenite = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 async-std = { version = "1.9", features = ["attributes", "unstable"], optional = true }
 anyhow = "1.0"

--- a/chromiumoxide_pdl/src/build/generator.rs
+++ b/chromiumoxide_pdl/src/build/generator.rs
@@ -223,7 +223,7 @@ impl Generator {
             } else {
                 sequential_retries += 1;
                 if sequential_retries > refs.len() {
-                    panic!(format!("No type found for ref {}", reff));
+                    panic!("No type found for ref {}", reff);
                 }
                 refs.push_back((name, reff));
             }
@@ -930,9 +930,10 @@ impl Generator {
                 .filter(|ev| self.with_deprecated || !ev.is_deprecated())
                 .filter(|ev| self.with_experimental || !ev.is_experimental())
             {
-                let domain_idx = self.domains.get(domain.name.as_ref()).unwrap_or_else(|| {
-                    panic!(format!("No matching domain registered for {}", domain.name))
-                });
+                let domain_idx = self
+                    .domains
+                    .get(domain.name.as_ref())
+                    .unwrap_or_else(|| panic!("No matching domain registered for {}", domain.name));
                 let protocol_mod = format_ident!("{}", self.protocol_mods[*domain_idx]);
 
                 let ev_name = format!("Event{}", event.name().to_camel_case());
@@ -940,7 +941,7 @@ impl Generator {
                 let size = *self
                     .type_size
                     .get(&ev_name)
-                    .unwrap_or_else(|| panic!(format!("No type found for ref {}", ev_name)));
+                    .unwrap_or_else(|| panic!("No type found for ref {}", ev_name));
 
                 // See https://rust-lang.github.io/rust-clippy/master/#large_enum_variant
                 // The maximum size of a enum’s variant to avoid box suggestion is 200


### PR DESCRIPTION
This is a follow up on the issue of having browser.on events supported (#22). It's not in a ready state yet but I'm again looking for feedback.

I've got sort of the equivalent to `browser.on('targetchanged')` and `browser.on('targetcreated')` prototyped here as `target_changed_listener` and `target_created_listener` respectively. I haven't gotten the latter working though as I'm having trouble with the order of targets being created and added to the targets Hashmap.

I've also added a `get_page()` function so that I'm able to get the page from the `target_id`. Though, I'd really like to send the page directly to the listener.

This is how it's all used as of now:
```rust
use futures::StreamExt;
use std::sync::Arc;

use chromiumoxide::error::Result;
use chromiumoxide::browser::Browser;

mod get_debug_ws_url;

async fn page_ops(page: &chromiumoxide::Page) -> Result<(), Box<dyn std::error::Error>>{
    let title = page.get_title().await?;
    match title {
        Some(title) => {
            println!("{}", title);
        },
        None => {},
    }
    Ok(())
}

#[async_std::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let debug_ws_url = get_debug_ws_url::get_ws_url().await?;
    let (browser, mut handler) = 
    Browser::connect(debug_ws_url).await?;

    let handle = async_std::task::spawn(async move {
        loop {
            handler.next().await;
        }
    });

    let shared: Arc<_> = Arc::new(browser);
    let browser_one = shared.clone();
    let browser_two = shared.clone();

    let mut events = browser_one.target_changed_listener().await?;
    async_std::task::spawn(async move {
        while let Some(event) = events.next().await {
            if event.target_info.r#type == "page" {
                let page = browser_one.get_page(event.target_info.target_id.clone()).await;
                match page {
                    Ok(page) => {let _ = page_ops(&page).await;},
                    Err(e) => {println!("{}", e)}
                }
            }
        }
    });

    let mut events = browser_two.target_created_listener().await?;
    async_std::task::spawn(async move {
        while let Some(event) = events.next().await {
            if event.target_info.r#type == "page" {
                let page = browser_two.get_page(event.target_info.target_id.clone()).await;
                match page {
                    Ok(page) => {let _ = page_ops(&page).await;},
                    Err(e) => {println!("{}", e)}
                }
                
            }
        }
    });
    
    handle.await;
    Ok(())
}

```

also `get_debug_ws_url.rs`:
```rust
use std::collections::HashMap;

pub async fn get_ws_url() -> Result<std::string::String, Box<dyn std::error::Error>> {
    let web_socket_debugger_url = std::thread::spawn(|| {//Keep tokio from panicing if run from a existing tokio runtime
        let web_socket_debugger_url = tokio::runtime::Runtime::new() //Keep reqwest from panicking if run without a tokio runtime
            .unwrap()
            .block_on(async { wrap_in_result_function().await.unwrap_or_default() });
            web_socket_debugger_url
    }).join().expect("Thread panicked");
    Ok(web_socket_debugger_url)
}

async fn wrap_in_result_function() -> Result<std::string::String, Box<dyn std::error::Error>> {
    let resp = reqwest::get("http://127.0.0.1:9222/json/version")
        .await?
        .json::<HashMap<String, String>>()
        .await?;
    let web_socket_debugger_url = resp["webSocketDebuggerUrl"].clone();
    Ok(web_socket_debugger_url)
}
```