### PR TITLE
Add fn disable_default_args() to fix duplicated chrome args

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -505,23 +505,19 @@ impl BrowserConfig {
         let dbg_port = format!("--remote-debugging-port={}", self.port);
 
         let mut cmd = process::Command::new(&self.executable);
-        match &self.disable_default_args {
-            true => {
-                cmd.args(&self.args).args(
-                    self.extensions
-                        .iter()
-                        .map(|e| format!("--load-extension={}", e)),
-                );
-            }
-            false => {
-                let args = [dbg_port.as_str(), "--enable-blink-features=IdleDetection"];
-                cmd.args(&args).args(&DEFAULT_ARGS).args(&self.args).args(
-                    self.extensions
-                        .iter()
-                        .map(|e| format!("--load-extension={}", e)),
-                );
-            }
+
+        if self.disable_default_args {
+            cmd.args(&self.args);
+        } else {
+            let args = [dbg_port.as_str(), "--enable-blink-features=IdleDetection"];
+            cmd.args(&args).args(&DEFAULT_ARGS).args(&self.args);
         }
+
+        cmd.args(
+            self.extensions
+                .iter()
+                .map(|e| format!("--load-extension={}", e)),
+        );
 
         if let Some(ref user_data) = self.user_data_dir {
             cmd.arg(format!("--user-data-dir={}", user_data.display()));


### PR DESCRIPTION
When I use arg() in BrowserConfigBuilder, the value was duplicated with DEFAULT_ARGS.
For example, if I have passed arg("--remote-debugging-port=9222") to BrowserConfigBuilder, Google chrome started up with "--remote-debugging-port=9222 --remote-debugging-port=0 ...etc " as arguments.
I have added disable_default_args() so that any args can be passed without using DEFAULT_ARGS.

Thanks,