### PR TITLE
Include Chromium `stderr` when failing to launch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ base64 = "0.21"
 fnv = "1"
 futures-timer = "3"
 cfg-if = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "fs", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "fs", "macros", "process"], optional = true }
 tracing = "0.1"
 pin-project-lite = "0.2"
 

--- a/src/async_process.rs
+++ b/src/async_process.rs
@@ -1,0 +1,182 @@
+//! Internal module providing an async child process abstraction for `async-std` or `tokio`.
+
+use std::ffi::OsStr;
+use std::pin::Pin;
+pub use std::process::{ExitStatus, Stdio};
+use std::task::{Context, Poll};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "async-std-runtime")] {
+        use ::async_std::process;
+    } else if #[cfg(feature = "tokio-runtime")] {
+        use ::tokio::process;
+    }
+}
+
+#[derive(Debug)]
+pub struct Command {
+    inner: process::Command,
+}
+
+impl Command {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        let inner = process::Command::new(program);
+        Self { inner }
+    }
+
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.inner.arg(arg);
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.inner.args(args);
+        self
+    }
+
+    pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.envs(vars);
+        self
+    }
+
+    pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+        self.inner.stderr(cfg);
+        self
+    }
+
+    pub fn spawn(&mut self) -> std::io::Result<Child> {
+        let inner = self.inner.spawn()?;
+        Ok(Child::new(inner))
+    }
+}
+
+#[derive(Debug)]
+pub struct Child {
+    pub stderr: Option<ChildStderr>,
+    pub inner: process::Child,
+}
+
+/// Wrapper for an async child process.
+///
+/// The inner implementation depends on the selected async runtime (features `async-std-runtime`
+/// or `tokio-runtime`).
+impl Child {
+    fn new(mut inner: process::Child) -> Self {
+        let stderr = inner.stderr.take();
+        Self {
+            inner,
+            stderr: stderr.map(|inner| ChildStderr { inner }),
+        }
+    }
+
+    /// Kill the child process, asynchronously if possible (otherwise by blocking)
+    ///
+    /// - `async-std-runtime`: blocking call to `async_std::process::Child::kill`.
+    /// - `tokio-runtime`: async call to `tokio::process::Child::kill`
+    pub async fn async_kill(&mut self) -> std::io::Result<()> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "async-std-runtime")] {
+                self.inner.kill()
+            } else if #[cfg(feature = "tokio-runtime")] {
+                self.inner.kill().await
+            }
+        }
+    }
+
+    /// Kill the child process synchronously (blocking)
+    ///
+    /// - `async-std-runtime`: blocking call to `async_std::process::Child::kill`.
+    /// - `tokio-runtime`: async call to `tokio::process::Child::kill`, resolved with `tokio::runtime::Handle::block_on`
+    pub fn kill(&mut self) -> std::io::Result<()> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "async-std-runtime")] {
+                self.inner.kill()
+            } else if #[cfg(feature = "tokio-runtime")] {
+                let fut = self.async_kill();
+                let handle = tokio::runtime::Handle::current();
+                handle.block_on(fut)
+            }
+        }
+    }
+
+    /// Asynchronously wait for the child process to exit (non-blocking)
+    ///
+    /// - `async-std-runtime`: async call to `async_std::process::Child::status`.
+    /// - `tokio-runtime`: async call to `tokio::process::Child::wait`
+    pub async fn async_wait(&mut self) -> std::io::Result<ExitStatus> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "async-std-runtime")] {
+                self.inner.status().await
+            } else if #[cfg(feature = "tokio-runtime")] {
+                self.inner.wait().await
+            }
+        }
+    }
+
+    /// Synchronously wait for the child process to exit (blocking)
+    ///
+    /// - `async-std-runtime`: async call to `async_std::process::Child::status`, resolved with `async_std::task::block_on`
+    /// - `tokio-runtime`: async call to `tokio::process::Child::wait`, resolved with `tokio::runtime::Handle::block_on`
+    pub fn wait(&mut self) -> std::io::Result<ExitStatus> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "async-std-runtime")] {
+                let fut = self.async_wait();
+                async_std::task::block_on(fut)
+            } else if #[cfg(feature = "tokio-runtime")] {
+                let fut = self.async_wait();
+                let handle = tokio::runtime::Handle::current();
+                handle.block_on(fut)
+            }
+        }
+    }
+
+    /// If the child process has exited, get its status (non-blocking)
+    ///
+    /// - `async-std-runtime`: call to `async_std::process::Child::try_status`
+    /// - `tokio-runtime`: call to `tokio::process::Child::try_wait`
+    pub fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "async-std-runtime")] {
+                self.inner.try_status()
+            } else if #[cfg(feature = "tokio-runtime")] {
+                self.inner.try_wait()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ChildStderr {
+    pub inner: process::ChildStderr,
+}
+
+impl futures::AsyncRead for ChildStderr {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "async-std-runtime")] {
+                Pin::new(&mut self.inner).poll_read(cx, buf)
+            } else if #[cfg(feature = "tokio-runtime")] {
+                let mut buf = tokio::io::ReadBuf::new(buf);
+                futures::ready!(tokio::io::AsyncRead::poll_read(
+                    Pin::new(&mut self.inner),
+                    cx,
+                    &mut buf
+                ))?;
+                Poll::Ready(Ok(buf.filled().len()))
+            }
+        }
+    }
+}

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::time::Duration;
 use std::{
     collections::HashMap,
@@ -7,6 +8,7 @@ use std::{
 
 use futures::channel::mpsc::{channel, unbounded, Sender};
 use futures::channel::oneshot::channel as oneshot_channel;
+use futures::select;
 use futures::SinkExt;
 
 use chromiumoxide_cdp::cdp::browser_protocol::target::{
@@ -19,7 +21,7 @@ use crate::async_process::{self, Child, ExitStatus, Stdio};
 use crate::cmd::{to_command_response, CommandMessage};
 use crate::conn::Connection;
 use crate::detection::{self, DetectionOptions};
-use crate::error::{CdpError, Result};
+use crate::error::{BrowserStderr, CdpError, Result};
 use crate::handler::browser::BrowserContext;
 use crate::handler::viewport::Viewport;
 use crate::handler::{Handler, HandlerConfig, HandlerMessage, REQUEST_TIMEOUT};
@@ -81,21 +83,19 @@ impl Browser {
         // launch a new chromium instance
         let mut child = config.launch()?;
 
-        // extract the ws:
-        let get_ws_url = ws_url_from_output(&mut child);
-
         let dur = config.launch_timeout;
-
         cfg_if::cfg_if! {
             if #[cfg(feature = "async-std-runtime")] {
-                let debug_ws_url = async_std::future::timeout(dur, get_ws_url)
-            .await
-            .map_err(|_| CdpError::Timeout)?;
+                let timeout_fut = Box::pin(async_std::task::sleep(dur));
             } else if #[cfg(feature = "tokio-runtime")] {
-                let debug_ws_url = tokio::time::timeout(dur, get_ws_url).await
-            .map_err(|_| CdpError::Timeout)?;
+                let timeout_fut = tokio::time::sleep(dur);
+            } else {
+                panic!("missing chromiumoxide runtime: enable `async-std-runtime` or `tokio-runtime`")
             }
-        }
+        };
+
+        // extract the ws:
+        let debug_ws_url = ws_url_from_output(&mut child, timeout_fut).await?;
 
         let conn = Connection::<CdpEventMessage>::connect(&debug_ws_url).await?;
 
@@ -325,30 +325,62 @@ impl Drop for Browser {
     }
 }
 
