### PR TITLE
update state on update_protocol_request_interception

### DIFF
--- a/src/handler/network.rs
+++ b/src/handler/network.rs
@@ -119,6 +119,7 @@ impl NetworkManager {
         }
         self.update_protocol_cache_disabled();
         if enabled {
+            self.protocol_request_interception_enabled = true;
             self.push_cdp_request(
                 fetch::EnableParams::builder()
                     .handle_auth_requests(true)
@@ -126,6 +127,7 @@ impl NetworkManager {
                     .build(),
             )
         } else {
+            self.protocol_request_interception_enabled = false;
             self.push_cdp_request(DisableParams::default())
         }
     }


### PR DESCRIPTION
When updating protocol request interception we do not actual update the current state.

This causes a number of issues.

While supplying credentials via the page.authenticate() method, protocol interception is enabled. However the variable `protocol_request_interception_enabled` is never updated and remains *false*.

During page visit the `on_fetch_request_paused` method is called. However the check whether we should continue with the request fails due to `protocol_request_interception_enabled` being *false*. The request never continues and times out.

https://github.com/mattsse/chromiumoxide/blob/6f2392f78ae851e2acf33df8e9764cc299d837db/src/handler/network.rs#L133-L136