### PR TITLE
fix: Fix Clippy issues

### DIFF
--- a/chromiumoxide_cdp/src/lib.rs
+++ b/chromiumoxide_cdp/src/lib.rs
@@ -110,7 +110,7 @@ impl std::error::Error for ExceptionDetails {}
 impl fmt::Display for StackTrace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(desc) = self.description.as_ref() {
-            writeln!(f, "{}", desc)?;
+            writeln!(f, "{desc}")?;
         }
         for frame in &self.call_frames {
             writeln!(

--- a/chromiumoxide_pdl/src/build/generator.rs
+++ b/chromiumoxide_pdl/src/build/generator.rs
@@ -223,7 +223,7 @@ impl Generator {
             } else {
                 sequential_retries += 1;
                 if sequential_retries > refs.len() {
-                    panic!("No type found for ref {}", reff);
+                    panic!("No type found for ref {reff}");
                 }
                 refs.push_back((name, reff));
             }
@@ -385,7 +385,7 @@ impl Generator {
             }
         };
 
-        let output = target.join(format!("{}.rs", mod_name));
+        let output = target.join(format!("{mod_name}.rs"));
         fs::write(output, stream.to_string())?;
 
         fmt(target);
@@ -897,7 +897,7 @@ impl Generator {
             let ref_domain_idx = self
                 .domains
                 .get(&path)
-                .unwrap_or_else(|| panic!("No referenced domain found for {}", path));
+                .unwrap_or_else(|| panic!("No referenced domain found for {path}"));
 
             if *current_domain_idx == *ref_domain_idx {
                 let super_ident = format_ident!("{}", path.to_snake_case());
@@ -945,7 +945,7 @@ impl Generator {
                 let size = *self
                     .type_size
                     .get(&ev_name)
-                    .unwrap_or_else(|| panic!("No type found for ref {}", ev_name));
+                    .unwrap_or_else(|| panic!("No type found for ref {ev_name}"));
 
                 // See https://rust-lang.github.io/rust-clippy/master/#large_enum_variant
                 // The maximum size of a enum’s variant to avoid box suggestion is 200
@@ -1190,7 +1190,7 @@ pub fn fmt(out_dir: impl AsRef<Path>) {
 
         match result {
             Err(e) => {
-                eprintln!("error running rustfmt: {:?}", e);
+                eprintln!("error running rustfmt: {e:?}");
             }
             Ok(output) => {
                 if !output.status.success() {

--- a/examples/block-navigation.rs
+++ b/examples/block-navigation.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         if event.request.url == TARGET {
                           resolution.action = InterceptAction::Fullfill;
                         }
-                        println!("paused: {:?}, network: {:?}", resolution, network_id);
+                        println!("paused: {resolution:?}, network: {network_id:?}");
                         resolve(&intercept_page, &network_id, &mut resolutions).await;
                     }
                   }
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                           InterceptAction::Forward
                       };
                       resolution.action = action;
-                      println!("sent: {:?}", resolution);
+                      println!("sent: {resolution:?}");
                       resolve(&intercept_page, &event.request_id, &mut resolutions).await;
                   }
               },
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Navigate to target
     page.goto("http://google.com").await?;
     let content = page.content().await?;
-    println!("Content: {}", content);
+    println!("Content: {content}");
 
     browser.close().await?;
     browser_handle.await;
@@ -145,15 +145,14 @@ impl RequestIdExt for fetch::RequestId {
 }
 
 fn is_navigation(event: &EventRequestWillBeSent) -> bool {
-    if event.request_id.inner() == event.loader_id.inner() {
-        if event
+    if event.request_id.inner() == event.loader_id.inner()
+        && event
             .r#type
             .as_ref()
             .map(|t| *t == ResourceType::Document)
             .unwrap_or(false)
-        {
-            return true;
-        }
+    {
+        return true;
     }
     false
 }
@@ -185,17 +184,17 @@ async fn resolve(
 }
 
 async fn forward(page: &Page, request_id: &fetch::RequestId) {
-    println!("Request {:?} forwarded", request_id);
+    println!("Request {request_id:?} forwarded");
     if let Err(e) = page
         .execute(ContinueRequestParams::new(request_id.clone()))
         .await
     {
-        println!("Failed to forward request: {}", e);
+        println!("Failed to forward request: {e}");
     }
 }
 
 async fn abort(page: &Page, request_id: &fetch::RequestId) {
-    println!("Request {:?} aborted", request_id);
+    println!("Request {request_id:?} aborted");
     if let Err(e) = page
         .execute(FailRequestParams::new(
             request_id.clone(),
@@ -203,12 +202,12 @@ async fn abort(page: &Page, request_id: &fetch::RequestId) {
         ))
         .await
     {
-        println!("Failed to abort request: {}", e);
+        println!("Failed to abort request: {e}");
     }
 }
 
 async fn fullfill(page: &Page, request_id: &fetch::RequestId) {
-    println!("Request {:?} fullfilled", request_id);
+    println!("Request {request_id:?} fullfilled");
     if let Err(e) = page
         .execute(
             FulfillRequestParams::builder()
@@ -220,6 +219,6 @@ async fn fullfill(page: &Page, request_id: &fetch::RequestId) {
         )
         .await
     {
-        println!("Failed to fullfill request: {}", e);
+        println!("Failed to fullfill request: {e}");
     }
 }

--- a/examples/evaluate.rs
+++ b/examples/evaluate.rs
@@ -10,13 +10,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (mut browser, mut handler) = Browser::launch(BrowserConfig::builder().build()?).await?;
 
     let handle = async_std::task::spawn(async move {
-        loop {
-            match handler.next().await {
-                Some(h) => match h {
-                    Ok(_) => continue,
-                    Err(_) => break,
-                },
-                None => break,
+        while let Some(h) = handler.next().await {
+            match h {
+                Ok(_) => continue,
+                Err(_) => break,
             }
         }
     });

--- a/examples/interception.rs
+++ b/examples/interception.rs
@@ -52,15 +52,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                 {
-                    println!("Failed to fullfill request: {}", e);
+                    println!("Failed to fullfill request: {e}");
                 }
-            } else {
-                if let Err(e) = intercept_page
-                    .execute(ContinueRequestParams::new(event.request_id.clone()))
-                    .await
-                {
-                    println!("Failed to continue request: {}", e);
-                }
+            } else if let Err(e) = intercept_page
+                .execute(ContinueRequestParams::new(event.request_id.clone()))
+                .await
+            {
+                println!("Failed to continue request: {e}");
             }
         }
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum CdpError {
     #[error("Timeout while resolving websocket URL from browser process, stderr: {0:?}")]
     LaunchTimeout(BrowserStderr),
     #[error(
-        "Input/Output error while resolving websocket URL from browser process, stderr: {0:?}"
+        "Input/Output error while resolving websocket URL from browser process, stderr: {1:?}: {0}"
     )]
     LaunchIo(#[source] io::Error, BrowserStderr),
     #[error("Request timed out.")]


### PR DESCRIPTION
This commit fixes Clippy errors. The main issue was the new rule to use identifiers in format strings, fixed with `clippy --fix`. It also fixes an example to use `while let Some(_)` instead of a `loop { match {...}}`.

Finally, it also fixes the error message for the recently added `CdpError::LaunchIo` variant.