### PR TITLE
feat: add command futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures-timer = "3"
 cfg-if = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "fs", "macros"], optional = true }
 tracing = "0.1"
+pin-project-lite = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10"
@@ -47,6 +48,9 @@ tokio-runtime = ["tokio", "async-tungstenite/tokio-runtime"]
 name = "wiki-tokio"
 required-features = ["tokio-runtime"]
 
+[[example]]
+name = "httpfuture"
+required-features = ["tokio-runtime"]
 
 [workspace]
 members = [

--- a/examples/httpfuture.rs
+++ b/examples/httpfuture.rs
@@ -1,0 +1,37 @@
+use futures::StreamExt;
+use futures::TryFutureExt;
+
+use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::cdp::browser_protocol::page::NavigateParams;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let (browser, mut handler) =
+        Browser::launch(BrowserConfig::builder().with_head().build()?).await?;
+
+    let handle = tokio::task::spawn(async move {
+        loop {
+            let _ = handler.next().await.unwrap();
+        }
+    });
+
+    let page = browser.new_page("https://en.wikipedia.org").await?;
+
+    let response1 = page
+        .http_future(NavigateParams {
+            url: "https://en.wikipedia.org".to_string(),
+            transition_type: None,
+            frame_id: None,
+            referrer: None,
+            referrer_policy: None,
+        })?
+        .and_then(|request| async { Ok(request.map(|r| r.response.clone())) })
+        .await?;
+
+    let _html = page.wait_for_navigation().await?.content().await?;
+
+    handle.await?;
+    Ok(())
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -35,7 +35,7 @@ pub(crate) fn to_command_response<T: Command>(
 /// Messages used internally to communicate with the connection, which is
 /// executed in the the background task.
 #[derive(Debug, Serialize)]
-pub(crate) struct CommandMessage<T = Result<Response>> {
+pub struct CommandMessage<T = Result<Response>> {
     pub method: MethodId,
     #[serde(rename = "sessionId", skip_serializing_if = "Option::is_none")]
     pub session_id: Option<SessionId>,

--- a/src/handler/commandfuture.rs
+++ b/src/handler/commandfuture.rs
@@ -1,0 +1,87 @@
+use futures::channel::{
+    mpsc,
+    oneshot::{self, channel as oneshot_channel},
+};
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::cmd::{to_command_response, CommandMessage};
+use crate::error::Result;
+use crate::handler::target::TargetMessage;
+use chromiumoxide_cdp::cdp::browser_protocol::target::SessionId;
+use chromiumoxide_types::{Command, CommandResponse, MethodId, Response};
+
+pin_project! {
+    pub struct CommandFuture<T, M = Result<Response>> {
+        #[pin]
+        rx_command: oneshot::Receiver<M>,
+        #[pin]
+        target_sender: mpsc::Sender<TargetMessage>,
+
+        message: Option<TargetMessage>,
+
+        method: MethodId,
+
+        _marker: PhantomData<T>
+    }
+}
+
+impl<T: Command> CommandFuture<T> {
+    pub fn new(
+        cmd: T,
+        target_sender: mpsc::Sender<TargetMessage>,
+        session: Option<SessionId>,
+    ) -> Result<Self> {
+        let (tx, rx_command) = oneshot_channel::<Result<Response>>();
+        let method = cmd.identifier();
+
+        let message = Some(TargetMessage::Command(CommandMessage::with_session(
+            cmd, tx, session,
+        )?));
+
+        Ok(Self {
+            target_sender,
+            rx_command,
+            message,
+            method,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T> Future for CommandFuture<T>
+where
+    T: Command,
+{
+    type Output = Result<CommandResponse<T::Response>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        if this.message.is_some() {
+            match this.target_sender.poll_ready(cx) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(_)) => {
+                    let message = this.message.take().expect("existence checked above");
+                    let _ = this.target_sender.start_send(message)?;
+
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        } else {
+            match this.rx_command.as_mut().poll(cx) {
+                Poll::Ready(Ok(Ok(response))) => {
+                    Poll::Ready(to_command_response::<T>(response, this.method.clone()))
+                }
+                Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}

--- a/src/handler/frame.rs
+++ b/src/handler/frame.rs
@@ -19,11 +19,11 @@ use chromiumoxide_cdp::cdp::{
 };
 use chromiumoxide_types::{Method, MethodId, Request};
 
-use crate::cmd::CommandChain;
 use crate::error::DeadlineExceeded;
 use crate::handler::domworld::DOMWorld;
 use crate::handler::http::HttpRequest;
 use crate::handler::REQUEST_TIMEOUT;
+use crate::{cmd::CommandChain, ArcHttpRequest};
 
 pub const UTILITY_WORLD_NAME: &str = "__chromiumoxide_utility_world__";
 const EVALUATION_SCRIPT_URL: &str = "____chromiumoxide_utility_world___evaluation_script__";
@@ -40,7 +40,7 @@ pub struct Frame {
     /// Current url of this frame
     url: Option<String>,
     /// The http request that loaded this with this frame
-    http_request: Option<Arc<HttpRequest>>,
+    http_request: ArcHttpRequest,
     /// The frames contained in this frame
     child_frames: HashSet<FrameId>,
     name: Option<String>,

--- a/src/handler/httpfuture.rs
+++ b/src/handler/httpfuture.rs
@@ -1,0 +1,61 @@
+use futures::channel::mpsc;
+use futures::future::{Fuse, FusedFuture};
+use futures::FutureExt;
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use crate::error::Result;
+use crate::handler::commandfuture::CommandFuture;
+use crate::handler::http::HttpRequest;
+use crate::handler::navigationfuture::NavigationFuture;
+use crate::handler::target::TargetMessage;
+use chromiumoxide_types::Command;
+
+type ArcRequest = Option<Arc<HttpRequest>>;
+
+pin_project! {
+    pub struct HttpFuture<T: Command> {
+        #[pin]
+        command: Fuse<CommandFuture<T>>,
+        #[pin]
+        navigation: NavigationFuture,
+    }
+}
+
+impl<T: Command> HttpFuture<T> {
+    pub fn new(sender: mpsc::Sender<TargetMessage>, command: CommandFuture<T>) -> Self {
+        Self {
+            command: command.fuse(),
+            navigation: NavigationFuture::new(sender),
+        }
+    }
+}
+
+impl<T> Future for HttpFuture<T>
+where
+    T: Command,
+{
+    type Output = Result<ArcRequest>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // 1. First complete command request future
+        // 2. Switch polls navigation
+        if this.command.is_terminated() {
+            this.navigation.poll(cx)
+        } else {
+            match this.command.poll(cx) {
+                Poll::Ready(Ok(_command_response)) => {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -33,11 +33,14 @@ use crate::page::Page;
 pub const REQUEST_TIMEOUT: u64 = 30_000;
 
 pub mod browser;
+pub mod commandfuture;
 pub mod domworld;
 pub mod emulation;
 pub mod frame;
 pub mod http;
+pub mod httpfuture;
 mod job;
+pub mod navigationfuture;
 pub mod network;
 mod page;
 mod session;
@@ -451,7 +454,7 @@ impl Stream for Handler {
             while let Poll::Ready(Some(msg)) = Pin::new(&mut pin.from_browser).poll_next(cx) {
                 match msg {
                     HandlerMessage::Command(cmd) => {
-                        pin.submit_external_command(cmd, now).unwrap();
+                        pin.submit_external_command(cmd, now)?;
                     }
                     HandlerMessage::CreatePage(params, tx) => {
                         pin.create_page(params, tx);

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -40,11 +40,11 @@ pub mod frame;
 pub mod http;
 pub mod httpfuture;
 mod job;
-pub mod navigationfuture;
 pub mod network;
 mod page;
 mod session;
 pub mod target;
+pub mod target_message_future;
 pub mod viewport;
 
 /// The handler that monitors the state of the chromium browser and drives all

--- a/src/handler/navigationfuture.rs
+++ b/src/handler/navigationfuture.rs
@@ -1,0 +1,64 @@
+use futures::channel::{
+    mpsc,
+    oneshot::{self, channel as oneshot_channel},
+};
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use crate::error::Result;
+use crate::handler::http::HttpRequest;
+use crate::handler::target::TargetMessage;
+
+type ArcRequest = Option<Arc<HttpRequest>>;
+
+pin_project! {
+pub struct NavigationFuture {
+    #[pin]
+    rx_request: oneshot::Receiver<ArcRequest>,
+    #[pin]
+    target_sender: mpsc::Sender<TargetMessage>,
+
+    message: Option<TargetMessage>,
+}
+}
+
+impl NavigationFuture {
+    pub fn new(target_sender: mpsc::Sender<TargetMessage>) -> Self {
+        let (tx, rx_request) = oneshot_channel();
+
+        let message = Some(TargetMessage::WaitForNavigation(tx));
+
+        Self {
+            target_sender,
+            rx_request,
+            message,
+        }
+    }
+}
+
+impl Future for NavigationFuture {
+    type Output = Result<ArcRequest>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        if this.message.is_some() {
+            match this.target_sender.poll_ready(cx) {
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                Poll::Ready(Ok(_)) => {
+                    let message = this.message.take().expect("existence checked above");
+                    let _ = this.target_sender.start_send(message)?;
+
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        } else {
+            this.rx_request.as_mut().poll(cx).map_err(Into::into)
+        }
+    }
+}

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -31,12 +31,12 @@ use crate::error::{CdpError, Result};
 use crate::handler::commandfuture::CommandFuture;
 use crate::handler::domworld::DOMWorldKind;
 use crate::handler::httpfuture::HttpFuture;
-use crate::handler::navigationfuture::NavigationFuture;
 use crate::handler::target::{GetExecutionContext, TargetMessage};
+use crate::handler::target_message_future::TargetMessageFuture;
 use crate::js::EvaluationResult;
-use crate::keys;
 use crate::layout::Point;
 use crate::page::ScreenshotParams;
+use crate::{keys, ArcHttpRequest};
 
 #[derive(Debug)]
 pub struct PageHandle {
@@ -82,8 +82,8 @@ impl PageInner {
     }
 
     /// This creates navigation future with the final http response when the page is loaded
-    pub(crate) fn wait_for_navigation(&self) -> NavigationFuture {
-        NavigationFuture::new(self.sender.clone())
+    pub(crate) fn wait_for_navigation(&self) -> TargetMessageFuture<ArcHttpRequest> {
+        TargetMessageFuture::<ArcHttpRequest>::wait_for_navigation(self.sender.clone())
     }
 
     /// This creates HTTP future with navigation and responds with the final

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -28,8 +28,10 @@ use chromiumoxide_types::{Command, CommandResponse};
 
 use crate::cmd::{to_command_response, CommandMessage};
 use crate::error::{CdpError, Result};
+use crate::handler::commandfuture::CommandFuture;
 use crate::handler::domworld::DOMWorldKind;
-use crate::handler::http::HttpRequest;
+use crate::handler::httpfuture::HttpFuture;
+use crate::handler::navigationfuture::NavigationFuture;
 use crate::handler::target::{GetExecutionContext, TargetMessage};
 use crate::js::EvaluationResult;
 use crate::keys;
@@ -74,14 +76,23 @@ impl PageInner {
         execute(cmd, self.sender.clone(), Some(self.session_id.clone())).await
     }
 
-    /// This responds with the final http response when the page is loaded
-    pub(crate) async fn wait_for_navigation(&self) -> Result<Option<Arc<HttpRequest>>> {
-        let (tx, rx) = oneshot_channel();
-        self.sender
-            .clone()
-            .send(TargetMessage::WaitForNavigation(tx))
-            .await?;
-        Ok(rx.await?)
+    /// Create a PDL command future
+    pub(crate) fn command_future<T: Command>(&self, cmd: T) -> Result<CommandFuture<T>> {
+        CommandFuture::new(cmd, self.sender.clone(), Some(self.session_id.clone()))
+    }
+
+    /// This creates navigation future with the final http response when the page is loaded
+    pub(crate) fn wait_for_navigation(&self) -> NavigationFuture {
+        NavigationFuture::new(self.sender.clone())
+    }
+
+    /// This creates HTTP future with navigation and responds with the final
+    /// http response when the page is loaded
+    pub(crate) fn http_future<T: Command>(&self, cmd: T) -> Result<HttpFuture<T>> {
+        Ok(HttpFuture::new(
+            self.sender.clone(),
+            self.command_future(cmd)?,
+        ))
     }
 
     /// The identifier of this page's target

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -28,13 +28,12 @@ use crate::handler::frame::{
     FrameEvent, FrameManager, NavigationError, NavigationId, NavigationOk,
 };
 use crate::handler::frame::{FrameNavigationRequest, UTILITY_WORLD_NAME};
-use crate::handler::http::HttpRequest;
 use crate::handler::network::{NetworkEvent, NetworkManager};
 use crate::handler::page::PageHandle;
 use crate::handler::viewport::Viewport;
 use crate::handler::{PageInner, REQUEST_TIMEOUT};
 use crate::listeners::{EventListenerRequest, EventListeners};
-use crate::page::Page;
+use crate::{page::Page, ArcHttpRequest};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::ExecutionContextId;
 use std::time::Duration;
 
@@ -86,7 +85,7 @@ pub struct Target {
     /// All registered event subscriptions
     event_listeners: EventListeners,
     /// Senders that need to be notified once the main frame has loaded
-    wait_for_frame_navigation: Vec<Sender<Option<Arc<HttpRequest>>>>,
+    wait_for_frame_navigation: Vec<Sender<ArcHttpRequest>>,
     /// The sender who requested the page.
     initiator: Option<Sender<Result<Page>>>,
 }
@@ -696,7 +695,7 @@ pub enum TargetMessage {
     /// Return the url of this target's page
     Url(Sender<Option<String>>),
     /// A Message that resolves when the frame finished loading a new url
-    WaitForNavigation(Sender<Option<Arc<HttpRequest>>>),
+    WaitForNavigation(Sender<ArcHttpRequest>),
     /// A request to submit a new listener that gets notified with every
     /// received event
     AddEventListener(EventListenerRequest),

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -686,7 +686,7 @@ impl GetExecutionContext {
 }
 
 #[derive(Debug)]
-pub(crate) enum TargetMessage {
+pub enum TargetMessage {
     /// Execute a command within the session of this target
     Command(CommandMessage),
     /// Return the main frame of this target's page

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@
 
 #![warn(missing_debug_implementations, rust_2018_idioms)]
 
+use crate::handler::http::HttpRequest;
+use std::sync::Arc;
+
 /// reexport the generated cdp types
 pub use chromiumoxide_cdp::cdp;
 pub use chromiumoxide_types::{self as types, Binary, Command, Method, MethodType};
@@ -86,3 +89,5 @@ pub mod layout;
 pub mod listeners;
 pub mod page;
 pub(crate) mod utils;
+
+pub type ArcHttpRequest = Option<Arc<HttpRequest>>;

--- a/src/page.rs
+++ b/src/page.rs
@@ -29,14 +29,13 @@ use crate::element::Element;
 use crate::error::{CdpError, Result};
 use crate::handler::commandfuture::CommandFuture;
 use crate::handler::domworld::DOMWorldKind;
-use crate::handler::http::HttpRequest;
 use crate::handler::httpfuture::HttpFuture;
 use crate::handler::target::TargetMessage;
 use crate::handler::PageInner;
 use crate::js::{Evaluation, EvaluationResult};
 use crate::layout::Point;
 use crate::listeners::{EventListenerRequest, EventStream};
-use crate::utils;
+use crate::{utils, ArcHttpRequest};
 
 #[derive(Debug, Clone)]
 pub struct Page {
@@ -161,7 +160,7 @@ impl Page {
     /// This is necessary after an interaction with the page that may trigger a
     /// navigation (`click`, `press_key`) in order to wait until the new browser
     /// page is loaded
-    pub async fn wait_for_navigation_response(&self) -> Result<Option<Arc<HttpRequest>>> {
+    pub async fn wait_for_navigation_response(&self) -> Result<ArcHttpRequest> {
         self.inner.wait_for_navigation().await
     }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -27,8 +27,10 @@ use chromiumoxide_types::*;
 
 use crate::element::Element;
 use crate::error::{CdpError, Result};
+use crate::handler::commandfuture::CommandFuture;
 use crate::handler::domworld::DOMWorldKind;
 use crate::handler::http::HttpRequest;
+use crate::handler::httpfuture::HttpFuture;
 use crate::handler::target::TargetMessage;
 use crate::handler::PageInner;
 use crate::js::{Evaluation, EvaluationResult};
@@ -44,7 +46,17 @@ pub struct Page {
 impl Page {
     /// Execute a command and return the `Command::Response`
     pub async fn execute<T: Command>(&self, cmd: T) -> Result<CommandResponse<T::Response>> {
-        self.inner.execute(cmd).await
+        self.command_future(cmd)?.await
+    }
+
+    /// Execute a command and return the `Command::Response`
+    pub fn command_future<T: Command>(&self, cmd: T) -> Result<CommandFuture<T>> {
+        self.inner.command_future(cmd)
+    }
+
+    /// Execute a command and return the `Command::Response`
+    pub fn http_future<T: Command>(&self, cmd: T) -> Result<HttpFuture<T>> {
+        self.inner.http_future(cmd)
     }
 
     /// Adds an event listener to the `Target` and returns the receiver part as


### PR DESCRIPTION
Adding 3 futures: CommandFuture, NavigationFuture and HttpFuture. The later wraps CommandFuture and NavigationFuture in makes it convenient to use in situations when Command is `NavigateParams` followed with `wait_for_navigation()` method call. My use case is a higher-level manual future than polls these chromiumoxide futures.

Usage:
```rust
    let _ = page
        .http_future(NavigateParams {
            url: "https://www.example.org".to_string(),
            transition_type: None,
            frame_id: None,
            referrer: None,
            referrer_policy: None,
        })?
        .await?;
```

Some types had to be made public. The change also pulls additional dependency of `pin-project-lite`, I have seen other manual futures using manual projection, and I am willing to refactor those to use pin-project or I can implement manual projection on these 3 new ones.

Let me know what you think. 

cc @mattsse 
