### PR TITLE
Modify browser default args / settings

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -502,15 +502,12 @@ impl BrowserConfigBuilder {
 
 impl BrowserConfig {
     pub fn launch(&self) -> io::Result<Child> {
-        let dbg_port = format!("--remote-debugging-port={}", self.port);
-
         let mut cmd = process::Command::new(&self.executable);
 
         if self.disable_default_args {
             cmd.args(&self.args);
         } else {
-            let args = [dbg_port.as_str(), "--enable-blink-features=IdleDetection"];
-            cmd.args(&args).args(&DEFAULT_ARGS).args(&self.args);
+            cmd.args(&DEFAULT_ARGS).args(&self.args);
         }
 
         cmd.args(
@@ -529,6 +526,10 @@ impl BrowserConfig {
 
         if !self.sandbox {
             cmd.args(&["--no-sandbox", "--disable-setuid-sandbox"]);
+        }
+
+        if self.port != 0 {
+            cmd.arg(format!("--remote-debugging-port={}", self.port));
         }
 
         if self.headless {
@@ -606,7 +607,7 @@ pub(crate) fn get_chrome_path_from_windows_registry() -> Option<std::path::PathB
 
 /// These are passed to the Chrome binary by default.
 /// Via https://github.com/puppeteer/puppeteer/blob/4846b8723cf20d3551c0d755df394cc5e0c82a94/src/node/Launcher.ts#L157
-static DEFAULT_ARGS: [&str; 23] = [
+static DEFAULT_ARGS: [&str; 24] = [
     "--disable-background-networking",
     "--enable-features=NetworkService,NetworkServiceInProcess",
     "--disable-background-timer-throttling",
@@ -630,4 +631,5 @@ static DEFAULT_ARGS: [&str; 23] = [
     "--enable-automation",
     "--password-store=basic",
     "--use-mock-keychain",
+    "--enable-blink-features=IdleDetection",
 ];

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -398,6 +398,11 @@ impl BrowserConfigBuilder {
         self
     }
 
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
     pub fn request_timeout(mut self, timeout: Duration) -> Self {
         self.request_timeout = timeout;
         self

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -515,6 +515,14 @@ impl BrowserConfig {
             cmd.args(&DEFAULT_ARGS).args(&self.args);
         }
 
+        if !self
+            .args
+            .iter()
+            .any(|arg| arg.contains("--remote-debugging-port="))
+        {
+            cmd.arg(format!("--remote-debugging-port={}", self.port));
+        }
+
         cmd.args(
             self.extensions
                 .iter()
@@ -531,10 +539,6 @@ impl BrowserConfig {
 
         if !self.sandbox {
             cmd.args(&["--no-sandbox", "--disable-setuid-sandbox"]);
-        }
-
-        if self.port != 0 {
-            cmd.arg(format!("--remote-debugging-port={}", self.port));
         }
 
         if self.headless {


### PR DESCRIPTION
If, for example, `--remote-debugging-port=9222` is set via the `args` method within the  `BrowserConfigBuilder` and if `disable_default_args` is `false` (as it is by default).  One will encounter an issue similar to the one articulated by @Norio4 here: https://github.com/mattsse/chromiumoxide/pull/70#issue-1037493641

I am, therefore, proposing the following solution / changes:

1. Limit the behavior of the `disable_default_args` option to precisely that (i.e., disabling the default args specified in the `DEFAULT_ARGS` array here): https://github.com/mattsse/chromiumoxide/blob/801d22b7467155eff885506610dc30bbd44be42e/src/browser.rs#L609
2. Add a method to the `BrowserConfigBuilder` implementation that enables the selection of a debugging port. 
3. Add a condition within the `BrowserConfig` implementation to modify the remote debugging port only if the `--remote-debugging-port=<port>` has _not_ been set via the `args` method within the `BrowserConfigBuilder`. 
4. Add / move the `--enable-blink-features=IdleDetection` flag to the `DEFAULT_ARGS` array.  This flag is currently part of the default arguments found in puppeteer as referenced here: 
https://github.com/mattsse/chromiumoxide/blob/801d22b7467155eff885506610dc30bbd44be42e/src/browser.rs#L608

@mattsse, @Norio4, etc., I welcome your thoughts and feedback on this.  Thank you for your contributions!