### PR TITLE
Fix for iframes and future timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,13 @@ categories = ["web-programming", "api-bindings", "development-tools::testing"]
 [dependencies]
 async-tungstenite = "0.22"
 serde = { version = "1", features = ["derive"] }
-async-std = { version = "1.5", features = ["attributes", "unstable"], optional = true }
+async-std = { version = "1.5", features = [
+    "attributes",
+    "unstable",
+], optional = true }
 futures = "0.3"
-chromiumoxide_types = { path = "chromiumoxide_types", version = "0.5"}
-chromiumoxide_cdp = { path = "chromiumoxide_cdp", version = "0.5"}
+chromiumoxide_types = { path = "chromiumoxide_types", version = "0.5" }
+chromiumoxide_cdp = { path = "chromiumoxide_cdp", version = "0.5" }
 chromiumoxide_fetcher = { path = "chromiumoxide_fetcher", version = "0.5", default-features = false, optional = true }
 serde_json = "1"
 which = "4"
@@ -28,7 +31,14 @@ base64 = "0.21"
 fnv = "1"
 futures-timer = "3"
 cfg-if = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "fs", "macros", "process"], optional = true }
+tokio = { version = "1", features = [
+    "rt",
+    "rt-multi-thread",
+    "time",
+    "fs",
+    "macros",
+    "process",
+], optional = true }
 tracing = "0.1"
 pin-project-lite = "0.2"
 dunce = "1"
@@ -41,6 +51,7 @@ quote = "1"
 proc-macro2 = "1"
 chrono = "0.4.1"
 tracing-subscriber = "0.3"
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
 
 [features]
 default = ["async-std-runtime"]
@@ -58,6 +69,11 @@ _fetcher-native-tokio = ["fetcher", "chromiumoxide_fetcher/_native-tokio"]
 [[example]]
 name = "wiki-tokio"
 required-features = ["tokio-runtime"]
+
+[[example]]
+name = "iframe-workaround"
+required-features = ["tokio-runtime", "tokio"]
+
 
 [[example]]
 name = "httpfuture"

