### PR TITLE
Use the configured request_timeout instead of the default REQUEST_TIMEOUT.

### DIFF
--- a/src/handler/commandfuture.rs
+++ b/src/handler/commandfuture.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use crate::cmd::{CommandMessage, to_command_response};
 use crate::error::Result;
@@ -39,6 +40,7 @@ impl<T: Command> CommandFuture<T> {
         cmd: T,
         target_sender: mpsc::Sender<TargetMessage>,
         session: Option<SessionId>,
+        timeout: Duration,
     ) -> Result<Self> {
         let (tx, rx_command) = oneshot_channel::<Result<Response>>();
         let method = cmd.identifier();
@@ -47,9 +49,7 @@ impl<T: Command> CommandFuture<T> {
             cmd, tx, session,
         )?));
 
-        let delay = futures_timer::Delay::new(std::time::Duration::from_millis(
-            crate::handler::REQUEST_TIMEOUT,
-        ));
+        let delay = futures_timer::Delay::new(timeout);
 
         Ok(Self {
             target_sender,

--- a/src/handler/frame.rs
+++ b/src/handler/frame.rs
@@ -20,7 +20,6 @@ use chromiumoxide_cdp::cdp::{
 use chromiumoxide_types::{Method, MethodId, Request};
 
 use crate::error::DeadlineExceeded;
-use crate::handler::REQUEST_TIMEOUT;
 use crate::handler::domworld::DOMWorld;
 use crate::handler::http::HttpRequest;
 use crate::{ArcHttpRequest, cmd::CommandChain};
@@ -657,12 +656,8 @@ pub struct FrameNavigationRequest {
 }
 
 impl FrameNavigationRequest {
-    pub fn new(id: NavigationId, req: Request) -> Self {
-        Self {
-            id,
-            req,
-            timeout: Duration::from_millis(REQUEST_TIMEOUT),
-        }
+    pub fn new(id: NavigationId, req: Request, timeout: Duration) -> Self {
+        Self { id, req, timeout }
     }
 
     /// This will set the id of the frame into the `params` `frameId` field.

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -341,7 +341,11 @@ impl Handler {
         if msg.is_navigation() {
             let (req, tx) = msg.split();
             let id = self.next_navigation_id();
-            target.goto(FrameNavigationRequest::new(id, req));
+            target.goto(FrameNavigationRequest::new(
+                id,
+                req,
+                self.config.request_timeout,
+            ));
             self.navigations.insert(
                 id,
                 NavigationRequest::Navigate(NavigationInProgress::new(tx)),

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::channel::mpsc::{Receiver, Sender, channel};
 use futures::channel::oneshot::channel as oneshot_channel;
@@ -46,13 +47,19 @@ pub struct PageHandle {
 }
 
 impl PageHandle {
-    pub fn new(target_id: TargetId, session_id: SessionId, opener_id: Option<TargetId>) -> Self {
+    pub fn new(
+        target_id: TargetId,
+        session_id: SessionId,
+        opener_id: Option<TargetId>,
+        request_timeout: Duration,
+    ) -> Self {
         let (commands, rx) = channel(1);
         let page = PageInner {
             target_id,
             session_id,
             opener_id,
             sender: commands,
+            request_timeout,
         };
         Self {
             rx: rx.fuse(),
@@ -71,6 +78,7 @@ pub(crate) struct PageInner {
     session_id: SessionId,
     opener_id: Option<TargetId>,
     sender: Sender<TargetMessage>,
+    request_timeout: Duration,
 }
 
 impl PageInner {
@@ -81,7 +89,12 @@ impl PageInner {
 
     /// Create a PDL command future
     pub(crate) fn command_future<T: Command>(&self, cmd: T) -> Result<CommandFuture<T>> {
-        CommandFuture::new(cmd, self.sender.clone(), Some(self.session_id.clone()))
+        CommandFuture::new(
+            cmd,
+            self.sender.clone(),
+            Some(self.session_id.clone()),
+            self.request_timeout,
+        )
     }
 
     /// This creates navigation future with the final http response when the page is loaded

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -162,8 +162,12 @@ impl Target {
     fn create_page(&mut self) {
         if self.page.is_none() {
             if let Some(session) = self.session_id.clone() {
-                let handle =
-                    PageHandle::new(self.target_id().clone(), session, self.opener_id().cloned());
+                let handle = PageHandle::new(
+                    self.target_id().clone(),
+                    session,
+                    self.opener_id().cloned(),
+                    self.config.request_timeout,
+                );
                 self.page = Some(handle);
             }
         }


### PR DESCRIPTION
### Issue # (if available)

https://github.com/mattsse/chromiumoxide/issues/310

### Description of changes

The timeouts for [CommandFuture](https://github.com/mattsse/chromiumoxide/blob/a7e2bb835b9643410f9e3dc044f0d947e96cbfa4/src/handler/commandfuture.rs#L51) and [FrameNavigationRequest](https://github.com/mattsse/chromiumoxide/blob/a7e2bb835b9643410f9e3dc044f0d947e96cbfa4/src/handler/frame.rs#L664) both use [HandlerConfig.request_timeout](https://github.com/mattsse/chromiumoxide/blob/a7e2bb835b9643410f9e3dc044f0d947e96cbfa4/src/handler/mod.rs#L667) instead of the default [REQUEST_TIMEOUT](https://github.com/mattsse/chromiumoxide/blob/a7e2bb835b9643410f9e3dc044f0d947e96cbfa4/src/handler/mod.rs#L34) constant.

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature (if needed)
- [ ] Created a least one integration test
