### PR TITLE
implement Browser::get_page

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -234,11 +234,7 @@ impl Browser {
             .clone()
             .send(HandlerMessage::GetPage(target_id, tx))
             .await?;
-        match rx.await? {
-            Some(rx) => Ok(rx),
-            None => Err(CdpError::NotFound),
-        }
-        // Ok(rx.await?)
+        rx.await?.ok_or(CdpError::NotFound)
     }
 }
 

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -11,7 +11,7 @@ use futures::channel::oneshot::channel as oneshot_channel;
 use futures::SinkExt;
 
 use chromiumoxide_cdp::cdp::browser_protocol::target::{
-    CreateBrowserContextParams, CreateTargetParams, DisposeBrowserContextParams,
+    CreateBrowserContextParams, CreateTargetParams, DisposeBrowserContextParams, TargetId,
 };
 use chromiumoxide_cdp::cdp::CdpEventMessage;
 use chromiumoxide_types::*;
@@ -225,6 +225,20 @@ impl Browser {
             .send(HandlerMessage::GetPages(tx))
             .await?;
         Ok(rx.await?)
+    }
+
+    /// Return page of given target_id
+    pub async fn get_page(&self, target_id: TargetId) -> Result<Page> {
+        let (tx, rx) = oneshot_channel();
+        self.sender
+            .clone()
+            .send(HandlerMessage::GetPage(target_id, tx))
+            .await?;
+        match rx.await? {
+            Some(rx) => Ok(rx),
+            None => Err(CdpError::NotFound),
+        }
+        // Ok(rx.await?)
     }
 }
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -468,6 +468,24 @@ impl Stream for Handler {
                     HandlerMessage::DisposeContext(ctx) => {
                         pin.browser_contexts.remove(&ctx);
                     }
+                    HandlerMessage::GetPage(target_id, tx) => {
+                        let target = pin
+                            .targets
+                            .values_mut()
+                            .find(|p| p.target_id() == &target_id);
+
+                        match target {
+                            Some(target) => {
+                                let page = target
+                                    .get_or_create_page()
+                                    .map(|page| Page::from(page.clone()));
+                                let _ = tx.send(page);
+                            }
+                            None => {
+                                let _ = tx.send(None);
+                            }
+                        }
+                    }
                 }
             }
 
@@ -626,4 +644,5 @@ pub(crate) enum HandlerMessage {
     DisposeContext(BrowserContext),
     GetPages(OneshotSender<Vec<Page>>),
     Command(CommandMessage),
+    GetPage(TargetId, OneshotSender<Option<Page>>),
 }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -469,20 +469,12 @@ impl Stream for Handler {
                         pin.browser_contexts.remove(&ctx);
                     }
                     HandlerMessage::GetPage(target_id, tx) => {
-                        let target = pin
-                            .targets.get_mut(&target_id);
-
-                        match target {
-                            Some(target) => {
-                                let page = target
-                                    .get_or_create_page()
-                                    .map(|page| Page::from(page.clone()));
-                                let _ = tx.send(page);
-                            }
-                            None => {
-                                let _ = tx.send(None);
-                            }
-                        }
+                        let page = pin
+                            .targets
+                            .get_mut(&target_id)
+                            .and_then(|target| target.get_or_create_page())
+                            .map(|page| Page::from(page.clone()));
+                        let _ = tx.send(page);
                     }
                 }
             }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -470,9 +470,7 @@ impl Stream for Handler {
                     }
                     HandlerMessage::GetPage(target_id, tx) => {
                         let target = pin
-                            .targets
-                            .values_mut()
-                            .find(|p| p.target_id() == &target_id);
+                            .targets.get_mut(&target_id);
 
                         match target {
                             Some(target) => {


### PR DESCRIPTION
Split from the earlier pull request #34.

This adds a `get_page` function that takes `target_id` and returns a the corresponding `Page`.
