### PR TITLE
Properly handle the close

### DIFF
--- a/examples/fetcher.rs
+++ b/examples/fetcher.rs
@@ -30,11 +30,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             match handler.next().await {
                 Some(h) => match h {
                     Ok(_) => continue,
-                    Err(_) => break,
+                    Err(e) => {
+                        println!("Err: {}", e);
+                        break;
+                    }
                 },
-                None => break,
+                None => {
+                    println!("None");
+                    break;
+                }
             }
         }
+        println!("Done");
     });
 
     let page = browser.new_page("about:blank").await?;
@@ -44,6 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("it worked!");
 
     browser.close().await?;
+    browser.wait().await?;
     handle.await;
     Ok(())
 }


### PR DESCRIPTION
Fixes #138 
Basically the way we tell people to drive the handler didn't match with the close expectation since it stopped driving the WS connection before the message was actually sent.

Now I think a refactor would be in order to hide the driving of the handler since the user should really not have to worry about that.