### PR TITLE
Fix #97 by removing capacity caps on websocket messages

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::pin::Pin;
 
-use async_tungstenite::{WebSocketStream, tungstenite::protocol::WebSocketConfig};
+use async_tungstenite::{tungstenite::protocol::WebSocketConfig, WebSocketStream};
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
 use futures::Sink;

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::pin::Pin;
 
-use async_tungstenite::WebSocketStream;
+use async_tungstenite::{WebSocketStream, tungstenite::protocol::WebSocketConfig};
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
 use futures::Sink;
@@ -38,11 +38,18 @@ pub struct Connection<T: EventMessage> {
 
 impl<T: EventMessage + Unpin> Connection<T> {
     pub async fn connect(debug_ws_url: impl AsRef<str>) -> Result<Self> {
+        let config = WebSocketConfig {
+            max_message_size: None,
+            max_frame_size: None,
+            max_send_queue: None,
+            ..Default::default()
+        };
+
         cfg_if::cfg_if! {
             if #[cfg(feature = "async-std-runtime")] {
-               let (ws, _) = async_tungstenite::async_std::connect_async(debug_ws_url.as_ref()).await?;
+               let (ws, _) = async_tungstenite::async_std::connect_async_with_config(debug_ws_url.as_ref(), Some(config)).await?;
             } else if #[cfg(feature = "tokio-runtime")] {
-                 let (ws, _) = async_tungstenite::tokio::connect_async(debug_ws_url.as_ref()).await?;
+                 let (ws, _) = async_tungstenite::tokio::connect_async_with_config(debug_ws_url.as_ref(), Some(config)).await?;
             }
         }
 


### PR DESCRIPTION
This fixes #97 by uncapping the max message & frame size on websocket messages.