### PR TITLE
feat: add init script

### DIFF
--- a/examples/add-init-script.rs
+++ b/examples/add-init-script.rs
@@ -27,10 +27,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     // Navigate to a page
-    page.goto("https://www.wikipedia.org").await?;
-    page.wait_for_navigation().await?;
-
-    page.find_element("h1").await?;
+    page.goto("https://www.wikipedia.org")
+        .await?
+        .find_element("h1")
+        .await?;
 
     let _html = page.wait_for_navigation().await?.content().await?;
 

--- a/examples/add-init-script.rs
+++ b/examples/add-init-script.rs
@@ -1,0 +1,39 @@
+use chromiumoxide::browser::{Browser, BrowserConfig};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let (browser, mut handler) =
+        Browser::launch(BrowserConfig::builder().with_head().build()?).await?;
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let _ = handler.next().await.unwrap();
+        }
+    });
+
+    let page = browser.new_page("about:blank").await?;
+
+    // Add the init script BEFORE navigation
+    page.add_init_script(
+        r#"
+        Object.defineProperty(navigator, 'webdriver', {
+            get: () => undefined
+        });
+    "#,
+    )
+    .await?;
+
+    // Navigate to a page
+    page.goto("https://www.wikipedia.org").await?;
+    page.wait_for_navigation().await?;
+
+    page.find_element("h1").await?;
+
+    let _html = page.wait_for_navigation().await?.content().await?;
+
+    handle.await?;
+    Ok(())
+}

--- a/examples/evaluate-on-new-document.rs
+++ b/examples/evaluate-on-new-document.rs
@@ -27,10 +27,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     // Navigate to a page
-    page.goto("https://www.wikipedia.org").await?;
-    page.wait_for_navigation().await?;
-
-    page.find_element("h1").await?;
+    page.goto("https://www.wikipedia.org")
+        .await?
+        .find_element("h1")
+        .await?;
 
     let _html = page.wait_for_navigation().await?.content().await?;
 

--- a/examples/evaluate-on-new-document.rs
+++ b/examples/evaluate-on-new-document.rs
@@ -1,0 +1,39 @@
+use chromiumoxide::browser::{Browser, BrowserConfig};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let (browser, mut handler) =
+        Browser::launch(BrowserConfig::builder().with_head().build()?).await?;
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let _ = handler.next().await.unwrap();
+        }
+    });
+
+    let page = browser.new_page("about:blank").await?;
+
+    // Add the init script BEFORE navigation
+    page.evaluate_on_new_document(
+        r#"
+        Object.defineProperty(navigator, 'webdriver', {
+            get: () => undefined
+        });
+    "#,
+    )
+    .await?;
+
+    // Navigate to a page
+    page.goto("https://www.wikipedia.org").await?;
+    page.wait_for_navigation().await?;
+
+    page.find_element("h1").await?;
+
+    let _html = page.wait_for_navigation().await?.content().await?;
+
+    handle.await?;
+    Ok(())
+}

--- a/src/page.rs
+++ b/src/page.rs
@@ -1146,13 +1146,41 @@ impl Page {
         self.inner.frame_secondary_execution_context(frame_id).await
     }
 
-    /// Evaluates given script in every frame upon creation (before loading
-    /// frame's scripts)
+    /// Evaluates given script in every frame upon creation (before loading frame's scripts).
+    ///
+    /// This is equivalent to Playwright's `addInitScript()` or Puppeteer's `evaluateOnNewDocument()`.
+    /// Useful for modifying the JavaScript environment before page scripts run, such as:
+    /// - Hiding automation detection properties
+    /// - Injecting polyfills
+    /// - Setting up global variables
+    ///
+    /// # Example
+    /// ```
+    /// # use chromiumoxide::page::Page;
+    /// # async fn example(page: Page) -> Result<(), Box<dyn std::error::Error>> {
+    /// // Hide webdriver property for stealth scraping
+    /// page.evaluate_on_new_document(r#"
+    ///     Object.defineProperty(navigator, 'webdriver', {
+    ///         get: () => undefined
+    ///     });
+    /// "#).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn evaluate_on_new_document(
         &self,
         script: impl Into<AddScriptToEvaluateOnNewDocumentParams>,
     ) -> Result<ScriptIdentifier> {
         Ok(self.execute(script.into()).await?.result.identifier)
+    }
+
+    /// Alias for `evaluate_on_new_document` - familiar to Playwright users.
+    #[inline]
+    pub async fn add_init_script(
+        &self,
+        script: impl Into<AddScriptToEvaluateOnNewDocumentParams>,
+    ) -> Result<ScriptIdentifier> {
+        self.evaluate_on_new_document(script).await
     }
 
     /// Set the content of the frame.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,6 +4,7 @@ use chromiumoxide::{Browser, BrowserConfig};
 use futures::{FutureExt, StreamExt};
 
 mod basic;
+mod page;
 
 pub async fn test<T>(test: T)
 where

--- a/tests/page.rs
+++ b/tests/page.rs
@@ -1,0 +1,57 @@
+use crate::test;
+
+#[tokio::test]
+async fn test_evaluate_on_new_document() {
+    test(async |browser| {
+        let page = browser
+            .new_page("about:blank")
+            .await
+            .expect("should create new page");
+
+        page.evaluate_on_new_document("window.testValue = 42;")
+            .await
+            .expect("should evaluate script on new document");
+
+        page.goto("https://www.google.com")
+            .await
+            .expect("should navigate to www.google.com");
+
+        let result: i32 = page
+            .evaluate("window.testValue")
+            .await
+            .expect("should evaluate window.testValue")
+            .into_value()
+            .expect("should convert to i32");
+
+        assert_eq!(result, 42);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_add_init_script() {
+    test(async |browser| {
+        let page = browser
+            .new_page("about:blank")
+            .await
+            .expect("should create new page");
+
+        page.add_init_script("window.testValue = 42;")
+            .await
+            .expect("should add init script");
+
+        page.goto("https://www.google.com")
+            .await
+            .expect("should navigate to www.google.com");
+
+        let result: i32 = page
+            .evaluate("window.testValue")
+            .await
+            .expect("should evaluate window.testValue")
+            .into_value()
+            .expect("should convert to i32");
+
+        assert_eq!(result, 42);
+    })
+    .await;
+}


### PR DESCRIPTION
Fixes https://github.com/mattsse/chromiumoxide/issues/205

The existing `evaluate_on_new_document` method already provides the functionality of Playwright’s [addInitScript](https://playwright.dev/docs/api/class-page#page-add-init-script), injecting JavaScript before any page scripts load. This method maps directly to Chrome DevTools Protocol’s [Page.addScriptToEvaluateOnNewDocument](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-addScriptToEvaluateOnNewDocument) command.

Although different tools use different names, Playwright calls it [addInitScript](https://playwright.dev/docs/api/class-page#page-add-init-script), Puppeteer uses [evaluateOnNewDocument](https://pptr.dev/api/puppeteer.page.evaluateonnewdocument), they all achieve the same goal: running initialization scripts ahead of page execution (e.g., to hide navigator.webdriver).

Added:

- Expanded documentation and example for `evaluate_on_new_document` and `add_init_script`.
- `add_init_script` added as an alias for `evaluate_on_new_document` for better discoverability.
