### PR TITLE
feat(page): add wait_for_network_idle

### DIFF
--- a/src/page.rs
+++ b/src/page.rs
@@ -313,8 +313,7 @@ impl Page {
             tokio::pin!(sleep);
             tokio::select! {
                 _ = &mut sleep => break,
-                _ = events.next() => (),
-                else => break,
+                _ = events.next() => ()
             }
         }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -312,8 +312,12 @@ impl Page {
             let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(500));
             tokio::pin!(sleep);
             tokio::select! {
-                _ = &mut sleep => break,
-                _ = events.next() => ()
+                _ = &mut sleep => (),
+                v = events.next() => {
+                  if v.is_none () {
+                      break;
+                  }
+                }
             }
         }
 
@@ -333,8 +337,12 @@ impl Page {
             pin_mut!(t1, t2);
 
             select! {
-                () = t1 => break,
-                _ = t2 => (),
+                () = t1 => (),
+                v = t2 => {
+                    if v.is_none () {
+                        break;
+                    }
+                  }
             }
         }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -312,7 +312,7 @@ impl Page {
             let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(500));
             tokio::pin!(sleep);
             tokio::select! {
-                _ = &mut sleep => (),
+                _ = &mut sleep => break,
                 v = events.next() => {
                   if v.is_none () {
                       break;
@@ -337,7 +337,7 @@ impl Page {
             pin_mut!(t1, t2);
 
             select! {
-                () = t1 => (),
+                () = t1 => break,
                 v = t2 => {
                     if v.is_none () {
                         break;

--- a/src/page.rs
+++ b/src/page.rs
@@ -308,19 +308,15 @@ impl Page {
     pub async fn wait_for_network_idle(&self) -> Result<&Self> {
         let mut events = self.event_listener::<chromiumoxide_cdp::cdp::browser_protocol::network::EventLoadingFinished>().await?;
 
-        if let Err(_) = tokio::time::timeout(tokio::time::Duration::from_secs(30), async move {
-            loop {
-                let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(500));
-                tokio::pin!(sleep);
-                tokio::select! {
-                    _ = &mut sleep => break,
-                    _ = events.next() => (),
-                    else => break,
-                }
+        loop {
+            let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(500));
+            tokio::pin!(sleep);
+            tokio::select! {
+                _ = &mut sleep => break,
+                _ = events.next() => (),
+                else => break,
             }
-        })
-        .await
-        {}
+        }
 
         Ok(self)
     }
@@ -331,22 +327,38 @@ impl Page {
         use futures::{future::FutureExt, pin_mut, select};
         let mut events = self.event_listener::<chromiumoxide_cdp::cdp::browser_protocol::network::EventLoadingFinished>().await?;
 
-        async_std::io::timeout(std::time::Duration::from_secs(30), async {
-            loop {
-                let t1 = async_std::task::sleep(std::time::Duration::from_millis(500)).fuse();
-                let t2 = events.next().fuse();
+        loop {
+            let t1 = async_std::task::sleep(std::time::Duration::from_millis(500)).fuse();
+            let t2 = events.next().fuse();
 
-                pin_mut!(t1, t2);
+            pin_mut!(t1, t2);
 
-                select! {
-                    () = t1 => break,
-                    _ = t2 => (),
-                }
+            select! {
+                () = t1 => break,
+                _ = t2 => (),
             }
-            Ok(())
-        })
-        .await?;
+        }
 
+        Ok(self)
+    }
+
+    /// Wait for the network to be idle for 500ms with a duration timeout
+    #[cfg(feature = "tokio-runtime")]
+    pub async fn wait_for_network_idle_with_timeout(
+        &self,
+        timeout: core::time::Duration,
+    ) -> Result<&Self> {
+        if let Err(_) = tokio::time::timeout(timeout, self.wait_for_network_idle()).await {}
+        Ok(self)
+    }
+
+    /// Wait for the network to be idle for 500ms with a duration timeout
+    #[cfg(feature = "async-std-runtime")]
+    pub async fn wait_for_network_idle_with_timeout(
+        &self,
+        timeout: core::time::Duration,
+    ) -> Result<&Self> {
+        let _ = (async_std::future::timeout(timeout, self.wait_for_network_idle()).await).is_err();
         Ok(self)
     }
 


### PR DESCRIPTION
Hi, this PR provides a way for the client to wait for network connections to become idle. It mimics puppeteers and playwrights implementation of waiting for at least 500 seconds for the last network request. We provide two methods for control the feature. One comes with a timeout to prevent long polling from keeping connections open.