### PR TITLE
Way to add extra args to launch options

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -464,7 +464,6 @@ impl BrowserConfigBuilder {
         self
     }
 
-
     pub fn build(self) -> std::result::Result<BrowserConfig, String> {
         let executable = if let Some(e) = self.executable {
             e


### PR DESCRIPTION
Extra launch args, similar to how it's done in puppeteer.