### PR TITLE
Avoid panic when dropping after using method close. And add the metho…

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashMap,
     io::{self, BufRead, BufReader},
     path::{Path, PathBuf},
-    process::{self, Child, Stdio, ExitStatus},
+    process::{self, Child, ExitStatus, Stdio},
 };
 
 use futures::channel::mpsc::{channel, unbounded, Sender};
@@ -131,10 +131,10 @@ impl Browser {
     }
 
     /// Wait for the spawned chromium instance (by method launch) to exit completely, usually called after the method close.
-    pub fn wait(&mut self)-> io::Result<Option<ExitStatus>>{
-        if let Some( child) = self.child.as_mut(){
+    pub fn wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        if let Some(child) = self.child.as_mut() {
             Ok(Some(child.wait()?))
-        }else{
+        } else {
             Ok(None)
         }
     }
@@ -279,10 +279,10 @@ impl Browser {
 impl Drop for Browser {
     fn drop(&mut self) {
         if let Some(child) = self.child.as_mut() {
-            if let Ok(Some(s)) = child.try_wait(){
+            if let Ok(Some(s)) = child.try_wait() {
                 // already exited, do nothing. Usually occurs after using the method close.
                 // If there is a method to detect whether the child handle is still available, it should be used instead of try_wait.
-            }else{
+            } else {
                 child.kill().expect("!kill");
             }
         }


### PR DESCRIPTION
…d wait to wait for the browser to completely exit.

In the previous version, I found that when I finished running the task, the browser did not completely exit normally when the program exited, which caused the browser to have a prompt to restore the pages when it was restarted.

Even if I used the method close, it was the same.

```
#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let opt = Opt::from_args();
// ...
// running the task
// ....
    match browser.close().await {
        Ok(_a) => println!("ok {}", _a),
        Err(e) => println!("err {e}"),
    }
   
    Ok(())
}
```

Then I found that there was not enough time for close, so the instance was still killed.

If I add a wait statement, it will exit completely, but it will cause a panic.

```
    match browser.close().await {
        Ok(_a) => println!("ok {}", _a),
        Err(e) => println!("err {e}"),
    }
    sleep(Duration::from_secs(5)).await;
```

Now, I do some processing in the method drop and add a method wait.

So, it can exit completely instead of being killed.

```
#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let opt = Opt::from_args();
// ...
// running the task
// ....
   match browser.close().await {
        Ok(_a) => {}
        Err(e) => println!("{e}"),
    }

    // sleep(Duration::from_secs(5)).await;
    let a = browser.wait();
    println!("wait result {:?}", a);
    Ok(())
}```