### PR TITLE
fix: add "Break on start" pause reason

### DIFF
--- a/chromiumoxide_cdp/js_protocol.pdl
+++ b/chromiumoxide_cdp/js_protocol.pdl
@@ -517,6 +517,7 @@ domain Debugger
         other
         promiseRejection
         XHR
+        Break on start
       # Object containing break-specific auxiliary properties.
       optional object data
       # Hit breakpoints IDs

--- a/chromiumoxide_pdl/src/pdl/parser.rs
+++ b/chromiumoxide_pdl/src/pdl/parser.rs
@@ -322,7 +322,7 @@ pub fn parse_pdl(input: &str) -> Result<Protocol, Error> {
         }
 
         // enum literal
-        if regex!("^      (  )?[^\\s]+$").is_match(line) {
+        if regex!("^      (  )?[^\\n\\t]+$").is_match(line) {
             if member_enum {
                 let param = match member
                     .as_mut()


### PR DESCRIPTION
Because "Break on start" contains whitespace characters, I modified the regular expression of the enumeration object. 