### PR TITLE
fix: always try to flush after ready

### DIFF
--- a/examples/simple-google.rs
+++ b/examples/simple-google.rs
@@ -1,0 +1,29 @@
+use chromiumoxide::browser::BrowserConfigBuilder;
+use chromiumoxide::Browser;
+use futures::StreamExt;
+use std::time::Duration;
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let (browser, mut handler) = Browser::launch(
+        BrowserConfigBuilder::default()
+            .request_timeout(Duration::from_secs(5))
+            .build()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let h = task::spawn(async move {
+        while let Some(h) = handler.next().await {
+            h.unwrap();
+        }
+    });
+
+    let page = browser.new_page("https://www.google.com").await.unwrap();
+
+    println!("loaded page {:?}", page);
+    h.await.unwrap();
+}

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -26,7 +26,7 @@ impl EventListeners {
             method,
             kind,
         } = req;
-        let subs = self.listeners.entry(method).or_insert_with(Vec::new);
+        let subs = self.listeners.entry(method).or_default();
         subs.push(EventListener {
             listener,
             kind,


### PR DESCRIPTION
Closes #178

there were some changes in tungstenite regarding Sink flush related to this to this 

https://github.com/snapview/tokio-tungstenite/pull/284 which surfaced a logic bug in the Connection implementation that would result in a stalled connection.

this fix ensures that after each poll_ready call we continue with a flush