### PR TITLE
fix: replace carriage returns with line break

### DIFF
--- a/chromiumoxide_pdl/src/pdl/resolver.rs
+++ b/chromiumoxide_pdl/src/pdl/resolver.rs
@@ -19,9 +19,12 @@ pub fn resolve_pdl(path: &Path, input: &str) -> Result<String, Error> {
             let Some(name) = line.split_whitespace().nth(1) else {
                 bail!("Failed to get file name from include statement");
             };
-            let Ok(content) = fs::read_to_string(dir.join(name)) else {
+            let Ok(mut content) = fs::read_to_string(dir.join(name)) else {
                 bail!("Failed to read file {}", name);
             };
+
+            // Replace "carriage returns" with line breaks so license header splits works for windows
+            content = content.replace("\r\n", "\n");
 
             // Remove the license header
             let Some((_, content)) = content.split_once("\n\n") else {


### PR DESCRIPTION
### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes
Replaced carriage return with unix line breaks so license header splitting works

<!-- **Please explain what your changes does** -->
Uses .replace on content in to remove /r/n in place of /n

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature (if needed)
- [ ] Created a least one integration test
