### PR TITLE
[Based on #195 but zero-copy] Log ws message on parsing error to Message enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ _fetcher-rusttls-tokio = ["fetcher", "chromiumoxide_fetcher/_rustls-tokio"]
 _fetcher-native-async-std = ["fetcher", "chromiumoxide_fetcher/_native-async-std"]
 _fetcher-native-tokio = ["fetcher", "chromiumoxide_fetcher/_native-tokio"]
 
+debug-raw-ws-messages = []
+
 [[example]]
 name = "wiki-tokio"
 required-features = ["tokio-runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,6 @@ _fetcher-rusttls-tokio = ["fetcher", "chromiumoxide_fetcher/_rustls-tokio"]
 _fetcher-native-async-std = ["fetcher", "chromiumoxide_fetcher/_native-async-std"]
 _fetcher-native-tokio = ["fetcher", "chromiumoxide_fetcher/_native-tokio"]
 
-debug-raw-ws-messages = []
-
 [[example]]
 name = "wiki-tokio"
 required-features = ["tokio-runtime"]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -154,8 +154,9 @@ impl<T: EventMessage + Unpin> Stream for Connection<T> {
                 Poll::Ready(Some(ready))
             }
             Some(Ok(WsMessage::Close(_))) => Poll::Ready(None),
+            // ignore ping and pong
             Some(Ok(WsMessage::Ping(_))) | Some(Ok(WsMessage::Pong(_))) => {
-                // ignore pings
+                cx.waker().wake_by_ref();
                 Poll::Pending
             }
             Some(Ok(msg)) => Poll::Ready(Some(Err(CdpError::UnexpectedWsMessage(msg)))),

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -147,6 +147,9 @@ impl<T: EventMessage + Unpin> Stream for Connection<T> {
 
         tracing::trace!(target: "chromiumoxide::conn::raw_ws", ?msg, "Got raw WS message");
 
+        #[cfg(feature = "debug-raw-ws-messages")]
+        let msg_for_debug = msg.clone();
+
         Poll::Ready(Some(
             match serde_json::from_slice::<Message<T>>(&msg.into_data()) {
                 Ok(msg) => {
@@ -154,6 +157,9 @@ impl<T: EventMessage + Unpin> Stream for Connection<T> {
                     Ok(msg)
                 }
                 Err(err) => {
+                    #[cfg(feature = "debug-raw-ws-messages")]
+                    tracing::debug!(target: "chromiumoxide::conn::raw_ws::parse_errors", msg = ?msg_for_debug, "Failed to parse raw WS message");
+
                     tracing::error!("Failed to deserialize WS response {}", err);
                     Err(err.into())
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::process::ExitStatus;
 use std::time::Instant;
 
 use async_tungstenite::tungstenite;
+use async_tungstenite::tungstenite::Message;
 use base64::DecodeError;
 use futures::channel::mpsc::SendError;
 use futures::channel::oneshot::Canceled;
@@ -28,6 +29,8 @@ pub enum CdpError {
     Chrome(#[from] chromiumoxide_types::Error),
     #[error("Received no response from the chromium instance.")]
     NoResponse,
+    #[error("Received unexpected ws message: {0:?}")]
+    UnexpectedWsMessage(Message),
     #[error("{0}")]
     ChannelSendError(#[from] ChannelError),
     #[error("Browser process exited with status {0:?} before websocket URL could be resolved, stderr: {1:?}")]


### PR DESCRIPTION
As the title, this is based on #195, but zero-copy.

Also, it changes from doing `serde_json::from_slice(&data.into_data())` to doing `serde_json::from_str(&text)` of `WsMessage::Text(text)`. Other variants of `WsMessage` are handled as follows:

- `Ping` and `Pong`: Ignored
- `Bytes` and `Frames`: Ignored
- `Close`: Ends the stream

