### PR TITLE
Include invalid JSON in an error returned with command execution

### DIFF
--- a/chromiumoxide_types/Cargo.toml
+++ b/chromiumoxide_types/Cargo.toml
@@ -12,4 +12,4 @@ include = ["src/**/*", "LICENSE-*"]
 
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.72"
+serde_json = { version = "1.0.72", features = ["raw_value"] }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -19,12 +19,14 @@ pub(crate) fn to_command_response<T: Command>(
     method: MethodId,
 ) -> Result<CommandResponse<T::Response>> {
     if let Some(res) = resp.result {
-        let result = serde_json::from_value(res)?;
-        Ok(CommandResponse {
-            id: resp.id,
-            result,
-            method,
-        })
+        match serde_json::from_str(res.get()) {
+            Ok(result) => Ok(CommandResponse {
+                id: resp.id,
+                result,
+                method,
+            }),
+            Err(error) => Err(CdpError::InvalidResponse { result: res, error }),
+        }
     } else if let Some(err) = resp.error {
         Err(err.into())
     } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,12 @@ pub enum CdpError {
     JavascriptException(Box<ExceptionDetails>),
     #[error("{0}")]
     Url(#[from] url::ParseError),
+    #[error("got invalid response with error: {error}")]
+    InvalidResponse {
+        // not Value to avoid deserialization and additional allocations
+        result: Box<serde_json::value::RawValue>,
+        error: serde_json::Error,
+    },
 }
 impl CdpError {
     pub fn msg(msg: impl Into<String>) -> Self {

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -210,10 +210,11 @@ impl Target {
         #[allow(clippy::single_match)] // allow for now
         match method {
             GetFrameTreeParams::IDENTIFIER => {
-                if let Some(resp) = resp
-                    .result
-                    .and_then(|val| GetFrameTreeParams::response_from_value(val).ok())
-                {
+                if let Some(resp) = resp.result.and_then(|val| {
+                    serde_json::from_str(val.get())
+                        .map(GetFrameTreeParams::infer_response)
+                        .ok()
+                }) {
                     self.frame_manager.on_frame_tree(resp.frame_tree);
                 }
             }


### PR DESCRIPTION
Related: #167 

In the main branch, users cannot get invalid JSON after getting an error with calling a function that executes a command, and it does not help to write fallback logic on receiving invalid responses from Chromium.

In my case, I had created a custom command just for getting `serde_json::Value` like the following.

```rust
#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
pub struct CustomGetFullAxTree;

impl Command for CustomGetFullAxTree {
    type Response = Value;
}

impl Method for CustomGetFullAxTree {
    fn identifier(&self) -> chromiumoxide::types::MethodId {
        chromiumoxide::types::MethodId::Borrowed("Accessibility.getFullAXTree")
    }
}
```