-async fn ws_url_from_output(child_process: &mut Child) -> String {
+/// Resolve devtools WebSocket URL from the provided browser process
+///
+/// If an error occurs, it returns the browser's stderr output.
+///
+/// The URL resolution fails if:
+/// - [`CdpError::LaunchTimeout`]: `timeout_fut` completes, this corresponds to a timeout
+/// - [`CdpError::LaunchExit`]: the browser process exits (or is killed)
+/// - [`CdpError::LaunchIo`]: an input/output error occurs when await the process exit or reading
+///   the browser's stderr: end of stream, invalid UTF-8, other
+async fn ws_url_from_output(
+    child_process: &mut Child,
+    timeout_fut: impl Future<Output = ()> + Unpin,
+) -> Result<String> {
+    use futures::{AsyncBufReadExt, FutureExt};
+    let mut timeout_fut = timeout_fut.fuse();
     let stderr = child_process.stderr.take().expect("no stderror");
-
-    async fn read_debug_url<S>(stream: S) -> String
-    where
-        S: futures::AsyncRead + Unpin,
-    {
-        use futures::AsyncBufReadExt;
-        let mut buf = futures::io::BufReader::new(stream);
-        let mut line = String::new();
-        loop {
-            if buf.read_line(&mut line).await.is_ok() {
-                // check for ws in line
-                if let Some(ws) = line.rsplit("listening on ").next() {
-                    if ws.starts_with("ws") && ws.contains("devtools/browser") {
-                        return ws.trim().to_string();
+    let mut stderr_bytes = Vec::<u8>::new();
+    let mut exit_status_fut = Box::pin(child_process.async_wait()).fuse();
+    let mut buf = futures::io::BufReader::new(stderr);
+    loop {
+        select! {
+            _ = timeout_fut => return Err(CdpError::LaunchTimeout(BrowserStderr::new(stderr_bytes))),
+            exit_status = exit_status_fut => {
+                return Err(match exit_status {
+                    Err(e) => CdpError::LaunchIo(e, BrowserStderr::new(stderr_bytes)),
+                    Ok(exit_status) => CdpError::LaunchExit(exit_status, BrowserStderr::new(stderr_bytes)),
+                })
+            },
+            read_res = buf.read_until(b'\n', &mut stderr_bytes).fuse() => {
+                match read_res {
+                    Err(e) => return Err(CdpError::LaunchIo(e, BrowserStderr::new(stderr_bytes))),
+                    Ok(byte_count) => {
+                        if byte_count == 0 {
+                            let e = io::Error::new(io::ErrorKind::UnexpectedEof, "unexpected end of stream");
+                            return Err(CdpError::LaunchIo(e, BrowserStderr::new(stderr_bytes)));
+                        }
+                        let start_offset = stderr_bytes.len() - byte_count;
+                        let new_bytes = &stderr_bytes[start_offset..];
+                        match std::str::from_utf8(new_bytes) {
+                            Err(_) => {
+                                let e = io::Error::new(io::ErrorKind::InvalidData, "stream did not contain valid UTF-8");
+                                return Err(CdpError::LaunchIo(e, BrowserStderr::new(stderr_bytes)));
+                            }
+                            Ok(line) => {
+                                if let Some((_, ws)) = line.rsplit_once("listening on ") {
+                                    if ws.starts_with("ws") && ws.contains("devtools/browser") {
+                                        return Ok(ws.trim().to_string());
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-            } else {
-                line = String::new();
             }
         }
     }
-    read_debug_url(stderr).await
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub mod error;
 pub mod fetcher {
     pub use chromiumoxide_fetcher::*;
 }
+pub mod async_process;
 pub mod handler;
 pub mod js;
 pub mod keys;


### PR DESCRIPTION
This PR addresses the issue #124. It updates the code waiting for the browser to be ready to provide more context if an error occurs.

The PR is split into two commits:
1. The first commit updates the lib to use the process utilities from either `async-std` or `tokio` instead of the standard library. The main goal of this is to get asynchronous I/O streams, in particular `stderr`. This is achieved by defining a wrapper type `AsyncProcess` abstracting the runtime selected by the compile-time features. Since the process can be accessed through a getter, this commit is a breaking change (type changed).
2. The second commit refactors the `ws_url_from_output` function to improve error handling. In particular it now detects if the process crashes as soon as it starts (previously it would have waited until the timeout before detecting it), and returns `stderr` content on error. Returning `stderr` content is extremely helpful when troubleshooting issues.

I had an issue when running `chromiumoxide` in GitLab CI because it was running as `root` but I did not disable the zygote sandbox. Previously the library only returned "LaunchTimeout", but with my changes I could make it return "LaunchExit" with the standard error explaining that running as root requires to disable the sandbox. It allowed me to fix my issue more easily.

The error formatting uses the same logic as the standard library: try to print as a UTF-8 string, with a fallback to bytes on error.