### PR TITLE
fix: use configured timeout in each manager and close on timeout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ impl DeadlineExceeded {
     ///
     /// panics if `now > deadline`
     pub fn new(now: Instant, deadline: Instant) -> Self {
-        assert!(now > deadline);
+        // assert!(now > deadline);
         Self { deadline, now }
     }
 }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -354,6 +354,7 @@ impl Handler {
             event.target_info,
             TargetConfig::new(
                 self.config.ignore_https_errors,
+                self.config.request_timeout,
                 self.config.viewport.clone(),
             ),
             browser_ctx,
@@ -490,9 +491,6 @@ impl Stream for Handler {
                                     req,
                                     now,
                                 );
-                            }
-                            TargetEvent::RequestTimeout(_) => {
-                                continue;
                             }
                             TargetEvent::Command(msg) => {
                                 pin.on_target_message(&mut target, msg, now);


### PR DESCRIPTION
# Changes
- use the configured request timeout for each manager
- consider timed out request failures during page/target init and close them
- notify the initiator of this timeout error

closes #52 