### PR TITLE
Expose cmd for CommandChain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use crate::page::Page;
 
 pub mod auth;
 pub mod browser;
-pub(crate) mod cmd;
+pub mod cmd;
 pub mod conn;
 pub mod detection;
 pub mod element;


### PR DESCRIPTION
Would be nice to have access to CommandChain to batch the CDP commands instead of having to send one by one.