### PR TITLE
Allow using --remote-debugging-pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Derive `Clone` for `Element`, `ScreenshotParams` and `ScreenshotParamsBuilder`
+- Allow using pipes to communicate with chromium, rather than websockets
 
 ## [0.9.1] 2026-02-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chromiumoxide"
 version = "0.9.1"
-rust-version = "1.85"
+rust-version = "1.87"
 autotests = false
 authors = ["Matthias Seitz <matthias.seitz@outlook.de>"]
 edition = "2024"
@@ -34,12 +34,15 @@ tokio = { version = "1", features = [
   "fs",
   "macros",
   "process",
+  "io-util",
 ] }
 tracing = "0.1"
 pin-project-lite = "0.2"
 dunce = "1"
 bytes = { version = "1", features = ["serde"], optional = true }
 reqwest = { version = "0.13", default-features = false }
+command-fds = { version = "0.3.3", features = ["tokio"] }
+tokio-util = { version = "0.7.18", features = ["io"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-registry = "0.6"

--- a/chromiumoxide_types/src/lib.rs
+++ b/chromiumoxide_types/src/lib.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub type MethodId = Cow<'static, str>;
 
 /// A Request sent by the client, identified by the `id`
-#[derive(Serialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct MethodCall {
     /// Identifier for this method call
     ///

--- a/src/async_process.rs
+++ b/src/async_process.rs
@@ -58,6 +58,15 @@ impl Command {
         self
     }
 
+    pub fn fd_mappings(
+        &mut self,
+        fd_mappings: Vec<command_fds::FdMapping>,
+    ) -> Result<&mut Self, command_fds::FdMappingCollision> {
+        use command_fds::CommandFdExt;
+        self.inner.fd_mappings(fd_mappings)?;
+        Ok(self)
+    }
+
     pub fn spawn(&mut self) -> std::io::Result<Child> {
         let inner = self.inner.spawn()?;
         Ok(Child::new(inner))

--- a/src/browser/config.rs
+++ b/src/browser/config.rs
@@ -26,6 +26,14 @@ pub enum HeadlessMode {
 }
 
 #[derive(Debug, Clone)]
+pub enum PortOrPipes {
+    /// Use a port
+    Port(u16),
+    /// Create new pipes
+    Pipes,
+}
+
+#[derive(Debug, Clone)]
 pub struct BrowserConfig {
     /// Determines whether to run headless version of the browser. Defaults to
     /// true.
@@ -37,8 +45,9 @@ pub struct BrowserConfig {
     /// Launch the browser with a specific window width and height.
     pub(crate) window_size: Option<(u32, u32)>,
 
-    /// Launch the browser with a specific debugging port.
-    pub(crate) port: u16,
+    /// Launch the browser with a specific debugging port, or use pipes to communicate
+    /// with the browser instead of a port.
+    pub(crate) port_or_pipes: PortOrPipes,
 
     /// Path for Chrome or Chromium.
     ///
@@ -104,7 +113,7 @@ pub struct BrowserConfigBuilder {
     headless: HeadlessMode,
     sandbox: bool,
     window_size: Option<(u32, u32)>,
-    port: u16,
+    port_or_pipes: PortOrPipes,
     executable: Option<PathBuf>,
     executation_detection: DetectionOptions,
     extensions: Vec<String>,
@@ -137,10 +146,10 @@ impl BrowserConfig {
 impl Default for BrowserConfigBuilder {
     fn default() -> Self {
         Self {
-            headless: HeadlessMode::True,
+            headless: HeadlessMode::False,
             sandbox: true,
             window_size: None,
-            port: 0,
+            port_or_pipes: PortOrPipes::Port(0),
             executable: None,
             executation_detection: DetectionOptions::default(),
             extensions: Vec::new(),
@@ -206,7 +215,12 @@ impl BrowserConfigBuilder {
     }
 
     pub fn port(mut self, port: u16) -> Self {
-        self.port = port;
+        self.port_or_pipes = PortOrPipes::Port(port);
+        self
+    }
+
+    pub fn pipes(mut self) -> Self {
+        self.port_or_pipes = PortOrPipes::Pipes;
         self
     }
 
@@ -345,7 +359,7 @@ impl BrowserConfigBuilder {
             headless: self.headless,
             sandbox: self.sandbox,
             window_size: self.window_size,
-            port: self.port,
+            port_or_pipes: self.port_or_pipes,
             executable,
             extensions: self.extensions,
             process_envs: self.process_envs,
@@ -367,7 +381,9 @@ impl BrowserConfigBuilder {
 }
 
 impl BrowserConfig {
-    pub fn launch(&self) -> io::Result<Child> {
+    pub fn launch(
+        &self,
+    ) -> io::Result<(Child, Option<(std::io::PipeReader, std::io::PipeWriter)>)> {
         let mut builder = ArgsBuilder::new();
 
         if self.disable_default_args {
@@ -376,8 +392,17 @@ impl BrowserConfig {
             builder.args(DEFAULT_ARGS.clone()).args(self.args.clone());
         }
 
-        if !builder.has("remote-debugging-port") {
-            builder.arg(Arg::value("remote-debugging-port", self.port));
+        match &self.port_or_pipes {
+            PortOrPipes::Port(port) => {
+                if !builder.has("remote-debugging-port") {
+                    builder.arg(Arg::value("remote-debugging-port", *port));
+                }
+            }
+            PortOrPipes::Pipes => {
+                if !builder.has("remote-debugging-pipe") {
+                    builder.arg(Arg::key("remote-debugging-pipe"));
+                }
+            }
         }
 
         if self.extensions.is_empty() {
@@ -451,7 +476,35 @@ impl BrowserConfig {
         if let Some(ref envs) = self.process_envs {
             cmd.envs(envs);
         }
-        cmd.stdout(Stdio::null()).stderr(Stdio::piped()).spawn()
+
+        cmd.stdout(Stdio::null()).stderr(Stdio::piped());
+        match &self.port_or_pipes {
+            PortOrPipes::Port(_) => {
+                // Nothing to do, it's provided as args
+                let child = cmd.spawn()?;
+                Ok((child, None))
+            }
+            PortOrPipes::Pipes => {
+                // For debug pipes, they need to be provided as fd 3 (for chrome to read from)
+                // and fd 4 (for chrome to write into).
+                let (pipe_reader_3, pipe_writer_3) = std::io::pipe().unwrap();
+                let (pipe_reader_4, pipe_writer_4) = std::io::pipe().unwrap();
+                cmd.fd_mappings(vec![
+                    command_fds::FdMapping {
+                        parent_fd: pipe_reader_3.into(),
+                        child_fd: 3,
+                    },
+                    command_fds::FdMapping {
+                        parent_fd: pipe_writer_4.into(),
+                        child_fd: 4,
+                    },
+                ])
+                .expect("There should not be an error setting up fd mappings");
+
+                let child = cmd.spawn()?;
+                Ok((child, Some((pipe_reader_4, pipe_writer_3))))
+            }
+        }
     }
 }
 

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -143,6 +143,34 @@ impl Browser {
         Ok((browser, fut))
     }
 
+    // Connect to an already running chromium instance with a given `HandlerConfig`.
+    ///
+    /// The write end of `read_pipe` must have been passed as fd 3 to the running chromium instance,
+    /// the read end of the `write_pipe` must have been passed as fd 4.
+    ///
+    /// Chromium must have been launched with `remote-debugging-pipe` enabled.
+    pub async fn connect_with_pipes_and_config(
+        read_pipe: std::io::PipeReader,
+        write_pipe: std::io::PipeWriter,
+        config: HandlerConfig,
+    ) -> Result<(Self, Handler)> {
+        let conn = Connection::<CdpEventMessage>::connect_with_pipes(write_pipe, read_pipe).await?;
+
+        let (tx, rx) = channel(1);
+
+        let fut = Handler::new(conn, rx, config);
+        let browser_context = fut.default_browser_context().clone();
+
+        let browser = Self {
+            sender: tx,
+            config: None,
+            child: None,
+            debug_ws_url: String::new(),
+            browser_context,
+        };
+        Ok((browser, fut))
+    }
+
     /// Launches a new instance of `chromium` in the background and attaches to
     /// its debug web socket.
     ///
@@ -156,7 +184,7 @@ impl Browser {
         config.executable = utils::canonicalize_except_snap(config.executable).await?;
 
         // Launch a new chromium instance
-        let mut child = config.launch()?;
+        let (mut child, pipes) = config.launch()?;
 
         /// Faillible initialization to run once the child process is created.
         ///
@@ -165,17 +193,28 @@ impl Browser {
         async fn with_child(
             config: &BrowserConfig,
             child: &mut Child,
+            pipes: Option<(std::io::PipeReader, std::io::PipeWriter)>,
         ) -> Result<(String, Connection<CdpEventMessage>)> {
             let dur = config.launch_timeout;
             let timeout_fut = Box::pin(tokio::time::sleep(dur));
 
-            // extract the ws:
-            let debug_ws_url = ws_url_from_output(child, timeout_fut).await?;
-            let conn = Connection::<CdpEventMessage>::connect(&debug_ws_url).await?;
-            Ok((debug_ws_url, conn))
+            match &config.port_or_pipes {
+                config::PortOrPipes::Port(_) => {
+                    // extract the ws:
+                    let debug_ws_url = ws_url_from_output(child, timeout_fut).await?;
+                    let conn = Connection::<CdpEventMessage>::connect(&debug_ws_url).await?;
+                    Ok((debug_ws_url, conn))
+                }
+                config::PortOrPipes::Pipes => {
+                    let pipes = pipes.unwrap();
+                    let conn =
+                        Connection::<CdpEventMessage>::connect_with_pipes(pipes.1, pipes.0).await?;
+                    Ok((String::new(), conn))
+                }
+            }
         }
 
-        let (debug_ws_url, conn) = match with_child(&config, &mut child).await {
+        let (debug_ws_url, conn) = match with_child(&config, &mut child, pipes).await {
             Ok(conn) => conn,
             Err(e) => {
                 // An initialization error occurred, clean up the process
@@ -193,7 +232,7 @@ impl Browser {
         // Only infaillible calls are allowed after this point to avoid clean-up issues with the
         // child process.
 
-        let (tx, rx) = channel(1);
+        let (tx, rx) = channel(100);
 
         let handler_config = HandlerConfig {
             ignore_https_errors: config.ignore_https_errors,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::io::{PipeReader, PipeWriter, Write};
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::ready;
@@ -8,6 +9,7 @@ use async_tungstenite::{WebSocketStream, tungstenite::protocol::WebSocketConfig}
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
 use futures::{SinkExt, StreamExt};
+use tokio_util::io::ReaderStream;
 
 use async_tungstenite::tokio::ConnectStream;
 use chromiumoxide_cdp::cdp::browser_protocol::target::SessionId;
@@ -16,20 +18,176 @@ use chromiumoxide_types::{CallId, EventMessage, Message, MethodCall, MethodId};
 use crate::error::CdpError;
 use crate::error::Result;
 
+#[derive(Debug)]
+enum ConnectionTransport<T: EventMessage> {
+    Websocket(WebSocketStream<ConnectStream>),
+    Pipes {
+        writer: PipeWriter,
+        reader: ReaderStream<tokio::net::unix::pipe::Receiver>,
+        read_buf: Vec<u8>,
+        _phantom: PhantomData<T>,
+    },
+}
+
+use futures::Sink;
+
+impl<T: EventMessage + Unpin> Sink<MethodCall> for ConnectionTransport<T> {
+    type Error = CdpError;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.get_mut() {
+            ConnectionTransport::Websocket(ws) => Pin::new(ws).poll_ready(cx).map_err(CdpError::Ws),
+            ConnectionTransport::Pipes { .. } => Poll::Ready(Ok(())),
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: MethodCall) -> std::result::Result<(), Self::Error> {
+        match self.get_mut() {
+            ConnectionTransport::Websocket(ws) => {
+                let msg = serde_json::to_string(&item)?;
+                ws.start_send_unpin(msg.into()).map_err(CdpError::Ws)
+            }
+            ConnectionTransport::Pipes { writer: write, .. } => {
+                let msg = serde_json::to_string(&item)?;
+                write.write_all(msg.as_bytes())?;
+                // Nul byte needed to indicate end of message
+                write.write_all(&[0])?;
+                Ok(())
+            }
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.get_mut() {
+            ConnectionTransport::Websocket(ws) => Pin::new(ws).poll_flush(cx).map_err(CdpError::Ws),
+            ConnectionTransport::Pipes { writer, .. } => {
+                writer.flush()?;
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.get_mut() {
+            ConnectionTransport::Websocket(ws) => Pin::new(ws).poll_close(cx).map_err(CdpError::Ws),
+            ConnectionTransport::Pipes { .. } => Poll::Ready(Ok(())),
+        }
+    }
+}
+
+impl<T: EventMessage + Unpin> Stream for ConnectionTransport<T> {
+    type Item = Result<Message<T>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.get_mut() {
+            ConnectionTransport::Websocket(ws) => {
+                match ready!(ws.poll_next_unpin(cx)) {
+                    Some(Ok(WsMessage::Text(text))) => {
+                        let ready = match serde_json::from_str::<Message<T>>(&text) {
+                            Ok(msg) => {
+                                tracing::trace!("Received {:?}", msg);
+                                Ok(msg)
+                            }
+                            Err(err) => {
+                                let msg = text.as_str().to_string();
+                                tracing::debug!(target: "chromiumoxide::conn::raw_ws::parse_errors", msg, "Failed to parse raw WS message {}", err);
+                                Err(CdpError::InvalidMessage(msg, err))
+                            }
+                        };
+                        Poll::Ready(Some(ready))
+                    }
+                    Some(Ok(WsMessage::Close(_))) => Poll::Ready(None),
+                    // ignore ping and pong
+                    Some(Ok(WsMessage::Ping(_))) | Some(Ok(WsMessage::Pong(_))) => {
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    }
+                    Some(Ok(msg)) => Poll::Ready(Some(Err(CdpError::UnexpectedWsMessage(msg)))),
+                    Some(Err(err)) => Poll::Ready(Some(Err(CdpError::Ws(err)))),
+                    None => {
+                        // ws connection closed
+                        Poll::Ready(None)
+                    }
+                }
+            }
+            ConnectionTransport::Pipes {
+                reader, read_buf, ..
+            } => {
+                /// Attempt to get the next message from the buffer
+                /// Returns None if there is no null byte found, indicating
+                /// that there is no complete message.
+                /// If there is a potential complete message, this function will try to
+                /// deserialize it, returning the result of deserialization.
+                fn try_get_message<T>(
+                    read_buf: &mut Vec<u8>,
+                ) -> Option<Result<Message<T>, CdpError>>
+                where
+                    T: EventMessage + Unpin,
+                {
+                    if let Some(index) = read_buf.iter().position(|x| *x == 0) {
+                        let mut msg_buf = read_buf.split_off(index + 1);
+                        std::mem::swap(&mut msg_buf, read_buf);
+
+                        msg_buf.truncate(msg_buf.len() - 1);
+                        let ready = match serde_json::from_slice::<Message<T>>(&msg_buf) {
+                            Ok(msg) => {
+                                tracing::trace!("Received {:?}", msg);
+                                Ok(msg)
+                            }
+                            Err(err) => {
+                                let msg = String::from_utf8_lossy(&msg_buf).into_owned();
+                                tracing::debug!(target: "chromiumoxide::conn::pipes::parse_errors", msg, "Failed to parse raw pipe message {}", err);
+                                Err(CdpError::InvalidMessage(msg, err))
+                            }
+                        };
+                        return Some(ready);
+                    }
+                    None
+                }
+
+                if let Some(message_result) = try_get_message(read_buf) {
+                    return Poll::Ready(Some(message_result));
+                }
+
+                loop {
+                    match ready!(reader.poll_next_unpin(cx)) {
+                        Some(Ok(bytes)) => {
+                            read_buf.extend_from_slice(&bytes);
+                            if let Some(message_result) = try_get_message(read_buf) {
+                                return Poll::Ready(Some(message_result));
+                            }
+                        }
+                        Some(Err(err)) => return Poll::Ready(Some(Err(CdpError::Io(err)))),
+                        None => return Poll::Ready(None),
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Exchanges the messages with the websocket
 #[must_use = "streams do nothing unless polled"]
 #[derive(Debug)]
 pub struct Connection<T: EventMessage> {
     /// Queue of commands to send.
     pending_commands: VecDeque<MethodCall>,
-    /// The websocket of the chromium instance
-    ws: WebSocketStream<ConnectStream>,
+    /// The connection transport of the chromium instance
+    connection_transport: ConnectionTransport<T>,
     /// The identifier for a specific command
     next_id: usize,
     needs_flush: bool,
     /// The message that is currently being proceessed
     pending_flush: Option<MethodCall>,
-    _marker: PhantomData<T>,
 }
 
 impl<T: EventMessage + Unpin> Connection<T> {
@@ -46,16 +204,32 @@ impl<T: EventMessage + Unpin> Connection<T> {
 
         Ok(Self {
             pending_commands: Default::default(),
-            ws,
+            connection_transport: ConnectionTransport::Websocket(ws),
             next_id: 0,
             needs_flush: false,
             pending_flush: None,
-            _marker: Default::default(),
+        })
+    }
+
+    pub async fn connect_with_pipes(writer: PipeWriter, reader: PipeReader) -> Result<Self> {
+        Ok(Self {
+            pending_commands: Default::default(),
+            connection_transport: ConnectionTransport::Pipes {
+                writer,
+                reader: ReaderStream::new(
+                    tokio::net::unix::pipe::Receiver::from_owned_fd(reader.into()).unwrap(),
+                ),
+                read_buf: vec![],
+                _phantom: Default::default(),
+            },
+            next_id: 0,
+            needs_flush: false,
+            pending_flush: None,
         })
     }
 }
 
-impl<T: EventMessage> Connection<T> {
+impl<T: EventMessage + Unpin> Connection<T> {
     fn next_call_id(&mut self) -> CallId {
         let id = CallId::new(self.next_id);
         self.next_id = self.next_id.wrapping_add(1);
@@ -85,15 +259,14 @@ impl<T: EventMessage> Connection<T> {
     /// sink
     fn start_send_next(&mut self, cx: &mut Context<'_>) -> Result<()> {
         if self.needs_flush {
-            if let Poll::Ready(Ok(())) = self.ws.poll_flush_unpin(cx) {
+            if let Poll::Ready(Ok(())) = self.connection_transport.poll_flush_unpin(cx) {
                 self.needs_flush = false;
             }
         }
         if self.pending_flush.is_none() && !self.needs_flush {
             if let Some(cmd) = self.pending_commands.pop_front() {
                 tracing::trace!("Sending {:?}", cmd);
-                let msg = serde_json::to_string(&cmd)?;
-                self.ws.start_send_unpin(msg.into())?;
+                self.connection_transport.start_send_unpin(cmd.clone())?;
                 self.pending_flush = Some(cmd);
             }
         }
@@ -115,7 +288,7 @@ impl<T: EventMessage + Unpin> Stream for Connection<T> {
 
             // send the message
             if let Some(call) = pin.pending_flush.take() {
-                if pin.ws.poll_ready_unpin(cx).is_ready() {
+                if pin.connection_transport.poll_ready_unpin(cx).is_ready() {
                     pin.needs_flush = true;
                     // try another flush
                     continue;
@@ -127,34 +300,6 @@ impl<T: EventMessage + Unpin> Stream for Connection<T> {
             break;
         }
 
-        // read from the ws
-        match ready!(pin.ws.poll_next_unpin(cx)) {
-            Some(Ok(WsMessage::Text(text))) => {
-                let ready = match serde_json::from_str::<Message<T>>(&text) {
-                    Ok(msg) => {
-                        tracing::trace!("Received {:?}", msg);
-                        Ok(msg)
-                    }
-                    Err(err) => {
-                        let msg = text.as_str().to_string();
-                        tracing::debug!(target: "chromiumoxide::conn::raw_ws::parse_errors", msg, "Failed to parse raw WS message {}", err);
-                        Err(CdpError::InvalidMessage(text.as_str().to_string(), err))
-                    }
-                };
-                Poll::Ready(Some(ready))
-            }
-            Some(Ok(WsMessage::Close(_))) => Poll::Ready(None),
-            // ignore ping and pong
-            Some(Ok(WsMessage::Ping(_))) | Some(Ok(WsMessage::Pong(_))) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Some(Ok(msg)) => Poll::Ready(Some(Err(CdpError::UnexpectedWsMessage(msg)))),
-            Some(Err(err)) => Poll::Ready(Some(Err(CdpError::Ws(err)))),
-            None => {
-                // ws connection closed
-                Poll::Ready(None)
-            }
-        }
+        pin.connection_transport.poll_next_unpin(cx)
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,6 @@
-use crate::test;
+use chromiumoxide::BrowserConfig;
+
+use crate::{test, test_config};
 
 #[tokio::test]
 async fn test_basic() {
@@ -8,5 +10,19 @@ async fn test_basic() {
         let title = page.get_title().await.unwrap().unwrap();
         assert!(title.contains("Google"));
     })
+    .await;
+}
+
+#[tokio::test]
+async fn test_basic_pipes() {
+    test_config(
+        BrowserConfig::builder().pipes().build().unwrap(),
+        async |browser| {
+            let page = browser.new_page("about:blank").await.unwrap();
+            page.goto("https://www.google.com").await.unwrap();
+            let title = page.get_title().await.unwrap().unwrap();
+            assert!(title.contains("Google"));
+        },
+    )
     .await;
 }


### PR DESCRIPTION
Resolves #294

### Description of changes

Allows using pipes to communicate with chromium, in addition to the existing websocket connections.

I have only tested/verified these changes on linux, but because I wanted to use the [async version of pipes](https://docs.rs/tokio/latest/tokio/net/unix/pipe/index.html), which is limited to Unix systems anyway, as well as the [`command_fds`](https://docs.rs/command-fds/latest/command_fds/) crate

For windows, there is an additional flag `--remote-debugging-io-pipes`:

> Specifies pipe names for the incoming and outbound messages on the Windows platform. This is a comma separated list of two pipe handles serialized as unsigned integers, e.g. "--remote-debugging-io-pipes=3,4". [↪](https://source.chromium.org/chromium/chromium/src/+/main:content/public/common/content_switches.cc?q=kRemoteDebuggingIoPipes&ss=chromium)

But since I cannot test the windows part, I think someone else might be better suited to implement this behaviour  for windows?

### Checklist

- [x] Added change to the changelog
- [ ] Created unit tests for my feature (if needed)
- [x] Created a least one integration test
