### PR TITLE
fallback if snap is targetted

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -155,18 +155,8 @@ impl Browser {
     /// (20 seconds by default).
     pub async fn launch(mut config: BrowserConfig) -> Result<(Self, Handler)> {
         // Canonalize paths to reduce issues with sandboxing
-        let mut executable_cleaned = utils::canonicalize(&config.executable).await?;
-        // Handle case where executable is provided by snap
-        if executable_cleaned.to_str().unwrap().ends_with("/snap") {
-            if config.executable.is_absolute() {
-                executable_cleaned = config.executable;
-            } else {
-                executable_cleaned = std::env::current_dir()?.join(config.executable);
-            }
-            config.executable = dunce::simplified(&executable_cleaned).to_path_buf();
-        } else {
-            config.executable = executable_cleaned;
-        }
+        config.executable = utils::canonicalize_except_snap(config.executable).await?;
+
         // Launch a new chromium instance
         let mut child = config.launch()?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,24 @@ pub(crate) async fn canonicalize<P: AsRef<Path> + Unpin>(path: P) -> std::io::Re
     Ok(dunce::simplified(&path).to_path_buf())
 }
 
+/// Absolute path
+///
+pub(crate) fn absolute(path: PathBuf) -> std::io::Result<PathBuf> {
+    let path = if path.is_absolute() { path } else { std::env::current_dir()?.join(path) };
+    Ok(dunce::simplified(&path).to_path_buf())
+}
+
+/// Canonicalize path except if target binary is snap, in this case only make the path absolute
+///
+pub(crate) async fn canonicalize_except_snap(path: PathBuf) -> std::io::Result<PathBuf> {
+    // Canonalize paths to reduce issues with sandboxing
+    let executable_cleaned: PathBuf = canonicalize(&path).await?;
+
+    // Handle case where executable is provided by snap, ignore canonicalize result and only make path absolute
+    Ok(if executable_cleaned.to_str().unwrap().ends_with("/snap") { absolute(path).unwrap() } else { executable_cleaned })
+}
+
+
 pub(crate) mod base64 {
     use base64::engine::general_purpose::STANDARD;
     use base64::{DecodeError, Engine};


### PR DESCRIPTION
This PR fixes #186 by reverting the canonalization in case the final binary is snap (when chromium is installed through snap).
We still try to make the path absolute and clean it. It might not be as effective but we only be done when snap is detected and used in a case which wasn't working before.

It will be more elegant to use fs::absolute but the feature is still in nightly rust version.