### PR TITLE
fix: find chrome from HKEY_CURRENT_USER on windows target

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -668,6 +668,8 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
 pub(crate) fn get_chrome_path_from_windows_registry() -> Option<std::path::PathBuf> {
     winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE)
         .open_subkey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe")
+        .or(winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER)
+            .open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe"))
         .and_then(|key| key.get_value::<String, _>(""))
         .map(std::path::PathBuf::from)
         .ok()

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -668,8 +668,10 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
 pub(crate) fn get_chrome_path_from_windows_registry() -> Option<std::path::PathBuf> {
     winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE)
         .open_subkey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe")
-        .or(winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER)
-            .open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe"))
+        .or_else(|_| {
+            winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER)
+                .open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe")
+        })
         .and_then(|key| key.get_value::<String, _>(""))
         .map(std::path::PathBuf::from)
         .ok()


### PR DESCRIPTION
In my environment, the chrome installation path is stored under `HKEY_CURRENT_USER`, not under `HKEY_LOCAL_MACHINE`.

I was not sure if the registry was simply wrong or if the location had changed due to a Chrome version upgrade, so I fixed it by increasing the search location to maintain backward compatibility.