### PR TITLE
added close method for Browser

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -24,7 +24,9 @@ use crate::handler::viewport::Viewport;
 use crate::handler::{Handler, HandlerConfig, HandlerMessage, REQUEST_TIMEOUT};
 use crate::listeners::{EventListenerRequest, EventStream};
 use crate::page::Page;
-use chromiumoxide_cdp::cdp::browser_protocol::browser::{GetVersionParams, GetVersionReturns};
+use chromiumoxide_cdp::cdp::browser_protocol::browser::{
+    CloseReturns, GetVersionParams, GetVersionReturns,
+};
 
 /// A [`Browser`] is created when chromiumoxide connects to a Chromium instance.
 #[derive(Debug)]
@@ -115,6 +117,17 @@ impl Browser {
         };
 
         Ok((browser, fut))
+    }
+
+    pub async fn close(&mut self) -> Result<CloseReturns> {
+        let (tx, rx) = oneshot_channel();
+
+        self.sender
+            .clone()
+            .send(HandlerMessage::CloseBrowser(tx))
+            .await?;
+
+        rx.await?
     }
 
     /// If not launched as incognito this creates a new incognito browser

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -471,6 +471,18 @@ impl Stream for Handler {
                     HandlerMessage::Command(cmd) => {
                         pin.submit_external_command(cmd, now)?;
                     }
+                    HandlerMessage::CloseBrowser(tx) => {
+                        let close_msg = CloseParams::default();
+
+                        pin.conn.submit_command(
+                            close_msg.identifier(),
+                            None,
+                            serde_json::to_value(close_msg).unwrap(),
+                        )?;
+                        tx.send(Ok(CloseReturns {})).ok();
+
+                        return Poll::Ready(None);
+                    }
                     HandlerMessage::CreatePage(params, tx) => {
                         pin.create_page(params, tx);
                     }
@@ -669,4 +681,5 @@ pub(crate) enum HandlerMessage {
     Command(CommandMessage),
     GetPage(TargetId, OneshotSender<Option<Page>>),
     AddEventListener(EventListenerRequest),
+    CloseBrowser(OneshotSender<Result<CloseReturns>>),
 }


### PR DESCRIPTION
added close method, that gracefully closes the browser. sends the Browser.close call over the web socket