### PR TITLE
Remove unused features from reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing = "0.1"
 pin-project-lite = "0.2"
 dunce = "1"
 bytes = { version = "1.4.0", features = ["serde"], optional = true }
-reqwest = { version = "0.11.20", features = [ "brotli", "gzip", "deflate", "native-tls-alpn", "stream" ] }
+reqwest = { version = "0.11.20", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -85,7 +85,7 @@ impl Browser {
 
     // Connect to an already running chromium instance with a given `HandlerConfig`.
     ///
-    /// If the URL is a http(s) URL, it will first attempt to retrieve the Websocket URL from the `json/version` endpoint.
+    /// If the URL is a http URL, it will first attempt to retrieve the Websocket URL from the `json/version` endpoint.
     pub async fn connect_with_config(
         url: impl Into<String>,
         config: HandlerConfig,


### PR DESCRIPTION
Hey @mattsse , thanks for the great library!

I've noticed in the new release there are a bunch of unused features in newly introduced reqwest dependency. Besides code bloat they could introduce cross-platform compatibility issues. Since reqwest is used only for single http-only request (Chromium debugging port is always HTTP) I've thought it would nice to remove them.

Cheers!
