### PR TITLE
Rollback PDL to stable and update fetcher to match

### DIFF
--- a/chromiumoxide_cdp/browser_protocol.pdl
+++ b/chromiumoxide_cdp/browser_protocol.pdl
@@ -532,8 +532,6 @@ experimental domain Audits
       WarnDomainNonASCII
       WarnThirdPartyPhaseout
       WarnCrossSiteRedirectDowngradeChangesInclusion
-      WarnDeprecationTrialMetadata
-      WarnThirdPartyCookieHeuristic
 
   type CookieOperation extends string
     enum
@@ -4223,6 +4221,7 @@ domain Emulation
       gyroscope
       linear-acceleration
       magnetometer
+      proximity
       relative-orientation
 
   experimental type SensorMetadata extends object
@@ -7925,8 +7924,8 @@ experimental domain Overlay
       # True for showing hit-test borders
       boolean show
 
-  # Deprecated, no longer has any effect.
-  deprecated command setShowWebVitals
+  # Request that backend shows an overlay with web vital metrics.
+  command setShowWebVitals
     parameters
       boolean show
 
@@ -8090,7 +8089,6 @@ domain Page
       deferred-fetch
       digital-credentials-get
       direct-sockets
-      direct-sockets-private
       display-capture
       document-domain
       encrypted-media

--- a/chromiumoxide_cdp/js_protocol.pdl
+++ b/chromiumoxide_cdp/js_protocol.pdl
@@ -606,6 +606,7 @@ domain Debugger
     properties
       # Type of the debug symbols.
       enum type
+        None
         SourceMap
         EmbeddedDWARF
         ExternalDWARF
@@ -688,8 +689,8 @@ domain Debugger
       experimental optional integer codeOffset
       # The language of the script.
       experimental optional Debugger.ScriptLanguage scriptLanguage
-      # If the scriptLanguage is WebAssembly, the source of debug symbols for the module.
-      experimental optional array of Debugger.DebugSymbols debugSymbols
+      # If the scriptLanguage is WebASsembly, the source of debug symbols for the module.
+      experimental optional Debugger.DebugSymbols debugSymbols
       # The name the embedder supplied for this script.
       experimental optional string embedderName
 

--- a/chromiumoxide_cdp/src/lib.rs
+++ b/chromiumoxide_cdp/src/lib.rs
@@ -29,7 +29,7 @@ pub mod revision;
 // is generally a good idea.
 
 /// Currently built CDP revision
