### PR TITLE
feat: add connect_with_headers for authenticated CDP endpoints

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -143,6 +143,81 @@ impl Browser {
         Ok((browser, fut))
     }
 
+    /// Same as [`Browser::connect`], but attaches the given HTTP headers to the
+    /// CDP WebSocket upgrade and to the `json/version` discovery request when
+    /// the URL is `http(s)://`. Required for authenticated remote CDP providers
+    /// (Cloudflare Browser Run, Browserless, etc.).
+    pub async fn connect_with_headers(
+        url: impl Into<String>,
+        headers: Vec<(String, String)>,
+    ) -> Result<(Self, Handler)> {
+        Self::connect_with_headers_and_config(url, HandlerConfig::default(), headers).await
+    }
+
+    /// Same as [`Browser::connect_with_config`], but attaches the given HTTP
+    /// headers. See [`Browser::connect_with_headers`] for details.
+    pub async fn connect_with_headers_and_config(
+        url: impl Into<String>,
+        config: HandlerConfig,
+        headers: Vec<(String, String)>,
+    ) -> Result<(Self, Handler)> {
+        let mut debug_ws_url = url.into();
+
+        if debug_ws_url.starts_with("http") {
+            let probe_url = if debug_ws_url.ends_with("/json/version")
+                || debug_ws_url.ends_with("/json/version/")
+            {
+                debug_ws_url.clone()
+            } else {
+                format!(
+                    "{}{}json/version",
+                    &debug_ws_url,
+                    if debug_ws_url.ends_with('/') { "" } else { "/" }
+                )
+            };
+
+            let mut req = reqwest::Client::new()
+                .get(probe_url)
+                .header("content-type", "application/json");
+            for (k, v) in &headers {
+                req = req.header(k, v);
+            }
+
+            match req.send().await {
+                Ok(resp) => {
+                    let socketaddr = resp.remote_addr().unwrap();
+                    let connection: BrowserConnection =
+                        serde_json::from_slice(&resp.bytes().await.unwrap_or_default())
+                            .unwrap_or_default();
+
+                    if !connection.web_socket_debugger_url.is_empty() {
+                        debug_ws_url = connection
+                            .web_socket_debugger_url
+                            .replace("127.0.0.1", &socketaddr.ip().to_string());
+                    }
+                }
+                Err(_) => return Err(CdpError::NoResponse),
+            }
+        }
+
+        let conn =
+            Connection::<CdpEventMessage>::connect_with_headers(&debug_ws_url, headers).await?;
+
+        let (tx, rx) = channel(1);
+
+        let fut = Handler::new(conn, rx, config);
+        let browser_context = fut.default_browser_context().clone();
+
+        let browser = Self {
+            sender: tx,
+            config: None,
+            child: None,
+            debug_ws_url,
+            browser_context,
+        };
+        Ok((browser, fut))
+    }
+
     /// Launches a new instance of `chromium` in the background and attaches to
     /// its debug web socket.
     ///

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -4,6 +4,8 @@ use std::pin::Pin;
 use std::task::ready;
 
 use async_tungstenite::tungstenite::Message as WsMessage;
+use async_tungstenite::tungstenite::client::IntoClientRequest;
+use async_tungstenite::tungstenite::http;
 use async_tungstenite::{WebSocketStream, tungstenite::protocol::WebSocketConfig};
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
@@ -43,6 +45,38 @@ impl<T: EventMessage + Unpin> Connection<T> {
             Some(config),
         )
         .await?;
+
+        Ok(Self {
+            pending_commands: Default::default(),
+            ws,
+            next_id: 0,
+            needs_flush: false,
+            pending_flush: None,
+            _marker: Default::default(),
+        })
+    }
+
+    pub async fn connect_with_headers(
+        debug_ws_url: impl AsRef<str>,
+        headers: Vec<(String, String)>,
+    ) -> Result<Self> {
+        let config = WebSocketConfig::default()
+            .max_message_size(None)
+            .max_frame_size(None);
+
+        let mut request = debug_ws_url.as_ref().into_client_request()?;
+        let req_headers = request.headers_mut();
+        for (k, v) in &headers {
+            let name = http::HeaderName::try_from(k.as_str())
+                .map_err(|e| CdpError::ChromeMessage(format!("invalid header name '{k}': {e}")))?;
+            let value = http::HeaderValue::try_from(v.as_str()).map_err(|e| {
+                CdpError::ChromeMessage(format!("invalid header value for '{k}': {e}"))
+            })?;
+            req_headers.append(name, value);
+        }
+
+        let (ws, _) =
+            async_tungstenite::tokio::connect_async_with_config(request, Some(config)).await?;
 
         Ok(Self {
             pending_commands: Default::default(),


### PR DESCRIPTION
### Issue # (if available)

No tracking issue in this repo. Industry precedent for the gap:
[browser-use#3111](https://github.com/browser-use/browser-use/issues/3111) —
authenticated remote-CDP providers (Cloudflare Browser Run, Browserless,
self-hosted setups behind auth) require custom HTTP headers (typically
`Authorization: Bearer …`) on the CDP WebSocket upgrade, and there is
currently no way to provide them through `Browser::connect`.

### Description of changes

Adds three additive entry points; nothing existing changes:

- `Connection::<T>::connect_with_headers(url, headers)` — opens the CDP
  WebSocket with the given headers attached to the upgrade request.
- `Browser::connect_with_headers(url, headers)` and
  `Browser::connect_with_headers_and_config(url, config, headers)` — the
  high-level equivalents. When `url` is `http(s)://`, headers are also
  forwarded to the `json/version` discovery probe so providers that gate
  the discovery endpoint work.

Design notes:

- `Vec<(String, String)>` instead of `HashMap`: HTTP allows duplicate
  header names (e.g. `Cookie`), and order matters for some providers.
- No new error variant: WS upgrade failures flow through the existing
  `CdpError::Ws(tungstenite::Error)`, and bad header name/value go
  through `CdpError::ChromeMessage(String)`.
- Existing `connect` / `connect_with_config` are byte-for-byte unchanged,
  so call sites are unaffected and the new API is opt-in.
- No new dependencies. Relies on `tungstenite::client::IntoClientRequest`,
  which `connect_async_with_config` already accepts.

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature (if needed) — the new code paths
      require a live (or mocked) authenticated CDP endpoint to exercise
      meaningfully; the repo currently has no fixture for one. Happy to
      add a `mockito`/`wiremock`-style test for the `json/version` header
      forwarding if you'd prefer.
- [ ] Created a least one integration test — same constraint as above.
