### PR TITLE
Use canonical paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cfg-if = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "fs", "macros", "process"], optional = true }
 tracing = "0.1"
 pin-project-lite = "0.2"
+dunce = "1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10"

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -27,6 +27,7 @@ use crate::handler::viewport::Viewport;
 use crate::handler::{Handler, HandlerConfig, HandlerMessage, REQUEST_TIMEOUT};
 use crate::listeners::{EventListenerRequest, EventStream};
 use crate::page::Page;
+use crate::utils;
 use chromiumoxide_cdp::cdp::browser_protocol::browser::{
     CloseReturns, GetVersionParams, GetVersionReturns,
 };
@@ -79,8 +80,11 @@ impl Browser {
     /// This fails if no web socket url could be detected from the child
     /// processes stderr for more than the configured `launch_timeout`
     /// (20 seconds by default).
-    pub async fn launch(config: BrowserConfig) -> Result<(Self, Handler)> {
-        // launch a new chromium instance
+    pub async fn launch(mut config: BrowserConfig) -> Result<(Self, Handler)> {
+        // Canonalize paths to reduce issues with sandboxing
+        config.executable = utils::canonicalize(&config.executable).await?;
+
+        // Launch a new chromium instance
         let mut child = config.launch()?;
 
         /// Faillible initialization to run once the child process is created.


### PR DESCRIPTION
Fixes #133 

I am unsure if you guys like that I force a canonical for all executable paths, so let me know I can change that.
I added the dependency dunce, its basically a nop for other platforms except windows so I figured it would be fine to always include it.