### PR TITLE
feat: add configuration for request interception and cache

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -98,6 +98,8 @@ impl Browser {
             viewport: Some(config.viewport.clone()),
             context_ids: Vec::new(),
             request_timeout: config.request_timeout,
+            request_intercept: config.request_intercept,
+            cache_enabled: config.cache_enabled,
         };
 
         let fut = Handler::new(conn, rx, handler_config);
@@ -321,6 +323,12 @@ pub struct BrowserConfig {
 
     /// Whether to disable DEFAULT_ARGS or not, default is false
     disable_default_args: bool,
+
+    /// Whether to enable request interception
+    pub request_intercept: bool,
+
+    /// Whether to enable cache
+    pub cache_enabled: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -339,6 +347,8 @@ pub struct BrowserConfigBuilder {
     request_timeout: Duration,
     args: Vec<String>,
     disable_default_args: bool,
+    request_intercept: bool,
+    cache_enabled: bool,
 }
 
 impl BrowserConfig {
@@ -368,6 +378,8 @@ impl Default for BrowserConfigBuilder {
             request_timeout: Duration::from_millis(REQUEST_TIMEOUT),
             args: Vec::new(),
             disable_default_args: false,
+            request_intercept: false,
+            cache_enabled: true,
         }
     }
 }
@@ -479,6 +491,16 @@ impl BrowserConfigBuilder {
         self
     }
 
+    pub fn enable_request_intercept(mut self) -> Self {
+        self.request_intercept = true;
+        self
+    }
+
+    pub fn enable_cache(mut self) -> Self {
+        self.cache_enabled = true;
+        self
+    }
+
     pub fn build(self) -> std::result::Result<BrowserConfig, String> {
         let executable = if let Some(e) = self.executable {
             e
@@ -501,6 +523,8 @@ impl BrowserConfigBuilder {
             request_timeout: self.request_timeout,
             args: self.args,
             disable_default_args: self.disable_default_args,
+            request_intercept: self.request_intercept,
+            cache_enabled: self.cache_enabled,
         })
     }
 }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -363,6 +363,8 @@ impl Handler {
                 self.config.ignore_https_errors,
                 self.config.request_timeout,
                 self.config.viewport.clone(),
+                self.config.request_intercept,
+                self.config.cache_enabled,
             ),
             browser_ctx,
         );
@@ -555,6 +557,10 @@ pub struct HandlerConfig {
     pub context_ids: Vec<BrowserContextId>,
     /// default request timeout to use
     pub request_timeout: Duration,
+    /// Whether to enable request interception
+    pub request_intercept: bool,
+    /// Whether to enable cache
+    pub cache_enabled: bool,
 }
 
 impl Default for HandlerConfig {
@@ -564,6 +570,8 @@ impl Default for HandlerConfig {
             viewport: Default::default(),
             context_ids: Vec::new(),
             request_timeout: Duration::from_millis(REQUEST_TIMEOUT),
+            request_intercept: false,
+            cache_enabled: true,
         }
     }
 }

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -97,7 +97,11 @@ impl Target {
     pub fn new(info: TargetInfo, config: TargetConfig, browser_context: BrowserContext) -> Self {
         let ty = TargetType::new(&info.r#type);
         let request_timeout = config.request_timeout;
-        let network_manager = NetworkManager::new(config.ignore_https_errors, request_timeout);
+        let mut network_manager = NetworkManager::new(config.ignore_https_errors, request_timeout);
+
+        network_manager.set_cache_enabled(config.cache_enabled);
+        network_manager.set_request_interception(config.request_intercept);
+
         Self {
             info,
             r#type: ty,
@@ -546,6 +550,8 @@ pub struct TargetConfig {
     ///  Request timeout to use
     pub request_timeout: Duration,
     pub viewport: Option<Viewport>,
+    pub request_intercept: bool,
+    pub cache_enabled: bool,
 }
 
 impl TargetConfig {
@@ -553,11 +559,15 @@ impl TargetConfig {
         ignore_https_errors: bool,
         request_timeout: Duration,
         viewport: Option<Viewport>,
+        request_intercept: bool,
+        cache_enabled: bool,
     ) -> Self {
         Self {
             ignore_https_errors,
             request_timeout,
             viewport,
+            request_intercept,
+            cache_enabled,
         }
     }
 }
@@ -568,6 +578,8 @@ impl Default for TargetConfig {
             ignore_https_errors: true,
             request_timeout: Duration::from_secs(REQUEST_TIMEOUT),
             viewport: Default::default(),
+            request_intercept: false,
+            cache_enabled: true,
         }
     }
 }


### PR DESCRIPTION
The change adds 2 new configuration options for passing to NetworkManager

The first one is for enabling Chrome cache and the second for request interception. BTW it's kind of cumbersome to have 3 configuration structs BrowserConfig, HandlerConfig and TargetConfig

```
network_manager.set_cache_enabled(config.cache_enabled);
network_manager.set_request_interception(config.request_intercept);
```

cc @mattsse 