-pub const CURRENT_REVISION: Revision = Revision(1359167);
+pub const CURRENT_REVISION: Revision = Revision(1354347);
 
 /// convenience fixups
 impl Default for CreateTargetParams {

--- a/chromiumoxide_cdp/src/lib.rs
+++ b/chromiumoxide_cdp/src/lib.rs
@@ -14,6 +14,20 @@ use crate::revision::Revision;
 pub mod cdp;
 pub mod revision;
 
+// The CDP is not a stable API, it changes from time to time and sometimes
+// in backward incompatible ways.
+//
+// When the CDP changes, the chromium team pushes a commit to the repository
+// https://github.com/ChromeDevTools/devtools-protocol. There you can find
+// valid CDP revisions. That number corresponds to a chromium revision.
+// It is a monotonic version number referring to the chromium master commit position.
+//
+// To map a revision to a chromium version you can use the site
+// https://chromiumdash.appspot.com/commits. We should not necessarily
+// always use the latest revision, as this will mean only the newest chromium
+// browser can be used. Apart from breaking changes, using an older CDP
+// is generally a good idea.
+
 /// Currently built CDP revision
 pub const CURRENT_REVISION: Revision = Revision(1359167);
 

--- a/chromiumoxide_cdp/tests/generate.rs
+++ b/chromiumoxide_cdp/tests/generate.rs
@@ -18,7 +18,7 @@ fn generated_code_is_fresh() {
 
     let tmp = tempfile::tempdir().unwrap();
     Generator::default()
-        .out_dir(&tmp.path())
+        .out_dir(tmp.path())
         .experimental(env::var("CDP_NO_EXPERIMENTAL").is_err())
         .deprecated(env::var("CDP_DEPRECATED").is_ok())
         .compile_pdls(&[js_proto, browser_proto])

--- a/chromiumoxide_fetcher/Cargo.toml
+++ b/chromiumoxide_fetcher/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/mattsse/chromiumoxide"
 readme = "../README.md"
 include = ["src/**/*", "LICENSE-*"]
 
+[dev-dependencies]
+ureq = "2.10.0"
+
 [dependencies]
 thiserror = "1"
 anyhow = "1"

--- a/chromiumoxide_fetcher/src/browser/options.rs
+++ b/chromiumoxide_fetcher/src/browser/options.rs
@@ -36,6 +36,7 @@ impl BrowserFetcherOptions {
         BrowserFetcherOptionsBuilder::default()
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn default() -> Result<Self> {
         Self::builder().build()
     }
@@ -84,7 +85,7 @@ impl BrowserFetcherOptionsBuilder {
 
         let platform =
             self.platform
-                .or_else(|| Platform::current())
+                .or_else(Platform::current)
                 .ok_or(FetcherError::UnsupportedOs(
                     std::env::consts::OS,
                     std::env::consts::ARCH,

--- a/chromiumoxide_fetcher/src/browser/zip.rs
+++ b/chromiumoxide_fetcher/src/browser/zip.rs
@@ -48,7 +48,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             } else {
                 if let Some(p) = outpath.parent() {
                     if !p.exists() {
-                        fs::create_dir_all(&p)?;
+                        fs::create_dir_all(p)?;
                     }
                 }
 

--- a/chromiumoxide_fetcher/src/lib.rs
+++ b/chromiumoxide_fetcher/src/lib.rs
@@ -21,7 +21,7 @@ pub use self::revision::Revision;
 // To map a revision to a chromium version you can use the site https://chromiumdash.appspot.com/commits.
 
 /// Currently downloaded chromium revision
-pub const CURRENT_REVISION: Revision = Revision(1362488);
+pub const CURRENT_REVISION: Revision = Revision(1355984);
 
 mod browser;
 mod error;

--- a/chromiumoxide_fetcher/src/lib.rs
+++ b/chromiumoxide_fetcher/src/lib.rs
@@ -3,8 +3,25 @@ pub use self::error::FetcherError;
 pub use self::platform::Platform;
 pub use self::revision::Revision;
 
+// The chromium revision is hard to get right and the relation to the CDP revision
+// even more so, so here are some guidances.
+//
+// We used to use the revision of Puppeteer, but they switched to chrome-for-testing.
+// This means we have to check things ourself. The chromium revision should at least
+// as great as the CDP revision otherwise they won't be compatible.
+// Not all revisions of chromium have builds for all platforms.
+//
+// This is essentially a bruteforce process. You can use the test `find_revision_available`
+// to find a revision that is available for all platforms. We recommend setting the `min`
+// to the current CDP revision and the max to max revision of stable chromium.
+// See https://chromiumdash.appspot.com/releases for the latest stable revision.
+//
+// In general, we should also try to ship as close as a stable version of chromium if possible.
+// The CDP should also be a bit older than that stable version.
+// To map a revision to a chromium version you can use the site https://chromiumdash.appspot.com/commits.
+
 /// Currently downloaded chromium revision
-pub const CURRENT_REVISION: Revision = Revision(1045629);
+pub const CURRENT_REVISION: Revision = Revision(1362488);
 
 mod browser;
 mod error;

--- a/chromiumoxide_fetcher/src/platform.rs
+++ b/chromiumoxide_fetcher/src/platform.rs
@@ -13,7 +13,8 @@ pub enum Platform {
 }
 
 impl Platform {
-    pub(crate) fn download_url(&self, host: &str, revision: &Revision) -> String {
+    #[doc(hidden)] // internal API
+    pub fn download_url(&self, host: &str, revision: &Revision) -> String {
         let archive = self.archive_name(revision);
         let name = match self {
             Self::Linux => "Linux_x64",

--- a/chromiumoxide_fetcher/src/revision.rs
+++ b/chromiumoxide_fetcher/src/revision.rs
@@ -24,7 +24,7 @@ impl std::str::FromStr for Revision {
     type Err = ParseIntError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<u32>().map(|v| Self(v))
+        s.parse::<u32>().map(Self)
     }
 }
 

--- a/chromiumoxide_fetcher/tests/verify.rs
+++ b/chromiumoxide_fetcher/tests/verify.rs
@@ -27,8 +27,8 @@ fn verify_revision_available() {
 #[ignore]
 #[test]
 fn find_revision_available() {
-    let min = 1361485; // Enter the minimum revision
-    let max = 1362838; // Enter the maximum revision
+    let min = 1355000; // Enter the minimum revision
+    let max = 1356013; // Enter the maximum revision
 
     'outer: for revision in (min..max).rev() {
         println!("Checking revision {}", revision);

--- a/chromiumoxide_fetcher/tests/verify.rs
+++ b/chromiumoxide_fetcher/tests/verify.rs
@@ -1,0 +1,57 @@
+use chromiumoxide_fetcher::{Platform, Revision, CURRENT_REVISION};
+
+// Check if the chosen revision has a build available for all platforms.
+// That not always the case, that is why we need to make sure of it.
+#[test]
+fn verify_revision_available() {
+    for platform in &[
+        Platform::Linux,
+        Platform::Mac,
+        Platform::MacArm,
+        Platform::Win32,
+        Platform::Win64,
+    ] {
+        let res =
+            ureq::head(&platform.download_url("https://storage.googleapis.com", &CURRENT_REVISION))
+                .call();
+
+        if res.is_err() {
+            panic!(
+                "Revision {} is not available for {:?}",
+                CURRENT_REVISION, platform
+            );
+        }
+    }
+}
+
+#[ignore]
+#[test]
+fn find_revision_available() {
+    let min = 1361485; // Enter the minimum revision
+    let max = 1362838; // Enter the maximum revision
+
+    'outer: for revision in (min..max).rev() {
+        println!("Checking revision {}", revision);
+
+        for platform in &[
+            Platform::Linux,
+            Platform::Mac,
+            Platform::MacArm,
+            Platform::Win32,
+            Platform::Win64,
+        ] {
+            let res = ureq::head(
+                &platform.download_url("https://storage.googleapis.com", &Revision::from(revision)),
+            )
+            .call();
+
+            if res.is_err() {
+                println!("Revision {} is not available for {:?}", revision, platform);
+                continue 'outer;
+            }
+        }
+
+        println!("Found revision {}", revision);
+        break;
+    }
+}


### PR DESCRIPTION
Couple of important changes:
- We can rely on puppeteer anymore to find our revisions, we must bruteforce it. I added a test to help us do that
- I had to roll-back the PDL to a stable version (< r1356013), otherwise it will break everybody. Let's be careful on that, there is really no reason to be agressive on that update.
- I added documentation on how to pick the CDP and fetcher revisions