### PR TITLE
Minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,31 +12,31 @@ keywords = ["chrome", "chromedriver", "puppeteer", "automation"]
 categories = ["web-programming", "api-bindings", "development-tools::testing"]
 
 [dependencies]
-async-tungstenite = "0.16.0"
-serde = { version = "1.0.130", features = ["derive"] }
-async-std = { version = "1.10.0", features = ["attributes", "unstable"], optional = true }
-futures = "0.3.18"
+async-tungstenite = "0.16"
+serde = { version = "1", features = ["derive"] }
+async-std = { version = "1.5", features = ["attributes", "unstable"], optional = true }
+futures = "0.3"
 chromiumoxide_types = { path = "chromiumoxide_types", version = "0.3.1" }
 chromiumoxide_cdp = { path = "chromiumoxide_cdp", version = "0.3.1" }
-serde_json = "1.0.72"
-which = "4.2.2"
-thiserror = "1.0.30"
-url = "2.2.2"
-log = "0.4.14"
-base64 = "0.13.0"
-fnv = "1.0.7"
-futures-timer = "3.0.2"
-cfg-if = "1.0.0"
-tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread", "time", "fs", "macros"], optional = true }
+serde_json = "1"
+which = "4"
+thiserror = "1"
+url = "2"
+log = "0.4"
+base64 = "0.13"
+fnv = "1"
+futures-timer = "3"
+cfg-if = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "fs", "macros"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.10.1"
+winreg = "0.10"
 
 [dev-dependencies]
-quote = "1.0.10"
-proc-macro2 = "1.0.32"
-chrono = "0.4.19"
-pretty_env_logger = "0.4.0"
+quote = "1"
+proc-macro2 = "1"
+chrono = "0.4.1"
+pretty_env_logger = "0.4"
 
 [features]
 default = ["async-std-runtime"]

--- a/src/handler/domworld.rs
+++ b/src/handler/domworld.rs
@@ -1,10 +1,7 @@
 use chromiumoxide_cdp::cdp::js_protocol::runtime::ExecutionContextId;
-use std::collections::HashSet;
 
 #[derive(Debug, Clone, Default)]
 pub struct DOMWorld {
-    /// Bindings that have been registered in the current context
-    ctx_bindings: HashSet<String>,
     execution_ctx: Option<ExecutionContextId>,
     detached: bool,
 }
@@ -12,7 +9,6 @@ pub struct DOMWorld {
 impl DOMWorld {
     pub fn main_world() -> Self {
         Self {
-            ctx_bindings: Default::default(),
             execution_ctx: None,
             detached: false,
         }
@@ -20,7 +16,6 @@ impl DOMWorld {
 
     pub fn secondary_world() -> Self {
         Self {
-            ctx_bindings: Default::default(),
             execution_ctx: None,
             detached: false,
         }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -367,7 +367,6 @@ impl Handler {
     fn on_attached_to_target(&mut self, event: EventAttachedToTarget) {
         let session = Session::new(
             event.session_id.clone(),
-            event.target_info.r#type,
             event.target_info.target_id,
         );
         if let Some(target) = self.targets.get_mut(session.target_id()) {

--- a/src/handler/session.rs
+++ b/src/handler/session.rs
@@ -5,17 +5,13 @@ use chromiumoxide_cdp::cdp::browser_protocol::target::{SessionId, TargetId};
 pub struct Session {
     /// Identifier for this session.
     id: SessionId,
-    /// The type of the target this session is attached to.
-    /// Used to determine whether this is a page or worker session.
-    target_type: String,
     /// The identifier of the target this session is attached to.
     target_id: TargetId,
 }
 impl Session {
-    pub fn new(id: SessionId, target_type: String, target_id: TargetId) -> Self {
+    pub fn new(id: SessionId, target_id: TargetId) -> Self {
         Self {
             id,
-            target_type,
             target_id,
         }
     }

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -67,8 +67,6 @@ pub struct Target {
     r#type: TargetType,
     /// Configs for this target
     config: TargetConfig,
-    /// Whether this target was marked as closed
-    is_closed: bool,
     /// The context this target is running in
     browser_context: BrowserContext,
     /// The frame manager that maintains the state of all frames and handles
@@ -104,7 +102,6 @@ impl Target {
             info,
             r#type: ty,
             config,
-            is_closed: false,
             frame_manager: FrameManager::new(request_timeout),
             network_manager,
             emulation_manager: EmulationManager::new(request_timeout),


### PR DESCRIPTION
I noticed you seem to use `cargo upgrade` to upgrade all dependencies. However, I think forcing downstream users to use the latest versions of all of your dependencies is not a great idea. Case in point, 2 days ago futures 0.3.18 got [yanked](https://github.com/rust-lang/futures-rs/issues/2529). As part of routine upgrades in #77, you forced downstream users to use 0.3.18, such that now your 0.3.2 is no longer usable if I want to stick with futures 0.3.17.

Here I used `cargo update -Z minimal-versions` to build a `Cargo.lock` with the oldest semver-compatible versions and then tried to run the tests. In order to get the tests to work I had to bump async-std to 1.5 and chrono to 0.4.1, but otherwise the tests at least work.

There were some unused value warnings, which I fixed in a separate commit.

I recommend you use `cargo upgrade` with the `--skip-compatible` option in the future for public library crates.