### PR TITLE
Implement function to fetch existing targets when connecting to existing chromium instance

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -12,7 +12,8 @@ use futures::select;
 use futures::SinkExt;
 
 use chromiumoxide_cdp::cdp::browser_protocol::target::{
-    CreateBrowserContextParams, CreateTargetParams, DisposeBrowserContextParams, TargetId, TargetInfo,
+    CreateBrowserContextParams, CreateTargetParams, DisposeBrowserContextParams, TargetId,
+    TargetInfo,
 };
 use chromiumoxide_cdp::cdp::{CdpEventMessage, IntoEventKind};
 use chromiumoxide_types::*;
@@ -182,7 +183,7 @@ impl Browser {
     /// By default, only targets launched after the browser connection are tracked
     /// when connecting to a existing browser instance with the devtools websocket url
     /// This function fetches existing targets on the browser and adds them as pages internally
-    /// 
+    ///
     /// The pages are not guaranteed to be ready as soon as the function returns
     /// You should wait a few millis if you need to use a page
     /// Returns [TargetInfo]

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -12,7 +12,7 @@ use futures::select;
 use futures::SinkExt;
 
 use chromiumoxide_cdp::cdp::browser_protocol::target::{
-    CreateBrowserContextParams, CreateTargetParams, DisposeBrowserContextParams, TargetId,
+    CreateBrowserContextParams, CreateTargetParams, DisposeBrowserContextParams, TargetId, TargetInfo,
 };
 use chromiumoxide_cdp::cdp::{CdpEventMessage, IntoEventKind};
 use chromiumoxide_types::*;
@@ -175,6 +175,26 @@ impl Browser {
         };
 
         Ok((browser, fut))
+    }
+
+    /// Request to fetch all existing browser targets.
+    ///
+    /// By default, only targets launched after the browser connection are tracked
+    /// when connecting to a existing browser instance with the devtools websocket url
+    /// This function fetches existing targets on the browser and adds them as pages internally
+    /// 
+    /// The pages are not guaranteed to be ready as soon as the function returns
+    /// You should wait a few millis if you need to use a page
+    /// Returns [TargetInfo]
+    pub async fn fetch_targets(&mut self) -> Result<Vec<TargetInfo>> {
+        let (tx, rx) = oneshot_channel();
+
+        self.sender
+            .clone()
+            .send(HandlerMessage::FetchTargets(tx))
+            .await?;
+
+        rx.await?
     }
 
     /// Request for the browser to close completely.

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -213,6 +213,30 @@ impl Handler {
                         }
                     }
                 }
+                PendingRequest::GetTargets(tx) => {
+                    match to_command_response::<GetTargetsParams>(resp, method) {
+                        Ok(resp) => {
+                            let targets: Vec<TargetInfo> = resp.result.target_infos;
+                            let results = targets.clone();
+                            for target_info in targets {
+                                let target_id = target_info.target_id.clone();
+                                let event: EventTargetCreated = EventTargetCreated { target_info };
+                                self.on_target_created(event);
+                                let attach = AttachToTargetParams::new(target_id);
+                                let _ = self.conn.submit_command(
+                                    attach.identifier(),
+                                    None,
+                                    serde_json::to_value(attach).unwrap(),
+                                );
+                            }
+
+                            let _ = tx.send(Ok(results)).ok();
+                        }
+                        Err(err) => {
+                            let _ = tx.send(Err(err)).ok();
+                        }
+                    }
+                }
                 PendingRequest::Navigate(id) => {
                     self.on_navigation_response(id, resp);
                 }
@@ -264,6 +288,22 @@ impl Handler {
             (PendingRequest::InternalCommand(target_id), req.method, now),
         );
         Ok(())
+    }
+
+    fn submit_fetch_targets(&mut self, tx: OneshotSender<Result<Vec<TargetInfo>>>, now: Instant) {
+        let msg = GetTargetsParams { filter: None };
+        let method = msg.identifier();
+        let call_id = self.conn.submit_command(
+           method.clone(),
+            None,
+            serde_json::to_value(msg).unwrap(),
+        )
+        .unwrap();
+
+        self.pending_commands.insert(
+            call_id,
+            (PendingRequest::GetTargets(tx), method, now),
+        );
     }
 
     /// Send the Request over to the server and store its identifier to handle
@@ -456,6 +496,9 @@ impl Handler {
                     PendingRequest::CreateTarget(tx) => {
                         let _ = tx.send(Err(CdpError::Timeout));
                     }
+                    PendingRequest::GetTargets(tx) => {
+                        let _ = tx.send(Err(CdpError::Timeout));
+                    }
                     PendingRequest::Navigate(nav) => {
                         if let Some(nav) = self.navigations.remove(&nav) {
                             match nav {
@@ -497,6 +540,9 @@ impl Stream for Handler {
                 match msg {
                     HandlerMessage::Command(cmd) => {
                         pin.submit_external_command(cmd, now)?;
+                    }
+                    HandlerMessage::FetchTargets(tx) => {
+                        pin.submit_fetch_targets(tx, now);
                     }
                     HandlerMessage::CloseBrowser(tx) => {
                         pin.submit_close(tx, now);
@@ -679,6 +725,8 @@ enum PendingRequest {
     /// A Request to create a new `Target` that results in the creation of a
     /// `Page` that represents a browser page.
     CreateTarget(OneshotSender<Result<Page>>),
+    /// A Request to fetch old `Target`s created before connection
+    GetTargets(OneshotSender<Result<Vec<TargetInfo>>>),
     /// A Request to navigate a specific `Target`.
     ///
     /// Navigation requests are not automatically completed once the response to
@@ -701,6 +749,7 @@ enum PendingRequest {
 #[derive(Debug)]
 pub(crate) enum HandlerMessage {
     CreatePage(CreateTargetParams, OneshotSender<Result<Page>>),
+    FetchTargets(OneshotSender<Result<Vec<TargetInfo>>>),
     InsertContext(BrowserContext),
     DisposeContext(BrowserContext),
     GetPages(OneshotSender<Vec<Page>>),

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -293,17 +293,13 @@ impl Handler {
     fn submit_fetch_targets(&mut self, tx: OneshotSender<Result<Vec<TargetInfo>>>, now: Instant) {
         let msg = GetTargetsParams { filter: None };
         let method = msg.identifier();
-        let call_id = self.conn.submit_command(
-           method.clone(),
-            None,
-            serde_json::to_value(msg).unwrap(),
-        )
-        .unwrap();
+        let call_id = self
+            .conn
+            .submit_command(method.clone(), None, serde_json::to_value(msg).unwrap())
+            .unwrap();
 
-        self.pending_commands.insert(
-            call_id,
-            (PendingRequest::GetTargets(tx), method, now),
-        );
+        self.pending_commands
+            .insert(call_id, (PendingRequest::GetTargets(tx), method, now));
     }
 
     /// Send the Request over to the server and store its identifier to handle


### PR DESCRIPTION
When connecting to an existing Chromium instance with ``Browser::connect``, pages created before the connection cannot be used because chromiumoxide doesn't know they exist.

I implemented a function ``Browser::fetch_targets`` that uses [``Target.getTargets``](https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-getTargets) to fetch all existing pages. If the user wants to use pages created before the connection, all they need to do is call that function.