### PR TITLE
expose non-mutable FrameManager on Target

### DIFF
--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -190,6 +190,10 @@ impl Target {
         self.info.opener_id.as_ref()
     }
 
+    pub fn frame_manager(&self) -> &FrameManager {
+        &self.frame_manager
+    }
+
     pub fn frame_manager_mut(&mut self) -> &mut FrameManager {
         &mut self.frame_manager
     }


### PR DESCRIPTION
I couldn't find another way of getting an `ExecutionContextId` for a `FrameId` (i.e. to run commands targeting a specific frame within a page) without this patch to expose a non-mutable `&FrameManager` through `&Target` (`mut Handler.targets() -> &Target -> &FrameManager -> &Frame -> &DOMWorld -> ExecutionContextId`).