### PR TITLE
Preserve `/proc/PID/fd/N` executable paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Derive `Clone` for `Element`, `ScreenshotParams` and `ScreenshotParamsBuilder`
+- Preserve Linux `/proc/self/fd/N` and `/proc/PID/fd/N` executable paths
 
 ## [0.9.1] 2026-02-25
 

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -153,7 +153,7 @@ impl Browser {
     /// (20 seconds by default).
     pub async fn launch(mut config: BrowserConfig) -> Result<(Self, Handler)> {
         // Canonalize paths to reduce issues with sandboxing
-        config.executable = utils::canonicalize_except_snap(config.executable).await?;
+        config.executable = utils::normalize_executable_path(config.executable).await?;
 
         // Launch a new chromium instance
         let mut child = config.launch()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,25 +29,38 @@ fn absolute(path: PathBuf) -> std::io::Result<PathBuf> {
     Ok(dunce::simplified(&path).to_path_buf())
 }
 
-/// Check if the given path is a Linux /proc/self/fd/N path
+/// Checks whether the path is a Linux procfs FD path of the form
+/// `/proc/self/fd/N` or `/proc/PID/fd/N`.
 #[cfg(any(target_os = "linux", test))]
-fn is_proc_self_fd_path(path: &Path) -> bool {
-    let Some(fd) = path
-        .to_str()
-        .and_then(|path| path.strip_prefix("/proc/self/fd/"))
-    else {
+fn is_proc_fd_path(path: &Path) -> bool {
+    let Some(path) = path.to_str().and_then(|path| path.strip_prefix("/proc/")) else {
         return false;
     };
 
-    fd.parse::<i32>()
-        .is_ok_and(|n| n >= 0 && n.to_string() == fd)
+    let mut components = path.split('/');
+    let (Some(pid), Some("fd"), Some(fd), None) = (
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+    ) else {
+        return false;
+    };
+
+    fn is_canonical_i32(value: &str, minimum: i32) -> bool {
+        value
+            .parse::<i32>()
+            .is_ok_and(|n| n >= minimum && n.to_string() == value)
+    }
+
+    (pid == "self" || is_canonical_i32(pid, 1)) && is_canonical_i32(fd, 0)
 }
 
 /// Normalize an executable path without resolving Linux paths that must retain
 /// their original form.
 pub(crate) async fn normalize_executable_path(path: PathBuf) -> std::io::Result<PathBuf> {
     #[cfg(target_os = "linux")]
-    if is_proc_self_fd_path(&path) {
+    if is_proc_fd_path(&path) {
         return Ok(path);
     }
 
@@ -140,9 +153,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn recognizes_proc_self_fd_paths() {
-        assert!(is_proc_self_fd_path(Path::new("/proc/self/fd/0")));
-        assert!(is_proc_self_fd_path(Path::new("/proc/self/fd/123")));
+    fn recognizes_proc_fd_paths() {
+        for path in [
+            "/proc/self/fd/0",
+            "/proc/self/fd/123",
+            "/proc/1/fd/0",
+            "/proc/123/fd/456",
+            "/proc/2147483647/fd/2147483647",
+        ] {
+            assert!(is_proc_fd_path(Path::new(path)), "{path}");
+        }
 
         for path in [
             "/proc/self/fd/",
@@ -155,8 +175,21 @@ mod tests {
             "/proc/self/fd/123/extra",
             "/proc/self/fd/123/../../../456",
             "/proc/self/fd/999999999999999999999999",
+            "/proc//fd/1",
+            "/proc/0/fd/1",
+            "/proc/0001/fd/1",
+            "/proc/-1/fd/1",
+            "/proc/+1/fd/1",
+            "/proc/not-a-pid/fd/1",
+            "/proc/1/fd/0001",
+            "/proc/1/fd/-1",
+            "/proc/1/fd/+1",
+            "/proc/1/fd/not-a-fd",
+            "/proc/1/fd/1/extra",
+            "/proc/1/fd/1/../../../2",
+            "/proc/999999999999999999999999/fd/1",
         ] {
-            assert!(!is_proc_self_fd_path(Path::new(path)), "{path}");
+            assert!(!is_proc_fd_path(Path::new(path)), "{path}");
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,8 @@ pub(crate) async fn canonicalize<P: AsRef<Path> + Unpin>(path: P) -> std::io::Re
 
 /// Absolute path
 ///
-pub(crate) fn absolute(path: PathBuf) -> std::io::Result<PathBuf> {
+#[cfg(target_os = "linux")]
+fn absolute(path: PathBuf) -> std::io::Result<PathBuf> {
     let path = if path.is_absolute() {
         path
     } else {
@@ -35,11 +36,12 @@ pub(crate) async fn canonicalize_except_snap(path: PathBuf) -> std::io::Result<P
     let executable_cleaned: PathBuf = canonicalize(&path).await?;
 
     // Handle case where executable is provided by snap, ignore canonicalize result and only make path absolute
-    Ok(if executable_cleaned.to_str().unwrap().ends_with("/snap") {
-        absolute(path).unwrap()
-    } else {
-        executable_cleaned
-    })
+    #[cfg(target_os = "linux")]
+    if executable_cleaned.to_str().unwrap().ends_with("/snap") {
+        return Ok(absolute(path).unwrap());
+    }
+
+    Ok(executable_cleaned)
 }
 
 pub(crate) mod base64 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,9 +29,28 @@ fn absolute(path: PathBuf) -> std::io::Result<PathBuf> {
     Ok(dunce::simplified(&path).to_path_buf())
 }
 
-/// Canonicalize path except if target binary is snap, in this case only make the path absolute
-///
-pub(crate) async fn canonicalize_except_snap(path: PathBuf) -> std::io::Result<PathBuf> {
+/// Check if the given path is a Linux /proc/self/fd/N path
+#[cfg(any(target_os = "linux", test))]
+fn is_proc_self_fd_path(path: &Path) -> bool {
+    let Some(fd) = path
+        .to_str()
+        .and_then(|path| path.strip_prefix("/proc/self/fd/"))
+    else {
+        return false;
+    };
+
+    fd.parse::<i32>()
+        .is_ok_and(|n| n >= 0 && n.to_string() == fd)
+}
+
+/// Normalize an executable path without resolving Linux paths that must retain
+/// their original form.
+pub(crate) async fn normalize_executable_path(path: PathBuf) -> std::io::Result<PathBuf> {
+    #[cfg(target_os = "linux")]
+    if is_proc_self_fd_path(&path) {
+        return Ok(path);
+    }
+
     // Canonalize paths to reduce issues with sandboxing
     let executable_cleaned: PathBuf = canonicalize(&path).await?;
 
@@ -119,6 +138,27 @@ fn skip_args(input: &mut &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recognizes_proc_self_fd_paths() {
+        assert!(is_proc_self_fd_path(Path::new("/proc/self/fd/0")));
+        assert!(is_proc_self_fd_path(Path::new("/proc/self/fd/123")));
+
+        for path in [
+            "/proc/self/fd/",
+            "/proc/self/fd/0001",
+            "/proc/self/fd/-1",
+            "/proc/self/fd/+1",
+            "/proc/self/fd/not-a-fd",
+            "/proc/self/fd//123",
+            "/proc/self/fd/./123",
+            "/proc/self/fd/123/extra",
+            "/proc/self/fd/123/../../../456",
+            "/proc/self/fd/999999999999999999999999",
+        ] {
+            assert!(!is_proc_self_fd_path(Path::new(path)), "{path}");
+        }
+    }
 
     #[test]
     fn is_js_function() {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,5 +1,48 @@
 use crate::{BrowserConfig, test_config};
 
+/// Verifies that Chromiumoxide preserves `/proc/PID/fd/N` executable paths.
+///
+/// The backing file is unlinked before launch, so preserving the procfs path
+/// allows the `exit 0` script to run and produce a successful `LaunchExit`.
+/// Canonicalizing it instead resolves to the deleted backing path and fails
+/// before the script can be launched.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn preserves_proc_pid_fd_executable_path() {
+    use std::os::{fd::AsRawFd, unix::fs::PermissionsExt};
+    use std::{env::temp_dir, fs, process::id, time};
+
+    use chromiumoxide::{Browser, error::CdpError};
+
+    let nonce = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let executable_path = temp_dir().join(format!("chromiumoxide-proc-fd-test-{}-{nonce}", id()));
+
+    // Keep stderr open briefly after the script exits so that Browser::launch
+    // observes the successful exit before it observes EOF on stderr.
+    fs::write(&executable_path, "#!/bin/sh\nsleep 1 &\nexit 0\n").unwrap();
+    let mut permissions = fs::metadata(&executable_path).unwrap().permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&executable_path, permissions).unwrap();
+
+    let executable = fs::File::open(&executable_path).unwrap();
+    fs::remove_file(&executable_path).unwrap();
+
+    let proc_fd_path = format!("/proc/{}/fd/{}", id(), executable.as_raw_fd());
+    let config = BrowserConfig::builder()
+        .chrome_executable(proc_fd_path)
+        .build()
+        .unwrap();
+
+    match Browser::launch(config).await {
+        Err(CdpError::LaunchExit(status, _)) => assert!(status.success()),
+        Err(error) => panic!("unexpected launch error: {error:?}"),
+        Ok(_) => panic!("test executable unexpectedly exposed a DevTools endpoint"),
+    }
+}
+
 #[tokio::test]
 #[ignore] // For some reason, this test fails on CI but works locally
 async fn test_config_disable_https_first() {


### PR DESCRIPTION
Preserving `/proc/PID/fd/N` paths allows Chromiumoxide to launch a Chrome executable backed by an anonymous file created with `memfd_create(2)`. The executable therefore does not need to exist as a regular file on disk.

This makes it possible to embed Chrome in an application and launch it without creating, managing, or cleaning up a temporary executable file, which is super convenient. A working proof of concept is available at [simnalamburt/chromiumoxide-memfd](https://github.com/simnalamburt/chromiumoxide-memfd).

### Issue # (if available)
N/A

### Description of changes
- Preserve exact Linux `/proc/self/fd/N` and `/proc/PID/fd/N` executable paths instead of canonicalizing them.
- Only bypass canonicalization for strictly valid procfs file-descriptor paths; malformed paths and paths containing extra components continue through normal canonicalization.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature (if needed)
- [x] Created a least one integration test
