### PR TITLE
feat: add Worker target evaluation support

### DIFF
--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 
-use chromiumoxide_cdp::cdp::browser_protocol::target::DetachFromTargetParams;
+
 use futures::channel::oneshot::Sender;
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
@@ -92,6 +92,21 @@ pub struct Target {
     wait_for_frame_navigation: Vec<Sender<ArcHttpRequest>>,
     /// The sender who requested the page.
     initiator: Option<Sender<Result<Page>>>,
+    /// Worker sessions attached to this target (dedicated, service, shared).
+    worker_sessions: Vec<WorkerSession>,
+}
+
+/// A worker session attached to a page target.
+#[derive(Debug, Clone)]
+pub struct WorkerSession {
+    /// The target ID of the worker.
+    pub target_id: TargetId,
+    /// The CDP session ID for communicating with this worker.
+    pub session_id: SessionId,
+    /// The type of worker.
+    pub target_type: TargetType,
+    /// The URL of the worker script.
+    pub url: String,
 }
 
 impl Target {
@@ -120,6 +135,7 @@ impl Target {
             event_listeners: Default::default(),
             initiator: None,
             browser_context,
+            worker_sessions: Vec::new(),
         }
     }
 
@@ -190,6 +206,11 @@ impl Target {
     /// Get the target that opened this target. Top-level targets return `None`.
     pub fn opener_id(&self) -> Option<&TargetId> {
         self.info.opener_id.as_ref()
+    }
+
+    /// Get all worker sessions attached to this target.
+    pub fn worker_sessions(&self) -> &[WorkerSession] {
+        &self.worker_sessions
     }
 
     pub fn frame_manager(&self) -> &FrameManager {
@@ -267,16 +288,18 @@ impl Target {
                     }));
                 }
 
-                if "service_worker" == &ev.target_info.r#type {
-                    let detach_command = DetachFromTargetParams::builder()
-                        .session_id(ev.session_id.clone())
-                        .build();
-
-                    self.queued_events.push_back(TargetEvent::Request(Request {
-                        method: detach_command.identifier(),
-                        session_id: self.session_id.clone().map(Into::into),
-                        params: serde_json::to_value(detach_command).unwrap(),
-                    }));
+                // Store the worker session for evaluation.
+                // Previously, service workers were auto-detached here.
+                // Now all worker types are kept attached so they can be
+                // evaluated via Runtime.evaluate on their session.
+                let worker_type = TargetType::new(&ev.target_info.r#type);
+                if worker_type.is_any_worker() {
+                    self.worker_sessions.push(WorkerSession {
+                        target_id: ev.target_info.target_id.clone(),
+                        session_id: ev.session_id.clone(),
+                        target_type: worker_type,
+                        url: ev.target_info.url.clone(),
+                    });
                 }
             }
 
