### PR TITLE
Update to reqwest 0.12 and async-tungstenite 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["chrome", "chromedriver", "puppeteer", "automation"]
 categories = ["web-programming", "api-bindings", "development-tools::testing"]
 
 [dependencies]
-async-tungstenite = "0.23"
+async-tungstenite = "0.25"
 serde = { version = "1", features = ["derive"] }
 async-std = { version = "1.5", features = [
     "attributes",
@@ -43,7 +43,7 @@ tracing = "0.1"
 pin-project-lite = "0.2"
 dunce = "1"
 bytes = { version = "1.4.0", features = ["serde"], optional = true }
-reqwest = { version = "0.11.20", default-features = false }
+reqwest = { version = "0.12", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"

--- a/chromiumoxide_fetcher/Cargo.toml
+++ b/chromiumoxide_fetcher/Cargo.toml
@@ -19,7 +19,7 @@ os_info = { version = "3", default-features = false }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 async-std = { version = "1.5", features = ["unstable"], optional = true }
 tokio = { version = "1", features = ["fs"], optional = true }
-reqwest = { version = "0.11", default-features = false, optional = true }
+reqwest = { version = "0.12", default-features = false, optional = true }
 surf = { version = "2.3", default-features = false, optional = true }
 
 [features]


### PR DESCRIPTION
Those dependencies use Hyper v1.0 family crates, so I've decided to update them together to avoid noise.