### PR TITLE
Expose more `Page` methods

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -8,6 +8,7 @@ use futures::channel::oneshot::Sender as OneshotSender;
 use futures::stream::{Fuse, Stream, StreamExt};
 use futures::task::{Context, Poll};
 
+use crate::auth::Credentials;
 use crate::listeners::{EventListenerRequest, EventListeners};
 use chromiumoxide_cdp::cdp::browser_protocol::browser::*;
 use chromiumoxide_cdp::cdp::browser_protocol::target::*;
@@ -431,13 +432,13 @@ impl Handler {
             .unwrap_or_else(|| self.default_browser_context.clone());
         let target = Target::new(
             event.target_info,
-            TargetConfig::new(
-                self.config.ignore_https_errors,
-                self.config.request_timeout,
-                self.config.viewport.clone(),
-                self.config.request_intercept,
-                self.config.cache_enabled,
-            ),
+            TargetConfig {
+                ignore_https_errors: self.config.ignore_https_errors,
+                request_timeout: self.config.request_timeout,
+                viewport: self.config.viewport.clone(),
+                request_intercept: self.config.request_intercept,
+                cache_enabled: self.config.cache_enabled,
+            },
             browser_ctx,
         );
         self.target_ids.push(target.target_id().clone());

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -8,7 +8,6 @@ use futures::channel::oneshot::Sender as OneshotSender;
 use futures::stream::{Fuse, Stream, StreamExt};
 use futures::task::{Context, Poll};
 
-use crate::auth::Credentials;
 use crate::listeners::{EventListenerRequest, EventListeners};
 use chromiumoxide_cdp::cdp::browser_protocol::browser::*;
 use chromiumoxide_cdp::cdp::browser_protocol::target::*;

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -46,11 +46,12 @@ pub struct PageHandle {
 }
 
 impl PageHandle {
-    pub fn new(target_id: TargetId, session_id: SessionId) -> Self {
+    pub fn new(target_id: TargetId, session_id: SessionId, opener_id: Option<TargetId>) -> Self {
         let (commands, rx) = channel(1);
         let page = PageInner {
             target_id,
             session_id,
+            opener_id,
             sender: commands,
         };
         Self {
@@ -68,6 +69,7 @@ impl PageHandle {
 pub(crate) struct PageInner {
     target_id: TargetId,
     session_id: SessionId,
+    opener_id: Option<TargetId>,
     sender: Sender<TargetMessage>,
 }
 
@@ -104,6 +106,11 @@ impl PageInner {
     /// The identifier of this page's target's session
     pub fn session_id(&self) -> &SessionId {
         &self.session_id
+    }
+
+    /// The identifier of this page's target's opener target
+    pub fn opener_id(&self) -> &Option<TargetId> {
+        &self.opener_id
     }
 
     pub(crate) fn sender(&self) -> &Sender<TargetMessage> {

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -162,7 +162,8 @@ impl Target {
     fn create_page(&mut self) {
         if self.page.is_none() {
             if let Some(session) = self.session_id.clone() {
-                let handle = PageHandle::new(self.target_id().clone(), session);
+                let handle =
+                    PageHandle::new(self.target_id().clone(), session, self.opener_id().cloned());
                 self.page = Some(handle);
             }
         }
@@ -187,7 +188,7 @@ impl Target {
     }
 
     /// Get the target that opened this target. Top-level targets return `None`.
-    pub fn opener(&self) -> Option<&TargetId> {
+    pub fn opener_id(&self) -> Option<&TargetId> {
         self.info.opener_id.as_ref()
     }
 

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -18,6 +18,7 @@ use chromiumoxide_cdp::cdp::events::CdpEvent;
 use chromiumoxide_cdp::cdp::CdpEventMessage;
 use chromiumoxide_types::{Command, Method, Request, Response};
 
+use crate::auth::Credentials;
 use crate::cdp::browser_protocol::target::CloseTargetParams;
 use crate::cmd::CommandChain;
 use crate::cmd::CommandMessage;
@@ -513,6 +514,9 @@ impl Target {
                                 let _ = tx.send(None);
                             }
                         }
+                        TargetMessage::Authenticate(credentials) => {
+                            self.network_manager.authenticate(credentials);
+                        }
                     }
                 }
             }
@@ -597,24 +601,6 @@ pub struct TargetConfig {
     pub viewport: Option<Viewport>,
     pub request_intercept: bool,
     pub cache_enabled: bool,
-}
-
-impl TargetConfig {
-    pub fn new(
-        ignore_https_errors: bool,
-        request_timeout: Duration,
-        viewport: Option<Viewport>,
-        request_intercept: bool,
-        cache_enabled: bool,
-    ) -> Self {
-        Self {
-            ignore_https_errors,
-            request_timeout,
-            viewport,
-            request_intercept,
-            cache_enabled,
-        }
-    }
 }
 
 impl Default for TargetConfig {
@@ -793,4 +779,5 @@ pub enum TargetMessage {
     AddEventListener(EventListenerRequest),
     /// Get the `ExecutionContext` if available
     GetExecutionContext(GetExecutionContext),
+    Authenticate(Credentials),
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -26,6 +26,7 @@ use chromiumoxide_cdp::cdp::js_protocol::runtime::{
 use chromiumoxide_cdp::cdp::{browser_protocol, IntoEventKind};
 use chromiumoxide_types::*;
 
+use crate::auth::Credentials;
 use crate::element::Element;
 use crate::error::{CdpError, Result};
 use crate::handler::commandfuture::CommandFuture;
@@ -337,6 +338,16 @@ impl Page {
             }))
             .await?;
         Ok(rx.await?)
+    }
+
+    pub async fn authenticate(&self, credentials: Credentials) -> Result<()> {
+        self.inner
+            .sender()
+            .clone()
+            .send(TargetMessage::Authenticate(credentials))
+            .await?;
+
+        Ok(())
     }
 
     /// Returns the current url of the page

--- a/src/page.rs
+++ b/src/page.rs
@@ -326,6 +326,11 @@ impl Page {
         self.inner.session_id()
     }
 
+    /// The identifier of the `Session` target of this page is attached to
+    pub fn opener_id(&self) -> &Option<TargetId> {
+        self.inner.opener_id()
+    }
+
     /// Returns the name of the frame
     pub async fn frame_name(&self, frame_id: FrameId) -> Result<Option<String>> {
         let (tx, rx) = oneshot_channel();


### PR DESCRIPTION
Despite being implemented in `Target`, Puppeteer's `authenticate()` API is not available for regular `Page` users. This PR adds a new target message to port that. Same goes for `opener_id()`.