@@ -320,15 +343,22 @@ impl Target {
 
     /// Advance that target's state
     pub(crate) fn poll(&mut self, cx: &mut Context<'_>, now: Instant) -> Option<TargetEvent> {
-        if !self.is_page() {
-            // can only poll pages
+        if !self.is_page() && !self.r#type().is_any_worker() {
+            // Only pages and workers can be polled
             return None;
         }
         match &mut self.init_state {
             TargetInit::AttachToTarget => {
-                self.init_state = TargetInit::InitializingFrame(FrameManager::init_commands(
-                    self.config.request_timeout,
-                ));
+                // Workers don't need Frame/Network/Page/Emulation init —
+                // they only need Runtime, which is available as soon as
+                // the session is attached.
+                if self.r#type().is_any_worker() {
+                    self.init_state = TargetInit::Initialized;
+                } else {
+                    self.init_state = TargetInit::InitializingFrame(FrameManager::init_commands(
+                        self.config.request_timeout,
+                    ));
+                }
                 let params = AttachToTargetParams::builder()
                     .target_id(self.target_id().clone())
                     .flatten(true)
@@ -620,6 +650,7 @@ impl Default for TargetConfig {
 pub enum TargetType {
     Page,
     BackgroundPage,
+    Worker,
     ServiceWorker,
     SharedWorker,
     Other,
@@ -633,6 +664,7 @@ impl TargetType {
         match ty {
             "page" => TargetType::Page,
             "background_page" => TargetType::BackgroundPage,
+            "worker" => TargetType::Worker,
             "service_worker" => TargetType::ServiceWorker,
             "shared_worker" => TargetType::SharedWorker,
             "other" => TargetType::Other,
@@ -650,12 +682,24 @@ impl TargetType {
         matches!(self, TargetType::BackgroundPage)
     }
 
+    pub fn is_worker(&self) -> bool {
+        matches!(self, TargetType::Worker)
+    }
+
     pub fn is_service_worker(&self) -> bool {
         matches!(self, TargetType::ServiceWorker)
     }
 
     pub fn is_shared_worker(&self) -> bool {
         matches!(self, TargetType::SharedWorker)
+    }
+
+    /// Returns true for any worker type (dedicated, service, or shared).
+    pub fn is_any_worker(&self) -> bool {
+        matches!(
+            self,
+            TargetType::Worker | TargetType::ServiceWorker | TargetType::SharedWorker
+        )
     }
 
     pub fn is_other(&self) -> bool {


### PR DESCRIPTION
## Summary

Closes #312.

Enables CDP evaluation in Web Worker contexts (dedicated, service, shared workers) by removing the three blocks identified in the issue: `TargetType` mapped service workers to a single variant and ignored `"worker"`, `Target::poll()` early-returned for non-page targets, and there was no public way to obtain a `SessionId` for an attached worker target.

## Changes

1. **`TargetType::Worker` variant.** Chrome's Target.targetCreated emits `"worker"` (dedicated workers) and `"service_worker"` separately. The variant `Worker` is added to cover the dedicated-worker case; `ServiceWorker` keeps its existing meaning.
2. **No auto-detach for service workers.** Previously detached on attach so they were unreachable for `Runtime.evaluate`. Now kept attached so consumers can evaluate against them.
3. **Workers walk `poll()`.** The init state machine `poll()` previously short-circuited for any non-Page target before reaching `Initialized`. Workers now reach `Initialized` via a fast-path that skips Frame/Network/Page/Emulation init (workers don't have those domains).
4. **`WorkerSession` struct + `target.worker_sessions()`.** Small public surface for consumers to discover attached worker sessions and their `SessionId` for routing CDP commands. Each entry carries `target_id`, `session_id`, `target_type`, and the worker's `url`.

## Use case

The motivating case (per #312) is collecting performance metrics from a Web Worker. In our case the WASM RDP client's WebCodecs H.264 decode pipeline runs in a worker, and `lamco-wasm-tools` needs to query frame timing or health metrics directly from worker state. The MessageChannel-bridge workaround (worker `postMessage`s to main thread, evaluate on page) works for ~20 lines of glue but locks the metrics shape into a bespoke postMessage protocol; direct CDP eval keeps `Runtime.evaluate` as the uniform interface.

## Test plan

- [x] `cargo build` clean (workspace)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p chromiumoxide --lib -- -D warnings` clean (the workspace-wide clippy fails on a pre-existing duplicate-import warning in `chromiumoxide_fetcher/src/runtime/zip/mod.rs:9` from upstream `afcc3a4`, unrelated to this change)
- [ ] Smoke-tested locally against a page that spawns a dedicated worker; `target.worker_sessions()` populated, `Runtime.evaluate` against the session id returned the expected value. Adding a CI-friendly integration test would require pulling a real Chrome and a worker fixture; happy to add if maintainers prefer it (or leave the smoke test to consumers).

## Notes

- `TargetType` parsing for the `"worker"` string lives in the existing `From<&str> for TargetType` impl.
- The fast-path init avoids issuing CDP commands that would error against worker targets (e.g., `Page.enable`).
- No public API removals; the changes are additive on the consumer side. Breaking on `TargetType` would be the addition of a non-exhaustive variant; the enum is already non-exhaustive in spirit since Chrome adds new target types over time.