--- a/examples/iframe-workaround.rs
+++ b/examples/iframe-workaround.rs
@@ -1,0 +1,44 @@
+// This example is for checking the iframe workaround.
+// a problem with the iframe workaround is that it will always fail to load the page
+// and goto will cause a timeout.
+
+use std::time::Duration;
+
+use chromiumoxide::handler::HandlerConfig;
+use chromiumoxide_cdp::cdp::browser_protocol::target::CreateBrowserContextParams;
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let (browser, mut handler) = chromiumoxide::Browser::connect(
+        "ws://127.0.0.1:9222/devtools/browser/191fdaef-494d-41b5-8b94-4abd04dff33c",
+        HandlerConfig::default(),
+    )
+    .await
+    .expect("failed to connect to browser");
+
+    let _ = tokio::task::spawn(async move {
+        while let Some(event) = handler.next().await {
+            tracing::debug!(event = ?event);
+        }
+    });
+
+    let page = browser
+        .new_page("about:blank")
+        .await
+        .expect("failed to create page");
+
+    // tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // let _ = page
+    //     .goto("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
+    //     .await
+    //     .expect("failed to navigate");
+
+    let _ = page
+        .goto("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
+        .await
+        .expect("failed to navigate");
+}

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -53,16 +53,36 @@ pub struct Browser {
 
 impl Browser {
     /// Connect to an already running chromium instance via websocket
-    pub async fn connect(
+    pub async fn connect(debug_ws_url: impl Into<String>) -> Result<(Self, Handler)> {
+        let debug_ws_url = debug_ws_url.into();
+        let conn = Connection::<CdpEventMessage>::connect(&debug_ws_url).await?;
+
+        let (tx, rx) = channel(1);
+
+        let fut = Handler::new(conn, rx, HandlerConfig::default());
+        let browser_context = fut.default_browser_context().clone();
+
+        let browser = Self {
+            sender: tx,
+            config: None,
+            child: None,
+            debug_ws_url,
+            browser_context,
+        };
+        Ok((browser, fut))
+    }
+
+    // Connect to an already running chromium instance via websocket with HandlerConfig
+    pub async fn connect_with_config(
         debug_ws_url: impl Into<String>,
-        handler_config: HandlerConfig,
+        config: HandlerConfig,
     ) -> Result<(Self, Handler)> {
         let debug_ws_url = debug_ws_url.into();
         let conn = Connection::<CdpEventMessage>::connect(&debug_ws_url).await?;
 
         let (tx, rx) = channel(1);
 
-        let fut = Handler::new(conn, rx, handler_config);
+        let fut = Handler::new(conn, rx, config);
         let browser_context = fut.default_browser_context().clone();
 
         let browser = Self {

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -53,13 +53,16 @@ pub struct Browser {
 
 impl Browser {
     /// Connect to an already running chromium instance via websocket
-    pub async fn connect(debug_ws_url: impl Into<String>) -> Result<(Self, Handler)> {
+    pub async fn connect(
+        debug_ws_url: impl Into<String>,
+        handler_config: HandlerConfig,
+    ) -> Result<(Self, Handler)> {
         let debug_ws_url = debug_ws_url.into();
         let conn = Connection::<CdpEventMessage>::connect(&debug_ws_url).await?;
 
         let (tx, rx) = channel(1);
 
-        let fut = Handler::new(conn, rx, HandlerConfig::default());
+        let fut = Handler::new(conn, rx, handler_config);
         let browser_context = fut.default_browser_context().clone();
 
         let browser = Self {

--- a/src/handler/commandfuture.rs
+++ b/src/handler/commandfuture.rs
@@ -20,6 +20,9 @@ pin_project! {
         rx_command: oneshot::Receiver<M>,
         #[pin]
         target_sender: mpsc::Sender<TargetMessage>,
+        // We need delay to be pinned because it's a future
+        // and we need to be able to poll it
+        // it is used to timeout the command if page was closed while waiting for response
         #[pin]
         delay: futures_timer::Delay,
 

--- a/src/handler/commandfuture.rs
+++ b/src/handler/commandfuture.rs
@@ -20,6 +20,8 @@ pin_project! {
         rx_command: oneshot::Receiver<M>,
         #[pin]
         target_sender: mpsc::Sender<TargetMessage>,
+        #[pin]
+        delay: futures_timer::Delay,
 
         message: Option<TargetMessage>,
 
@@ -42,10 +44,15 @@ impl<T: Command> CommandFuture<T> {
             cmd, tx, session,
         )?));
 
+        let delay = futures_timer::Delay::new(std::time::Duration::from_millis(
+            crate::handler::REQUEST_TIMEOUT,
+        ));
+
         Ok(Self {
             target_sender,
             rx_command,
             message,
+            delay,
             method,
             _marker: PhantomData,
         })
@@ -73,6 +80,8 @@ where
                 }
                 Poll::Pending => Poll::Pending,
             }
+        } else if this.delay.poll(cx).is_ready() {
+            Poll::Ready(Err(crate::error::CdpError::Timeout))
         } else {
             match this.rx_command.as_mut().poll(cx) {
                 Poll::Ready(Ok(Ok(response))) => {

--- a/src/handler/frame.rs
+++ b/src/handler/frame.rs
@@ -306,13 +306,11 @@ impl FrameManager {
                 )));
             }
             if let Some(frame) = self.frames.get(&watcher.frame_id) {
-                tracing::warn!("frame: {:?}", frame);
                 if let Some(nav) = self.check_lifecycle_complete(&watcher, frame) {
                     // request is complete if the frame's lifecycle is complete = frame received all
                     // required events
                     return Some(FrameEvent::NavigationResult(Ok(nav)));
                 } else {
-                    tracing::error!(?frame, ?watcher, "frame not loaded yet");
                     // not finished yet
                     self.navigation = Some((watcher, deadline));
                 }
@@ -335,7 +333,6 @@ impl FrameManager {
 
     /// Entrypoint for page navigation
     pub fn goto(&mut self, req: FrameNavigationRequest) {
-        tracing::debug!(frame_id = ?self.main_frame, "navigate main frame");
         if let Some(frame_id) = self.main_frame.clone() {
             self.navigate_frame(frame_id, req);
         }
@@ -385,7 +382,6 @@ impl FrameManager {
     }
 
     pub fn on_frame_navigated(&mut self, frame: &CdpFrame) {
-        tracing::debug!(frame = ?frame, "frame navigated");
         if frame.parent_id.is_some() {
             if let Some((id, mut f)) = self.frames.remove_entry(&frame.id) {
                 for child in &f.child_frames {
@@ -499,7 +495,6 @@ impl FrameManager {
 
     /// Fired for top level page lifecycle events (nav, load, paint, etc.)
     pub fn on_page_lifecycle_event(&mut self, event: &EventLifecycleEvent) {
-        tracing::warn!(event = ?event, "page lifecycle event");
         if let Some(frame) = self.frames.get_mut(&event.frame_id) {
             if event.name == "init" {
                 frame.loader_id = Some(event.loader_id.clone());

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -261,19 +261,16 @@ impl Target {
                     }));
                 }
 
-                match ev.target_info.r#type.as_ref() {
-                    "service_worker" => {
-                        let detach_command = DetachFromTargetParams::builder()
-                            .session_id(ev.session_id.clone())
-                            .build();
+                if "service_worker" == &ev.target_info.r#type {
+                    let detach_command = DetachFromTargetParams::builder()
+                        .session_id(ev.session_id.clone())
+                        .build();
 
-                        self.queued_events.push_back(TargetEvent::Request(Request {
-                            method: detach_command.identifier(),
-                            session_id: Some(self.session_id.clone().take().unwrap().into()),
-                            params: serde_json::to_value(detach_command).unwrap(),
-                        }));
-                    }
-                    _ => {}
+                    self.queued_events.push_back(TargetEvent::Request(Request {
+                        method: detach_command.identifier(),
+                        session_id: self.session_id.clone().map(Into::into),
+                        params: serde_json::to_value(detach_command).unwrap(),
+                    }));
                 }
             }
 


### PR DESCRIPTION
This library have some problems with handling iframes and dont work properly and handle service workers.
I created this pull request that contain's fixes for few cases.

1) Some websites, that contain's an iframe will load forever and never resolve's.
Problem is: I checked puppeteer or playwright libraries, and found, that they're sending runIfWaitingForDebugger for attached targets to target, what chromiumoxide doesn't do or handle.
Also, I noticed, that we have to send two events for service workers, runIfWaitingForDebugger and detachFromTarget.
I implemented both, and page's, that won't load before now loading successfully.
Example URLs: 
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
https://www.financialexpress.com/ (has an service worker)

Solution: I added runIfWaitingForDebugger when CdpEvent::TargetAttachedToTarget is emitted, and also, if it new target is service_worker, then we also send event detachFromTarget

After, I noticed, that page's now loading correctly, but future .goto(url) still failing on timeout. Then I started discovery source of this problem. And solution is in next case.

2) If page has an iframe, it will load forever and `.goto(url)` always fail on timeout.
Sample URL: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
Expected behaviour: Page loaded and `.goto(url)` future returns Ok.

Solution: I modified check_lifecycle and checking it for if lifecycle events contain's "load" event, or (if page url is None and lifecycle events has event DOMContentLoaded).

3) No way to customize request timeout. 
Solution: I added function connect_with_config to Browser instance. It accepts url as first parameter, and HandlerConfig as second.

4) Problem with .goto(url) action.
How to reproduce: Open new page and call .goto(url) on it, then go to browser and close tab (you should choose long-loading website to reproduce).
Future never will be await'ed, even there will be no timeout or other error.
So it will runs forever.

Solution: Added DelayFuture in CommandFuture, it uses crate::REQUEST_TIMEOUT and will return CdpError::Timeout if timer is ready.

Closes #163 and closes #171