### PR TITLE
feat: add session-aware cross-origin iframe support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Change `Element::node_id` from `NodeId` to `Option<NodeId>` because
+  session-scoped Runtime queries can produce valid elements without a frontend
+  node id
+- Mark `CdpError` as non-exhaustive and add frame- and interception-specific
+  error variants
+
+### Added
+
+- Add session-aware cross-origin iframe (OOPIF) support, including public frame
+  APIs, recursive child-session attachment, frame navigation and evaluation,
+  DOM element interaction, request interception, preload replay, and
+  deterministic detach/teardown handling
+
 ### Changed
 
 - Derive `Clone` for `Element`, `ScreenshotParams` and `ScreenshotParamsBuilder`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ windows-registry = "0.6"
 quote = "1"
 proc-macro2 = "1"
 chrono = "0.4.1"
+proptest = "1"
+static_assertions = "1"
+tempfile = "3.10"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
 
@@ -64,7 +67,7 @@ zip8 = ["chromiumoxide_fetcher/zip8"]
 
 [[example]]
 name = "fetcher"
-required-features = ["fetcher", "zip8", "rustls"]
+required-features = ["fetcher", "zip8"]
 
 [[test]]
 name = "chromiumoxide_tests"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,116 @@ pub async fn pdf(&self, params: PrintToPdfParams) -> Result<Vec<u8>> {
 
 If you need something else, the `Page::execute` function allows for writing your own command wrappers. PRs are very welcome if you think a meaningful command is missing a designated function.
 
+## Frames and cross-origin iframes
+
+`Page::main_frame`, `Page::all_frames`, and `Page::frame_by_id` return `Frame`
+handles pinned to the CDP session that owned the frame when the handle was created.
+That lets the same API work for ordinary child frames and out-of-process iframes
+(OOPIFs):
+
+```rust
+for frame in page.all_frames().await? {
+    println!(
+        "frame={} session={} oop={} url={:?}",
+        frame.id().as_ref(),
+        frame.session_id().as_ref(),
+        frame.is_out_of_process(),
+        frame.url(),
+    );
+
+    if frame.is_out_of_process() {
+        let title: String = frame.eval("document.title").await?.into_value()?;
+        println!("child title: {title}");
+    }
+}
+```
+
+Frame handles support raw `execute`, JavaScript `eval`, `query_selector`, navigation,
+navigation waiting, and parent/child traversal. Elements returned by a frame retain the
+same session and can be queried, clicked, hovered, measured, and explicitly disposed.
+See [`examples/iframe.rs`](examples/iframe.rs) for a complete example.
+
+Navigate a frame with `Frame::goto`, which pins both the frame and its session. Raw
+`Frame::execute` rejects `Page.navigate` with `CdpError::NotAllowed`, because a raw command
+loses the frame identity a navigation watcher needs and would target the page's main frame.
+
+A frame can move to another CDP session during a process swap. An old handle then returns
+`CdpError::FrameNotReady`; enumerate the frames again or call `frame_by_id` to obtain a
+fresh handle. There is a short browser-controlled swap-in window where a frame can be
+attached but its OOP session is not yet ready, so retry `FrameNotReady` operations after
+refreshing the handle.
+
+When a page target is destroyed or the connection closes, in-flight frame operations are
+settled with a typed error rather than a channel cancellation: `Frame::wait_for_navigation`
+resolves to `CdpError::FrameNotReady`, while `Page::goto` / `Frame::goto` resolve to
+`CdpError::NoResponse`. `Frame::fetch_url` is the one read that follows the frame's current
+session instead of failing on a stale handle; see its rustdoc.
+
+## Managed request interception
+
+Use `PausedRequest` as the response capability for Fetch interception. Register the stream
+first, await Chrome-side enablement second, and only then navigate:
+
+```rust
+let mut paused_requests = page.paused_requests().await?;
+page.set_request_interception(true).await?;
+
+while let Some(paused) = paused_requests.next().await {
+    if paused.event().request.url.ends_with(".png") {
+        paused.fail(ErrorReason::BlockedByClient).await?;
+    } else {
+        paused.continue_request().await?;
+    }
+}
+```
+
+`continue_request`, `continue_with`, `fulfill`, and `fail` consume the handle and always
+use the request id and CDP session captured with the pause. This is required for OOPIF
+requests; a raw `Page::execute(ContinueRequestParams { .. })` is a main-session operation.
+Dropping a delivered `PausedRequest` has no protocol side effect, so every request that
+must be released needs an explicit response. Dropping the stream allows a later stream to
+register, but does not answer already delivered requests. See
+[`examples/interception.rs`](examples/interception.rs) and
+[`examples/block-navigation.rs`](examples/block-navigation.rs).
+
+Await ordering-sensitive state changes such as `authenticate` and
+`set_request_interception` before `Page::goto` or `Frame::goto`. Their futures establish
+the ordering; launching them concurrently with navigation does not.
+
+If either update returns an error, retry it before navigating. The retry always sends a
+fresh idempotent Chrome configuration batch and waits for its acknowledgement. Until that
+retry succeeds, a newly attached OOPIF can briefly inherit the requested interception/auth
+state even though the main session did not confirm it; the failed caller has already received
+`Err`, so applications should treat the configuration as unavailable during that window.
+
+## Compatibility and current limitations
+
+The frame/OOPIF API has two intentional source-compatibility exceptions:
+
+- `Element::node_id` is now `Option<NodeId>` because frame-scoped elements may only have a
+  remote object and backend node id.
+- `CdpError` is now `#[non_exhaustive]`. Making an existing public enum non-exhaustive is the
+  one-time source break here: after upgrading, a downstream exhaustive `match` on `CdpError`
+  must add a wildcard (`_`) arm. Once that arm exists, the new variants are additive and cost
+  nothing further — `FrameNotReady`, `PausedRequestResponderAlreadyRegistered`, and `NotAllowed`
+  (returned when a raw operation is submitted through an entry point that does not support it,
+  e.g. `Frame::execute(Page.navigate)` — use `Frame::goto` instead).
+
+Existing `TargetMessage`, `GetExecutionContext`, the five-variant `NetworkEvent`, and legacy
+handler signatures remain unchanged.
+
+Current OOPIF limitations include:
+
+- `expose_function`, stealth helper replay, and dynamic user-agent replay remain
+  main-session-only.
+- High-level frame-scoped console/network event attribution and full cross-session response
+  body adoption are not exposed yet; typed raw events remain available.
+- Init scripts are replayed when added, but there is no public remove-init-script API.
+  The default behavior applies scripts to future documents rather than current contexts;
+  `runImmediately=true` is not guaranteed during paused OOPIF initialization.
+- `Element::dispose().await` releases its remote object explicitly. Dropping an `Element`
+  remains a local operation and does not send a release command.
+
 ### Add chromiumoxide to your project
 
 `chromiumoxide` only supports the [`tokio`](https://github.com/tokio-rs/tokio) runtime.

--- a/chromiumoxide_pdl/Cargo.toml
+++ b/chromiumoxide_pdl/Cargo.toml
@@ -22,5 +22,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 chromiumoxide_types = { path = "../chromiumoxide_types", version = "0.9" }
 either = "1.6"
 
+[dev-dependencies]
+tempfile = "3.10"
+
 [features]
 serde = ["dep:serde"]

--- a/chromiumoxide_pdl/src/build/generator.rs
+++ b/chromiumoxide_pdl/src/build/generator.rs
@@ -1205,20 +1205,42 @@ pub fn fmt(out_dir: impl AsRef<Path>) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::fs;
 
     use super::*;
 
     #[test]
     fn test_serde_import() {
-        let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        const PDL: &str = r#"version
+  major 1
+  minor 0
+
+domain Runtime
+  type RemoteObjectId extends string
+
+  command evaluate
+    parameters
+      string expression
+    returns
+      optional string result
+
+  event consoleAPICalled
+    parameters
+      string text
+"#;
+
+        let fixture = tempfile::tempdir().expect("temporary PDL fixture can be created");
+        let source = fixture.path().join("runtime.pdl");
+        fs::write(&source, PDL).expect("PDL fixture can be written");
+
         Generator::default()
-            .out_dir(dir.join("src"))
+            .out_dir(fixture.path())
             .serde(SerdeSupport::with_feature("serde0"))
-            .compile_pdls(&[
-                dir.join("js_protocol.pdl"),
-                dir.join("browser_protocol.pdl"),
-            ])
-            .unwrap();
+            .compile_pdls(&[source])
+            .expect("minimal PDL can be generated");
+
+        let generated = fs::read_to_string(fixture.path().join("cdp.rs"))
+            .expect("generated module can be read");
+        assert!(generated.contains("#[cfg(feature = \"serde0\")]"));
     }
 }

--- a/examples/block-navigation.rs
+++ b/examples/block-navigation.rs
@@ -1,19 +1,21 @@
+//! Block navigations to specific hosts using `PausedRequest` as the response
+//! capability, correlating with `requestWillBeSent`.
+//!
+//! This example navigates to external websites, so it does not run offline;
+//! edit the target URLs to point at a local server to run it without network
+//! access.
+
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use chromiumoxide::Page;
 use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::fetch::{
-    self, ContinueRequestParams, EventRequestPaused, FailRequestParams, FulfillRequestParams,
-};
 use chromiumoxide::cdp::browser_protocol::network::{
-    self, ErrorReason, EventRequestWillBeSent, ResourceType,
+    ErrorReason, EventRequestWillBeSent, RequestId, ResourceType,
 };
+use chromiumoxide::{Binary, FulfillResponse, PausedRequest};
 use futures::{StreamExt, select};
-use tokio::time::sleep;
 
 const CONTENT: &str = "<html><head><meta http-equiv=\"refresh\" content=\"0;URL='http://www.example.com/'\" /></head><body><h1>TEST</h1></body></html>";
 const TARGET: &str = "http://google.com/";
@@ -22,87 +24,79 @@ const TARGET: &str = "http://google.com/";
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    // Spawn browser
     let (mut browser, mut handler) = Browser::launch(
         BrowserConfig::builder()
-            .enable_request_intercept()
             .disable_cache()
-            .request_timeout(Duration::from_secs(1))
+            .request_timeout(Duration::from_secs(5))
             .build()?,
     )
     .await?;
-
     let browser_handle = tokio::spawn(async move {
-        while let Some(h) = handler.next().await {
-            if h.is_err() {
+        while let Some(result) = handler.next().await {
+            if result.is_err() {
                 break;
             }
         }
     });
 
-    // Setup request interception
-    let page = Arc::new(browser.new_page("about:blank").await?);
-
+    let page = browser.new_page("about:blank").await?;
+    let mut paused_requests = page.paused_requests().await?.fuse();
     let mut request_will_be_sent = page
         .event_listener::<EventRequestWillBeSent>()
-        .await
-        .unwrap()
+        .await?
         .fuse();
-    let mut request_paused = page
-        .event_listener::<EventRequestPaused>()
-        .await
-        .unwrap()
-        .fuse();
-    let intercept_page = page.clone();
+    page.set_request_interception(true).await?;
+
     let intercept_handle = tokio::spawn(async move {
-        let mut resolutions: HashMap<network::RequestId, InterceptResolution> = HashMap::new();
+        let mut resolutions = HashMap::<RequestId, InterceptResolution>::new();
         loop {
             select! {
-              event = request_paused.next() => {
-                if let Some(event) = event {
-                    // Responses
-                    if event.response_status_code.is_some() {
-                        forward(&intercept_page, &event.request_id).await;
+                paused = paused_requests.next() => {
+                    let Some(paused) = paused else {
+                        continue;
+                    };
+                    if paused.event().response_status_code.is_some() {
+                        if let Err(error) = paused.continue_request().await {
+                            eprintln!("Failed to continue a response-stage pause: {error}");
+                        }
                         continue;
                     }
 
-                    if let Some(network_id) = event.network_id.as_ref().map(|id| id.as_network_id()) {
-                        let resolution = resolutions.entry(network_id.clone()).or_insert(InterceptResolution::new());
-                        resolution.request_id = Some(event.request_id.clone());
-                        if event.request.url == TARGET {
-                          resolution.action = InterceptAction::Fullfill;
+                    let Some(network_id) = paused.event().network_id.clone() else {
+                        if let Err(error) = paused.continue_request().await {
+                            eprintln!("Failed to continue an uncorrelated request: {error}");
                         }
-                        println!("paused: {resolution:?}, network: {network_id:?}");
-                        resolve(&intercept_page, &network_id, &mut resolutions).await;
+                        continue;
+                    };
+                    let target = paused.event().request.url == TARGET;
+                    let resolution = resolutions.entry(network_id.clone()).or_default();
+                    resolution.paused = Some(paused);
+                    if target {
+                        resolution.action = InterceptAction::Fulfill;
                     }
-                  }
-              },
-              event = request_will_be_sent.next() => {
-                  if let Some(event) = event {
-                      let resolution = resolutions.entry(event.request_id.clone()).or_insert(InterceptResolution::new());
-                      let action = if is_navigation(&event) {
-                          InterceptAction::Abort
-                      } else {
-                          InterceptAction::Forward
-                      };
-                      resolution.action = action;
-                      println!("sent: {resolution:?}");
-                      resolve(&intercept_page, &event.request_id, &mut resolutions).await;
-                  }
-              },
-              complete => break,
+                    resolve(&network_id, &mut resolutions).await;
+                },
+                sent = request_will_be_sent.next() => {
+                    let Some(sent) = sent else {
+                        continue;
+                    };
+                    let action = if sent.request.url == TARGET {
+                        InterceptAction::Fulfill
+                    } else if is_navigation(&sent) {
+                        InterceptAction::Abort
+                    } else {
+                        InterceptAction::Forward
+                    };
+                    resolutions.entry(sent.request_id.clone()).or_default().action = action;
+                    resolve(&sent.request_id, &mut resolutions).await;
+                },
+                complete => break,
             }
         }
-
-        println!("done");
     });
 
-    sleep(Duration::from_secs(5)).await;
-
-    // Navigate to target
-    page.goto("http://google.com").await?;
-    let content = page.content().await?;
-    println!("Content: {:?}", content);
+    page.goto(TARGET).await?;
+    println!("Content: {}", page.content().await?);
 
     browser.close().await?;
     browser_handle.await?;
@@ -110,114 +104,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 enum InterceptAction {
     Forward,
     Abort,
-    Fullfill,
+    Fulfill,
+    #[default]
     None,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct InterceptResolution {
     action: InterceptAction,
-    request_id: Option<fetch::RequestId>,
-}
-
-impl InterceptResolution {
-    pub fn new() -> Self {
-        Self {
-            action: InterceptAction::None,
-            request_id: None,
-        }
-    }
-}
-
-trait RequestIdExt {
-    fn as_network_id(&self) -> network::RequestId;
-}
-
-impl RequestIdExt for network::RequestId {
-    fn as_network_id(&self) -> network::RequestId {
-        network::RequestId::new(self.inner().clone())
-    }
+    paused: Option<PausedRequest>,
 }
 
 fn is_navigation(event: &EventRequestWillBeSent) -> bool {
-    if event.request_id.inner() == event.loader_id.inner()
-        && event
-            .r#type
-            .as_ref()
-            .map(|t| *t == ResourceType::Document)
-            .unwrap_or(false)
-    {
-        return true;
-    }
-    false
+    event.request_id.inner() == event.loader_id.inner()
+        && event.r#type.as_ref() == Some(&ResourceType::Document)
 }
 
 async fn resolve(
-    page: &Page,
-    network_id: &network::RequestId,
-    resolutions: &mut HashMap<network::RequestId, InterceptResolution>,
+    network_id: &RequestId,
+    resolutions: &mut HashMap<RequestId, InterceptResolution>,
 ) {
-    if let Some(resolution) = resolutions.get(network_id) {
-        if let Some(request_id) = &resolution.request_id {
-            match resolution.action {
-                InterceptAction::Forward => {
-                    forward(page, request_id).await;
-                    resolutions.remove(network_id);
-                }
-                InterceptAction::Abort => {
-                    abort(page, request_id).await;
-                    resolutions.remove(network_id);
-                }
-                InterceptAction::Fullfill => {
-                    fullfill(page, request_id).await;
-                    resolutions.remove(network_id);
-                }
-                InterceptAction::None => (), // Processed pausd but not will be sent
-            }
-        }
+    let ready = resolutions.get(network_id).is_some_and(|resolution| {
+        resolution.paused.is_some() && resolution.action != InterceptAction::None
+    });
+    if !ready {
+        return;
     }
-}
 
-async fn forward(page: &Page, request_id: &fetch::RequestId) {
-    println!("Request {request_id:?} forwarded");
-    if let Err(e) = page
-        .execute(ContinueRequestParams::new(request_id.clone()))
-        .await
-    {
-        println!("Failed to forward request: {e}");
-    }
-}
-
-async fn abort(page: &Page, request_id: &fetch::RequestId) {
-    println!("Request {request_id:?} aborted");
-    if let Err(e) = page
-        .execute(FailRequestParams::new(
-            request_id.clone(),
-            ErrorReason::Aborted,
-        ))
-        .await
-    {
-        println!("Failed to abort request: {e}");
-    }
-}
-
-async fn fullfill(page: &Page, request_id: &fetch::RequestId) {
-    println!("Request {request_id:?} fullfilled");
-    if let Err(e) = page
-        .execute(
-            FulfillRequestParams::builder()
-                .request_id(request_id.clone())
-                .body(BASE64_STANDARD.encode(CONTENT))
-                .response_code(200)
+    let resolution = resolutions
+        .remove(network_id)
+        .expect("a ready resolution remains registered");
+    let paused = resolution
+        .paused
+        .expect("a ready resolution owns its response capability");
+    let result = match resolution.action {
+        InterceptAction::Forward => paused.continue_request().await,
+        InterceptAction::Abort => paused.fail(ErrorReason::Aborted).await,
+        InterceptAction::Fulfill => {
+            let response = FulfillResponse::builder(200)
+                .body(Binary::from(BASE64_STANDARD.encode(CONTENT)))
                 .build()
-                .unwrap(),
-        )
-        .await
-    {
-        println!("Failed to fullfill request: {e}");
+                .expect("the synthetic response is valid");
+            paused.fulfill(response).await
+        }
+        InterceptAction::None => unreachable!("readiness excludes an empty action"),
+    };
+    if let Err(error) = result {
+        eprintln!("Failed to resolve request {network_id:?}: {error}");
     }
 }

--- a/examples/iframe-workaround.rs
+++ b/examples/iframe-workaround.rs
@@ -1,6 +1,6 @@
-// This example is for checking the iframe workaround.
-// a problem with the iframe workaround is that it will always fail to load the page
-// and goto will cause a timeout.
+// Historical regression reproducer for the old iframe workaround, retained so
+// its former timeout behavior can still be compared. New code should use the
+// session-pinned Frame APIs demonstrated by `examples/iframe.rs`.
 
 use chromiumoxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;

--- a/examples/iframe.rs
+++ b/examples/iframe.rs
@@ -1,0 +1,63 @@
+//! Enumerate a page's frames and evaluate JavaScript inside a cross-origin
+//! (out-of-process) iframe.
+//!
+//! By default this visits an external website for a manual sanity check, so it
+//! does not run offline; pass a URL that embeds a cross-origin iframe as the
+//! first argument to run it against your own page. Deterministic, offline OOPIF
+//! coverage lives in the local fixtures under `tests/oopif.rs`.
+
+use chromiumoxide::browser::{Browser, BrowserConfig};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    // Default is an external site purely for a manual sanity check; pass any
+    // URL that embeds a cross-origin iframe as the first argument. Deterministic
+    // OOPIF coverage lives in the local fixtures under `tests/oopif.rs`.
+    let target = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "https://iframetester.com/?url=https%3A%2F%2Fexample.com".to_owned());
+    // `--site-per-process` forces cross-origin iframes out of process, and
+    // HTTPS-First is disabled to match the OOPIF test harness so Chrome 149 does
+    // not upgrade/interstitial the navigations under test.
+    let (mut browser, mut handler) = Browser::launch(
+        BrowserConfig::builder()
+            .arg("--site-per-process")
+            .disable_https_first()
+            .build()?,
+    )
+    .await?;
+    let handler_task = tokio::spawn(async move {
+        while let Some(result) = handler.next().await {
+            if result.is_err() {
+                break;
+            }
+        }
+    });
+
+    let page = browser.new_page(target).await?;
+    println!("main session: {}", page.session_id().as_ref());
+    for frame in page.all_frames().await? {
+        println!(
+            "frame={} session={} oop={} url={}",
+            frame.id().as_ref(),
+            frame.session_id().as_ref(),
+            frame.is_out_of_process(),
+            frame.url().as_deref().unwrap_or("<unknown>")
+        );
+        if frame.is_out_of_process() {
+            let title: String = frame
+                .eval("document.title")
+                .await?
+                .into_value()
+                .map_err(|error| format!("frame title was not a string: {error}"))?;
+            println!("  child document title: {title:?}");
+        }
+    }
+
+    browser.close().await?;
+    handler_task.await?;
+    Ok(())
+}

--- a/examples/interception.rs
+++ b/examples/interception.rs
@@ -1,11 +1,13 @@
-use std::sync::Arc;
+//! Managed Fetch request interception with `PausedRequest` / `FulfillResponse`.
+//!
+//! This example navigates to an external website (`TARGET`), so it does not run
+//! offline; edit `TARGET` to point at a local server to run it without network
+//! access.
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::fetch::{
-    ContinueRequestParams, EventRequestPaused, FulfillRequestParams,
-};
+use chromiumoxide::{Binary, FulfillResponse};
 use futures::StreamExt;
 
 const CONTENT: &str = "<html><head></head><body><h1>TEST</h1></body></html>";
@@ -15,67 +17,47 @@ const TARGET: &str = "https://news.ycombinator.com/";
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    // Spawn browser
-    let (mut browser, mut handler) = Browser::launch(
-        BrowserConfig::builder()
-            .enable_request_intercept()
-            .disable_cache()
-            .build()?,
-    )
-    .await?;
-
+    let (mut browser, mut handler) =
+        Browser::launch(BrowserConfig::builder().disable_cache().build()?).await?;
     let browser_handle = tokio::spawn(async move {
-        while let Some(h) = handler.next().await {
-            if h.is_err() {
+        while let Some(result) = handler.next().await {
+            if result.is_err() {
                 break;
             }
         }
     });
 
-    // Setup request interception
-    let page = Arc::new(browser.new_page("about:blank").await?);
+    let page = browser.new_page("about:blank").await?;
+    // Register the responder before enabling Fetch so the first navigation
+    // cannot pause before a consumer exists.
+    let mut paused_requests = page.paused_requests().await?;
+    page.set_request_interception(true).await?;
 
-    let mut request_paused = page.event_listener::<EventRequestPaused>().await.unwrap();
-    let intercept_page = page.clone();
     let intercept_handle = tokio::spawn(async move {
-        while let Some(event) = request_paused.next().await {
-            if event.request.url == TARGET {
-                if let Err(e) = intercept_page
-                    .execute(
-                        FulfillRequestParams::builder()
-                            .request_id(event.request_id.clone())
-                            .body(BASE64_STANDARD.encode(CONTENT))
-                            .response_code(200)
-                            .build()
-                            .unwrap(),
-                    )
-                    .await
-                {
-                    println!("Failed to fullfill request: {e}");
-                }
-            } else if let Err(e) = intercept_page
-                .execute(ContinueRequestParams::new(event.request_id.clone()))
-                .await
-            {
-                println!("Failed to continue request: {e}");
+        while let Some(paused) = paused_requests.next().await {
+            let result = if paused.event().request.url == TARGET {
+                let response = FulfillResponse::builder(200)
+                    .body(Binary::from(BASE64_STANDARD.encode(CONTENT)))
+                    .build()
+                    .expect("the synthetic response is valid");
+                paused.fulfill(response).await
+            } else {
+                paused.continue_request().await
+            };
+            if let Err(error) = result {
+                eprintln!("Failed to resolve an intercepted request: {error}");
             }
         }
     });
 
-    // Navigate to target
     page.goto(TARGET).await?;
-    page.wait_for_navigation().await?;
-    let content = page.content().await?;
-    if content == CONTENT {
-        println!("Content overriden!")
+    if page.content().await?.contains("<h1>TEST</h1>") {
+        println!("Content overridden");
     }
 
-    // Navigate to other
     page.goto("https://google.com").await?;
-    page.wait_for_navigation().await?;
-    let content = page.content().await?;
-    if content != CONTENT {
-        println!("Content not overriden!")
+    if !page.content().await?.contains("<h1>TEST</h1>") {
+        println!("Other content was continued normally");
     }
 
     browser.close().await?;

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,22 +1,25 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use chromiumoxide_types::ClickOptions;
+use chromiumoxide_types::{ClickOptions, Command, CommandResponse};
 use futures::{Future, FutureExt, Stream, future};
 
 use chromiumoxide_cdp::cdp::browser_protocol::dom::{
-    BackendNodeId, DescribeNodeParams, GetBoxModelParams, GetContentQuadsParams, Node, NodeId,
+    BackendNodeId, DescribeNodeParams, GetBoxModelParams, GetContentQuadsParams,
+    GetFrameOwnerParams, Node, NodeId, QuerySelectorAllParams, QuerySelectorParams,
     ResolveNodeParams,
 };
 use chromiumoxide_cdp::cdp::browser_protocol::page::{
-    CaptureScreenshotFormat, CaptureScreenshotParams, Viewport,
+    CaptureScreenshotFormat, CaptureScreenshotParams, FrameId, Viewport,
 };
+use chromiumoxide_cdp::cdp::browser_protocol::target::SessionId;
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{
-    CallFunctionOnReturns, GetPropertiesParams, PropertyDescriptor, RemoteObjectId,
-    RemoteObjectType,
+    CallArgument, CallFunctionOnParams, CallFunctionOnReturns, ExceptionDetails,
+    GetPropertiesParams, PropertyDescriptor, ReleaseObjectParams, RemoteObject, RemoteObjectId,
+    RemoteObjectSubtype, RemoteObjectType,
 };
 
 use crate::error::{CdpError, Result};
@@ -31,29 +34,52 @@ pub struct Element {
     pub remote_object_id: RemoteObjectId,
     /// Identifier of the backend node.
     pub backend_node_id: BackendNodeId,
-    /// The identifier of the node this element represents.
-    pub node_id: NodeId,
+    /// The document-scoped node identifier, when this handle was created from
+    /// an enabled DOM document.
+    ///
+    /// Frame-scoped selectors are object-based and therefore intentionally do
+    /// not manufacture a `NodeId`.
+    pub node_id: Option<NodeId>,
+    frame_id: FrameId,
+    session_id: SessionId,
     tab: Arc<PageInner>,
 }
 
 impl Element {
-    pub(crate) async fn new(tab: Arc<PageInner>, node_id: NodeId) -> Result<Self> {
+    pub(crate) async fn new(
+        tab: Arc<PageInner>,
+        node_id: NodeId,
+        frame_id: FrameId,
+    ) -> Result<Self> {
+        let session_id = tab.session_id().clone();
+        Self::from_node_in_session(tab, node_id, frame_id, session_id).await
+    }
+
+    async fn from_node_in_session(
+        tab: Arc<PageInner>,
+        node_id: NodeId,
+        frame_id: FrameId,
+        session_id: SessionId,
+    ) -> Result<Self> {
         let backend_node_id = tab
-            .execute(
+            .execute_with_session(
                 DescribeNodeParams::builder()
                     .node_id(node_id)
                     .depth(100)
                     .build(),
+                &session_id,
             )
             .await?
+            .result
             .node
             .backend_node_id;
 
         let resp = tab
-            .execute(
+            .execute_with_session(
                 ResolveNodeParams::builder()
                     .backend_node_id(backend_node_id)
                     .build(),
+                &session_id,
             )
             .await?;
 
@@ -65,19 +91,49 @@ impl Element {
         Ok(Self {
             remote_object_id,
             backend_node_id,
-            node_id,
+            node_id: Some(node_id),
+            frame_id,
+            session_id,
             tab,
         })
     }
 
+    pub(crate) fn from_remote_parts(
+        tab: Arc<PageInner>,
+        remote_object_id: RemoteObjectId,
+        backend_node_id: BackendNodeId,
+        frame_id: FrameId,
+        session_id: SessionId,
+    ) -> Self {
+        Self {
+            remote_object_id,
+            backend_node_id,
+            node_id: None,
+            frame_id,
+            session_id,
+            tab,
+        }
+    }
+
     /// Convert a slice of `NodeId`s into a `Vec` of `Element`s
-    pub(crate) async fn from_nodes(tab: &Arc<PageInner>, node_ids: &[NodeId]) -> Result<Vec<Self>> {
-        future::join_all(
-            node_ids
-                .iter()
-                .copied()
-                .map(|id| Element::new(Arc::clone(tab), id)),
-        )
+    pub(crate) async fn from_nodes(
+        tab: &Arc<PageInner>,
+        node_ids: &[NodeId],
+        frame_id: FrameId,
+    ) -> Result<Vec<Self>> {
+        let session_id = tab.session_id().clone();
+        Self::from_nodes_in_session(tab, node_ids, frame_id, session_id).await
+    }
+
+    async fn from_nodes_in_session(
+        tab: &Arc<PageInner>,
+        node_ids: &[NodeId],
+        frame_id: FrameId,
+        session_id: SessionId,
+    ) -> Result<Vec<Self>> {
+        future::join_all(node_ids.iter().copied().map(|id| {
+            Element::from_node_in_session(Arc::clone(tab), id, frame_id.clone(), session_id.clone())
+        }))
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()
@@ -86,22 +142,226 @@ impl Element {
     /// Returns the first element in the document which matches the given CSS
     /// selector.
     pub async fn find_element(&self, selector: impl Into<String>) -> Result<Self> {
-        let node_id = self.tab.find_element(selector, self.node_id).await?;
-        Element::new(Arc::clone(&self.tab), node_id).await
+        let selector = selector.into();
+        if let Some(node_id) = self.node_id {
+            let node_id = self
+                .execute(QuerySelectorParams::new(node_id, selector))
+                .await?
+                .result
+                .node_id;
+            if *node_id.inner() == 0 {
+                return Err(CdpError::NotFound);
+            }
+            return Self::from_node_in_session(
+                Arc::clone(&self.tab),
+                node_id,
+                self.frame_id.clone(),
+                self.session_id.clone(),
+            )
+            .await;
+        }
+
+        let remote_object_id = self
+            .query_remote_object(
+                "function(sel) { return this.querySelector(sel); }",
+                selector,
+            )
+            .await?
+            .ok_or(CdpError::NotFound)?;
+        self.element_from_remote_object(remote_object_id).await
     }
 
     /// Return all `Element`s in the document that match the given selector
     pub async fn find_elements(&self, selector: impl Into<String>) -> Result<Vec<Element>> {
-        Element::from_nodes(
-            &self.tab,
-            &self.tab.find_elements(selector, self.node_id).await?,
-        )
-        .await
+        let selector = selector.into();
+        if let Some(node_id) = self.node_id {
+            let node_ids = self
+                .execute(QuerySelectorAllParams::new(node_id, selector))
+                .await?
+                .result
+                .node_ids;
+            return Self::from_nodes_in_session(
+                &self.tab,
+                &node_ids,
+                self.frame_id.clone(),
+                self.session_id.clone(),
+            )
+            .await;
+        }
+
+        let Some(node_list_id) = self
+            .query_remote_object(
+                "function(sel) { return this.querySelectorAll(sel); }",
+                selector,
+            )
+            .await?
+        else {
+            return Ok(Vec::new());
+        };
+
+        let mut params = GetPropertiesParams::new(node_list_id.clone());
+        params.own_properties = Some(true);
+        let properties = match self.execute(params).await {
+            Ok(properties) => properties.result,
+            Err(error) => {
+                self.release_remote_objects_best_effort([node_list_id])
+                    .await;
+                return Err(error);
+            }
+        };
+        if let Some(exception) = properties.exception_details {
+            let mut cleanup = exception
+                .exception
+                .as_ref()
+                .and_then(|exception| exception.object_id.clone())
+                .into_iter()
+                .collect::<Vec<_>>();
+            cleanup.push(node_list_id);
+            self.release_remote_objects_best_effort(cleanup).await;
+            return Err(CdpError::JavascriptException(Box::new(exception)));
+        }
+
+        let mut indexed_ids: Vec<(usize, RemoteObjectId)> = Vec::new();
+        let mut missing_object_id = None;
+        for property in properties.result {
+            let Ok(index) = property.name.parse::<usize>() else {
+                continue;
+            };
+            let Some(remote_object_id) = property.value.and_then(|value| value.object_id) else {
+                missing_object_id.get_or_insert(property.name);
+                continue;
+            };
+            indexed_ids.push((index, remote_object_id));
+        }
+        if let Some(property_name) = missing_object_id {
+            let original = CdpError::msg(format!(
+                "NodeList property {property_name} did not contain a remote object id"
+            ));
+            let mut cleanup = indexed_ids
+                .iter()
+                .map(|(_, id)| id.clone())
+                .collect::<Vec<_>>();
+            cleanup.push(node_list_id);
+            self.release_remote_objects_best_effort(cleanup).await;
+            return Err(original);
+        }
+        indexed_ids.sort_by_key(|(index, _)| *index);
+        let child_ids = indexed_ids
+            .into_iter()
+            .map(|(_, remote_object_id)| remote_object_id)
+            .collect::<Vec<_>>();
+
+        let mut elements = Vec::with_capacity(child_ids.len());
+        for remote_object_id in &child_ids {
+            match self.describe_remote_object(remote_object_id.clone()).await {
+                Ok(element) => elements.push(element),
+                Err(error) => {
+                    let mut cleanup = child_ids.clone();
+                    cleanup.push(node_list_id);
+                    self.release_remote_objects_best_effort(cleanup).await;
+                    return Err(error);
+                }
+            }
+        }
+
+        // The NodeList is only a temporary enumeration container. Child
+        // object ids remain alive and are owned by the returned Elements.
+        self.release_remote_objects_best_effort([node_list_id])
+            .await;
+        Ok(elements)
+    }
+
+    async fn execute<T: Command>(&self, command: T) -> Result<CommandResponse<T::Response>> {
+        self.tab
+            .execute_with_session(command, &self.session_id)
+            .await
+    }
+
+    async fn query_remote_object(
+        &self,
+        function_declaration: &str,
+        selector: String,
+    ) -> Result<Option<RemoteObjectId>> {
+        let params = CallFunctionOnParams::builder()
+            .object_id(self.remote_object_id.clone())
+            .function_declaration(function_declaration)
+            .argument(CallArgument::builder().value(selector).build())
+            .return_by_value(false)
+            .build()
+            .map_err(CdpError::msg)?;
+        let response = self.execute(params).await?.result;
+
+        if let Some(exception) = response.exception_details {
+            let cleanup = remote_object_ids_for_exception(&response.result, &exception);
+            self.release_remote_objects_best_effort(cleanup).await;
+            return Err(CdpError::JavascriptException(Box::new(exception)));
+        }
+        if response.result.subtype == Some(RemoteObjectSubtype::Null) {
+            if let Some(remote_object_id) = response.result.object_id {
+                self.release_remote_objects_best_effort([remote_object_id])
+                    .await;
+            }
+            return Ok(None);
+        }
+
+        response
+            .result
+            .object_id
+            .map(Some)
+            .ok_or_else(|| CdpError::msg("Selector result did not contain a remote object id"))
+    }
+
+    async fn element_from_remote_object(&self, remote_object_id: RemoteObjectId) -> Result<Self> {
+        match self.describe_remote_object(remote_object_id.clone()).await {
+            Ok(element) => Ok(element),
+            Err(error) => {
+                self.release_remote_objects_best_effort([remote_object_id])
+                    .await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn describe_remote_object(&self, remote_object_id: RemoteObjectId) -> Result<Self> {
+        let backend_node_id = self
+            .execute(
+                DescribeNodeParams::builder()
+                    .object_id(remote_object_id.clone())
+                    .build(),
+            )
+            .await?
+            .result
+            .node
+            .backend_node_id;
+        Ok(Self::from_remote_parts(
+            Arc::clone(&self.tab),
+            remote_object_id,
+            backend_node_id,
+            self.frame_id.clone(),
+            self.session_id.clone(),
+        ))
+    }
+
+    async fn release_remote_objects_best_effort(
+        &self,
+        remote_object_ids: impl IntoIterator<Item = RemoteObjectId>,
+    ) {
+        let mut released = HashSet::new();
+        for remote_object_id in remote_object_ids {
+            if !released.insert(remote_object_id.clone()) {
+                continue;
+            }
+            if let Err(error) = self
+                .execute(ReleaseObjectParams::new(remote_object_id))
+                .await
+            {
+                tracing::warn!(%error, "failed to release temporary remote object");
+            }
+        }
     }
 
     async fn box_model(&self) -> Result<BoxModel> {
         let model = self
-            .tab
             .execute(
                 GetBoxModelParams::builder()
                     .backend_node_id(self.backend_node_id)
@@ -120,19 +380,67 @@ impl Element {
         })
     }
 
+    async fn frame_boundary_offset(&self) -> Result<Point> {
+        let snapshot = self
+            .tab
+            .frame_boundary_chain(self.frame_id.clone(), self.session_id.clone())
+            .await?;
+        let mut offset = Point::new(0.0, 0.0);
+
+        for boundary in &snapshot {
+            let owner = self
+                .tab
+                .execute_with_session(
+                    GetFrameOwnerParams::new(boundary.child_frame_id.clone()),
+                    &boundary.parent_session_id,
+                )
+                .await?
+                .result;
+            let model = self
+                .tab
+                .execute_with_session(
+                    GetBoxModelParams::builder()
+                        .backend_node_id(owner.backend_node_id)
+                        .build(),
+                    &boundary.parent_session_id,
+                )
+                .await?
+                .result
+                .model;
+            // CDP geometry is already session-root-relative. Only the content
+            // origin of an iframe that crosses into another session is added;
+            // same-session ancestors are absent from the snapshot to avoid
+            // double-counting their offsets.
+            offset = offset + ElementQuad::from_quad(&model.content).top_left;
+        }
+
+        // Re-walk the complete topology after every owner box lookup. A swap
+        // during the walk must fail before callers can dispatch input using a
+        // coordinate assembled from two different frame trees.
+        let current = self
+            .tab
+            .frame_boundary_chain(self.frame_id.clone(), self.session_id.clone())
+            .await?;
+        if current != snapshot {
+            return Err(CdpError::FrameNotReady);
+        }
+        Ok(offset)
+    }
+
     /// Returns the bounding box of the element (relative to the main frame)
     pub async fn bounding_box(&self) -> Result<BoundingBox> {
         let bounds = self.box_model().await?;
         let quad = bounds.border;
+        let offset = self.frame_boundary_offset().await?;
 
-        let x = quad.most_left();
-        let y = quad.most_top();
-        let width = quad.most_right() - x;
-        let height = quad.most_bottom() - y;
+        let local_x = quad.most_left();
+        let local_y = quad.most_top();
+        let width = quad.most_right() - local_x;
+        let height = quad.most_bottom() - local_y;
 
         Ok(BoundingBox {
-            x,
-            y,
+            x: local_x + offset.x,
+            y: local_y + offset.y,
             width,
             height,
         })
@@ -141,14 +449,14 @@ impl Element {
     /// Returns the best `Point` of this node to execute a click on.
     pub async fn clickable_point(&self) -> Result<Point> {
         let content_quads = self
-            .tab
             .execute(
                 GetContentQuadsParams::builder()
                     .backend_node_id(self.backend_node_id)
                     .build(),
             )
             .await?;
-        content_quads
+        let point = content_quads
+            .result
             .quads
             .iter()
             .filter(|q| q.inner().len() == 8)
@@ -156,7 +464,8 @@ impl Element {
             .filter(|q| q.quad_area() > 1.)
             .map(|q| q.quad_center())
             .next()
-            .ok_or_else(|| CdpError::msg("Node is either not visible or not an HTMLElement"))
+            .ok_or_else(|| CdpError::msg("Node is either not visible or not an HTMLElement"))?;
+        Ok(point + self.frame_boundary_offset().await?)
     }
 
     /// Submits a javascript function to the page and returns the evaluated
@@ -190,13 +499,14 @@ impl Element {
         function_declaration: impl Into<String>,
         await_promise: bool,
     ) -> Result<CallFunctionOnReturns> {
-        self.tab
-            .call_js_fn(
-                function_declaration,
-                await_promise,
-                self.remote_object_id.clone(),
-            )
-            .await
+        let params = CallFunctionOnParams::builder()
+            .object_id(self.remote_object_id.clone())
+            .function_declaration(function_declaration)
+            .generate_preview(true)
+            .await_promise(await_promise)
+            .build()
+            .map_err(CdpError::msg)?;
+        Ok(self.execute(params).await?.result)
     }
 
     /// Returns a JSON representation of this element.
@@ -325,7 +635,6 @@ impl Element {
     /// The description of the element's node
     pub async fn description(&self) -> Result<Node> {
         Ok(self
-            .tab
             .execute(
                 DescribeNodeParams::builder()
                     .backend_node_id(self.backend_node_id)
@@ -415,7 +724,7 @@ impl Element {
         let mut params = GetPropertiesParams::new(self.remote_object_id.clone());
         params.own_properties = Some(true);
 
-        let properties = self.tab.execute(params).await?;
+        let properties = self.execute(params).await?;
 
         Ok(properties
             .result
@@ -423,6 +732,18 @@ impl Element {
             .into_iter()
             .map(|p| (p.name.clone(), p))
             .collect())
+    }
+
+    /// Explicitly release this element's remote object in its captured CDP
+    /// session.
+    ///
+    /// `Element` clones share the same remote object id, so disposing one clone
+    /// invalidates every clone. Dropping an Element performs no asynchronous
+    /// cleanup; call this method when deterministic release is required.
+    pub async fn dispose(self) -> Result<()> {
+        self.execute(ReleaseObjectParams::new(self.remote_object_id.clone()))
+            .await?;
+        Ok(())
     }
 
     /// Scrolls the element into and takes a screenshot of it
@@ -463,6 +784,25 @@ impl Element {
     }
 }
 
+pub(crate) fn remote_object_ids_for_exception(
+    result: &RemoteObject,
+    exception: &ExceptionDetails,
+) -> Vec<RemoteObjectId> {
+    let mut object_ids = Vec::new();
+    if let Some(object_id) = result.object_id.clone() {
+        object_ids.push(object_id);
+    }
+    if let Some(object_id) = exception
+        .exception
+        .as_ref()
+        .and_then(|exception| exception.object_id.clone())
+        && !object_ids.contains(&object_id)
+    {
+        object_ids.push(object_id);
+    }
+    object_ids
+}
+
 pub type AttributeValueFuture<'a> = Option<(
     String,
     Pin<Box<dyn Future<Output = Result<Option<String>>> + 'a>>,
@@ -500,5 +840,262 @@ impl<'a> Stream for AttributeStream<'a> {
             }
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::{FutureExt, StreamExt};
+    use serde_json::json;
+
+    use chromiumoxide_cdp::cdp::browser_protocol::target::TargetId;
+    use chromiumoxide_types::{CallId, Response};
+
+    use super::*;
+    use crate::handler::PageHandle;
+    use crate::handler::target::{FrameBoundary, InternalTargetMessage};
+
+    fn ok_response(result: serde_json::Value) -> Response {
+        Response {
+            id: CallId::new(1),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn remote_object(object_id: &str) -> RemoteObject {
+        RemoteObject::builder()
+            .r#type(RemoteObjectType::Object)
+            .object_id(RemoteObjectId::new(object_id))
+            .build()
+            .expect("remote object fixture is complete")
+    }
+
+    #[test]
+    fn element_exception_cleanup_collects_both_distinct_object_ids() {
+        let result = remote_object("result");
+        let mut exception = ExceptionDetails::new(1, "boom", 0, 0);
+        exception.exception = Some(remote_object("exception"));
+
+        assert_eq!(
+            remote_object_ids_for_exception(&result, &exception),
+            vec![
+                RemoteObjectId::new("result"),
+                RemoteObjectId::new("exception")
+            ]
+        );
+    }
+
+    #[test]
+    fn element_exception_cleanup_deduplicates_shared_object_id() {
+        let result = remote_object("shared");
+        let mut exception = ExceptionDetails::new(1, "boom", 0, 0);
+        exception.exception = Some(remote_object("shared"));
+
+        assert_eq!(
+            remote_object_ids_for_exception(&result, &exception),
+            vec![RemoteObjectId::new("shared")]
+        );
+    }
+
+    #[tokio::test]
+    async fn element_click_rejects_changed_boundary_snapshot_before_input_dispatch() {
+        let mut page_handle =
+            PageHandle::new(TargetId::new("target"), SessionId::new("child"), None);
+        let element = Element::from_remote_parts(
+            Arc::clone(page_handle.inner()),
+            RemoteObjectId::new("element"),
+            BackendNodeId::new(7),
+            FrameId::new("child-frame"),
+            SessionId::new("child"),
+        );
+        let snapshot = vec![FrameBoundary {
+            child_frame_id: FrameId::new("child-frame"),
+            child_session_id: SessionId::new("child"),
+            parent_frame_id: FrameId::new("main-frame"),
+            parent_session_id: SessionId::new("parent"),
+        }];
+        let mut changed_snapshot = snapshot.clone();
+        changed_snapshot[0].parent_session_id = SessionId::new("new-parent");
+
+        let controller = async {
+            let InternalTargetMessage::SessionCommand {
+                session_id,
+                command,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("scroll command is sent")
+            else {
+                panic!("expected scroll session command")
+            };
+            assert_eq!(session_id, SessionId::new("child"));
+            assert_eq!(command.method.as_ref(), CallFunctionOnParams::IDENTIFIER);
+            command
+                .sender
+                .send(Ok(ok_response(json!({
+                    "result": { "type": "boolean", "value": false }
+                }))))
+                .expect("scroll response receiver remains live");
+
+            let InternalTargetMessage::SessionCommand {
+                session_id,
+                command,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("quad command is sent")
+            else {
+                panic!("expected quad session command")
+            };
+            assert_eq!(session_id, SessionId::new("child"));
+            assert_eq!(command.method.as_ref(), GetContentQuadsParams::IDENTIFIER);
+            command
+                .sender
+                .send(Ok(ok_response(json!({
+                    "quads": [[0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0]]
+                }))))
+                .expect("quad response receiver remains live");
+
+            let InternalTargetMessage::GetFrameBoundaryChain {
+                frame_id,
+                expected_session_id,
+                tx,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("initial boundary query is sent")
+            else {
+                panic!("expected initial boundary query")
+            };
+            assert_eq!(frame_id, FrameId::new("child-frame"));
+            assert_eq!(expected_session_id, SessionId::new("child"));
+            tx.send(Ok(snapshot.clone()))
+                .expect("initial boundary receiver remains live");
+
+            let InternalTargetMessage::SessionCommand {
+                session_id,
+                command,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("frame owner command is sent")
+            else {
+                panic!("expected frame owner session command")
+            };
+            assert_eq!(session_id, SessionId::new("parent"));
+            assert_eq!(command.method.as_ref(), GetFrameOwnerParams::IDENTIFIER);
+            command
+                .sender
+                .send(Ok(ok_response(json!({ "backendNodeId": 9 }))))
+                .expect("frame owner response receiver remains live");
+
+            let InternalTargetMessage::SessionCommand {
+                session_id,
+                command,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("owner box command is sent")
+            else {
+                panic!("expected owner box session command")
+            };
+            assert_eq!(session_id, SessionId::new("parent"));
+            assert_eq!(command.method.as_ref(), GetBoxModelParams::IDENTIFIER);
+            command
+                .sender
+                .send(Ok(ok_response(json!({
+                    "model": {
+                        "content": [10.0, 20.0, 20.0, 20.0, 20.0, 30.0, 10.0, 30.0],
+                        "padding": [10.0, 20.0, 20.0, 20.0, 20.0, 30.0, 10.0, 30.0],
+                        "border": [10.0, 20.0, 20.0, 20.0, 20.0, 30.0, 10.0, 30.0],
+                        "margin": [10.0, 20.0, 20.0, 20.0, 20.0, 30.0, 10.0, 30.0],
+                        "width": 10,
+                        "height": 10
+                    }
+                }))))
+                .expect("owner box response receiver remains live");
+
+            let InternalTargetMessage::GetFrameBoundaryChain { tx, .. } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("boundary re-check is sent")
+            else {
+                panic!("expected boundary re-check")
+            };
+            tx.send(Ok(changed_snapshot))
+                .expect("boundary re-check receiver remains live");
+        };
+
+        let (click_result, ()) = tokio::time::timeout(Duration::from_secs(1), async {
+            futures::join!(element.click(), controller)
+        })
+        .await
+        .expect("changed topology fails without waiting for input");
+        assert!(matches!(click_result, Err(CdpError::FrameNotReady)));
+        assert!(
+            page_handle.rx.next().now_or_never().is_none(),
+            "no Input command may be sent after a failed boundary re-check"
+        );
+    }
+
+    #[tokio::test]
+    async fn element_dispose_releases_on_the_captured_session() {
+        let mut page_handle =
+            PageHandle::new(TargetId::new("target"), SessionId::new("main"), None);
+        let element = Element::from_remote_parts(
+            Arc::clone(page_handle.inner()),
+            RemoteObjectId::new("element"),
+            BackendNodeId::new(7),
+            FrameId::new("child-frame"),
+            SessionId::new("child"),
+        );
+
+        let controller = async {
+            let InternalTargetMessage::SessionCommand {
+                session_id,
+                command,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("dispose command is sent")
+            else {
+                panic!("expected dispose session command")
+            };
+            assert_eq!(session_id, SessionId::new("child"));
+            assert_eq!(command.method.as_ref(), ReleaseObjectParams::IDENTIFIER);
+            assert_eq!(command.params["objectId"], "element");
+            command
+                .sender
+                .send(Ok(ok_response(json!({}))))
+                .expect("dispose response receiver remains live");
+        };
+
+        let (dispose_result, ()) = futures::join!(element.dispose(), controller);
+        dispose_result.expect("dispose succeeds");
+    }
+
+    #[test]
+    fn element_drop_does_not_send_an_implicit_release() {
+        let mut page_handle =
+            PageHandle::new(TargetId::new("target"), SessionId::new("main"), None);
+        let element = Element::from_remote_parts(
+            Arc::clone(page_handle.inner()),
+            RemoteObjectId::new("element"),
+            BackendNodeId::new(7),
+            FrameId::new("child-frame"),
+            SessionId::new("child"),
+        );
+        drop(element);
+        assert!(page_handle.internal_rx.next().now_or_never().is_none());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ use chromiumoxide_cdp::cdp::js_protocol::runtime::ExceptionDetails;
 pub type Result<T, E = CdpError> = std::result::Result<T, E>;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum CdpError {
     #[error("{0}")]
     Ws(#[from] tungstenite::Error),
@@ -47,6 +48,18 @@ pub enum CdpError {
     Timeout,
     #[error("FrameId {0:?} not found.")]
     FrameNotFound(FrameId),
+    /// The frame still has an identity, but its captured CDP session is no
+    /// longer usable or has not finished initializing yet.
+    #[error("The frame is not ready for session-scoped operations.")]
+    FrameNotReady,
+    /// Only one managed paused-request responder may own the response stream
+    /// for a page at a time.
+    #[error("A paused-request responder is already registered for this page.")]
+    PausedRequestResponderAlreadyRegistered,
+    /// An operation was rejected because it is not supported through the
+    /// entry point it was submitted to. The message names the supported path.
+    #[error("{0}")]
+    NotAllowed(String),
     /// Error message related to a cdp response that is not a
     /// `chromiumoxide_types::Error`
     #[error("{0}")]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,0 +1,620 @@
+use std::sync::{Arc, RwLock};
+
+use futures::SinkExt;
+use futures::channel::oneshot::channel as oneshot_channel;
+
+use chromiumoxide_cdp::cdp::browser_protocol::dom::DescribeNodeParams;
+use chromiumoxide_cdp::cdp::browser_protocol::page::{FrameId, NavigateParams, NavigateReturns};
+use chromiumoxide_cdp::cdp::browser_protocol::target::SessionId;
+use chromiumoxide_cdp::cdp::js_protocol::runtime::{
+    CallArgument, CallFunctionOnParams, EvaluateParams, ExecutionContextId, ReleaseObjectParams,
+    RemoteObjectId, RemoteObjectSubtype, RemoteObjectType,
+};
+use chromiumoxide_types::{Command, CommandResponse, Method, Request};
+
+use crate::cmd::{CommandMessage, to_command_response};
+use crate::element::{Element, remote_object_ids_for_exception};
+use crate::error::{CdpError, Result};
+use crate::handler::PageInner;
+use crate::handler::domworld::DOMWorldKind;
+use crate::handler::frame::FrameWaitError;
+use crate::handler::target::{ExecutionContextInfo, FrameInfo, InternalTargetMessage};
+use crate::js::{Evaluation, EvaluationResult};
+
+/// A frame handle pinned to the CDP session that owned the frame when the
+/// handle was created.
+///
+/// Process swaps do not retarget existing handles. Operations on a handle
+/// whose frame has moved to another session fail with [`CdpError::FrameNotReady`];
+/// obtain a fresh handle from [`crate::Page::all_frames`] or
+/// [`crate::Page::frame_by_id`] and retry.
+#[derive(Debug, Clone)]
+pub struct Frame {
+    inner: Arc<FrameInner>,
+}
+
+#[derive(Debug)]
+pub(crate) struct FrameInner {
+    frame_id: FrameId,
+    session_id: SessionId,
+    main_session_id: SessionId,
+    parent_id: Option<FrameId>,
+    security_origin: String,
+    tab: Arc<PageInner>,
+    cached_url: RwLock<Option<String>>,
+}
+
+impl Frame {
+    pub(crate) fn from_info(tab: Arc<PageInner>, info: FrameInfo) -> Self {
+        Self {
+            inner: Arc::new(FrameInner {
+                frame_id: info.frame_id,
+                session_id: info.session_id,
+                main_session_id: info.main_session_id,
+                parent_id: info.parent_id,
+                security_origin: info.security_origin,
+                tab,
+                cached_url: RwLock::new(info.url),
+            }),
+        }
+    }
+
+    /// The stable CDP frame identifier.
+    pub fn id(&self) -> &FrameId {
+        &self.inner.frame_id
+    }
+
+    /// The CDP session captured when this handle was created.
+    pub fn session_id(&self) -> &SessionId {
+        &self.inner.session_id
+    }
+
+    /// The effective CDP session captured when this handle was created.
+    pub fn effective_session_id(&self) -> &SessionId {
+        self.session_id()
+    }
+
+    /// The parent frame identifier captured when this handle was created.
+    pub fn parent_id(&self) -> Option<&FrameId> {
+        self.inner.parent_id.as_ref()
+    }
+
+    /// Whether this handle represents the page's main frame.
+    pub fn is_main_frame(&self) -> bool {
+        self.inner.parent_id.is_none()
+    }
+
+    /// Whether this frame is owned by a child target session.
+    pub fn is_out_of_process(&self) -> bool {
+        self.inner.session_id != self.inner.main_session_id
+    }
+
+    /// The security origin captured when this handle was created.
+    pub fn security_origin(&self) -> &str {
+        &self.inner.security_origin
+    }
+
+    /// The URL captured when this handle was created or last refreshed.
+    pub fn url(&self) -> Option<String> {
+        self.inner
+            .cached_url
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Re-query the current URL for this frame identifier.
+    ///
+    /// Unlike [`Frame::eval`], [`Frame::goto`], [`Frame::query_selector`], and
+    /// [`Frame::wait_for_navigation`] — which are pinned to this handle's
+    /// captured session and fail with [`CdpError::FrameNotReady`] once the frame
+    /// has swapped away — this reads whichever session currently owns the frame
+    /// id and follows it. On a stale handle it therefore returns the URL of the
+    /// frame's new binding rather than an error, and refreshes the cached URL to
+    /// match. It is a best-effort current-state read, not a stale-handle guard.
+    pub async fn fetch_url(&self) -> Result<Option<String>> {
+        let url = self
+            .inner
+            .tab
+            .frame_info(self.inner.frame_id.clone())
+            .await?
+            .and_then(|info| info.url);
+        *self
+            .inner
+            .cached_url
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = url.clone();
+        Ok(url)
+    }
+
+    /// Execute a raw CDP command on the captured frame session.
+    ///
+    /// `Page.navigate` is intentionally rejected here: raw execution loses the
+    /// frame identity needed to register a navigation watcher and would
+    /// misroute to the page's main frame. Navigate with [`Frame::goto`], which
+    /// pins both the frame and its session. Rejection is immediate and produces
+    /// no queued event or CDP request.
+    pub async fn execute<T: Command>(&self, cmd: T) -> Result<CommandResponse<T::Response>> {
+        let (tx, rx) = oneshot_channel();
+        let method = cmd.identifier();
+        if method.as_ref() == NavigateParams::IDENTIFIER {
+            return Err(CdpError::NotAllowed(
+                "Page.navigate is not supported through Frame::execute; use Frame::goto instead"
+                    .to_owned(),
+            ));
+        }
+        let command = CommandMessage::with_session(cmd, tx, Some(self.inner.session_id.clone()))?;
+        self.inner
+            .tab
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::FrameCommand {
+                frame_id: self.inner.frame_id.clone(),
+                expected_session_id: self.inner.session_id.clone(),
+                command,
+            })
+            .await?;
+        let response = rx.await??;
+        to_command_response::<T>(response, method)
+    }
+
+    /// Evaluate JavaScript in this frame's main execution context.
+    pub async fn eval(&self, evaluation: impl Into<Evaluation>) -> Result<EvaluationResult> {
+        match evaluation.into() {
+            Evaluation::Expression(expression) => self.evaluate_expression(expression).await,
+            Evaluation::Function(function) => self.evaluate_function(function).await,
+        }
+    }
+
+    /// Query the first element in this frame's pinned main execution context.
+    ///
+    /// The returned Element keeps the remote object in this Frame handle's
+    /// captured session and has no document-scoped `NodeId`.
+    pub async fn query_selector(&self, selector: &str) -> Result<Option<Element>> {
+        let context = self.pinned_execution_context().await?;
+        let params = CallFunctionOnParams::builder()
+            .function_declaration("function(sel) { return document.querySelector(sel); }")
+            .argument(CallArgument::builder().value(selector).build())
+            .return_by_value(false)
+            .execution_context_id(context.context_id)
+            .build()
+            .map_err(CdpError::msg)?;
+        let response = self.execute(params).await?.result;
+
+        if let Some(exception) = response.exception_details {
+            let cleanup = remote_object_ids_for_exception(&response.result, &exception);
+            self.release_remote_objects_best_effort(cleanup).await;
+            return Err(CdpError::JavascriptException(Box::new(exception)));
+        }
+        if response.result.subtype == Some(RemoteObjectSubtype::Null) {
+            if let Some(remote_object_id) = response.result.object_id {
+                self.release_remote_objects_best_effort([remote_object_id])
+                    .await;
+            }
+            return Ok(None);
+        }
+
+        let remote_object_id = response
+            .result
+            .object_id
+            .ok_or_else(|| CdpError::msg("Selector result did not contain a remote object id"))?;
+        let described = self
+            .execute(
+                DescribeNodeParams::builder()
+                    .object_id(remote_object_id.clone())
+                    .build(),
+            )
+            .await;
+        let backend_node_id = match described {
+            Ok(response) => response.result.node.backend_node_id,
+            Err(error) => {
+                self.release_remote_objects_best_effort([remote_object_id])
+                    .await;
+                return Err(error);
+            }
+        };
+
+        Ok(Some(Element::from_remote_parts(
+            Arc::clone(&self.inner.tab),
+            remote_object_id,
+            backend_node_id,
+            self.inner.frame_id.clone(),
+            self.inner.session_id.clone(),
+        )))
+    }
+
+    /// Navigate this frame and wait for its load lifecycle to complete.
+    pub async fn goto(&self, url: impl Into<String>) -> Result<NavigateReturns> {
+        let params = NavigateParams::new(url);
+        let method = params.identifier();
+        let request = Request::with_session(
+            method.clone(),
+            serde_json::to_value(params)?,
+            self.inner.session_id.as_ref(),
+        );
+        let (tx, rx) = oneshot_channel();
+        self.inner
+            .tab
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::FrameNavigate {
+                frame_id: self.inner.frame_id.clone(),
+                session_id: self.inner.session_id.clone(),
+                req: request,
+                tx,
+            })
+            .await?;
+        let response = rx.await??;
+        Ok(to_command_response::<NavigateParams>(response, method)?.result)
+    }
+
+    /// Wait for the next new-document navigation of this frame.
+    pub async fn wait_for_navigation(&self) -> Result<()> {
+        let (tx, rx) = oneshot_channel();
+        self.inner
+            .tab
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::FrameWaitForNavigation {
+                frame_id: self.inner.frame_id.clone(),
+                session_id: self.inner.session_id.clone(),
+                tx,
+            })
+            .await?;
+        match rx.await? {
+            Ok(()) => Ok(()),
+            Err(FrameWaitError::Timeout) => Err(CdpError::Timeout),
+            Err(FrameWaitError::FrameSwappedOrDetached) => Err(CdpError::FrameNotReady),
+            Err(FrameWaitError::FrameNotFound { frame }) => Err(CdpError::FrameNotFound(frame)),
+            Err(FrameWaitError::NavigationFailed(message)) => Err(CdpError::ChromeMessage(message)),
+        }
+    }
+
+    /// Return currently bound direct child frames.
+    pub async fn child_frames(&self) -> Result<Vec<Frame>> {
+        Ok(self
+            .inner
+            .tab
+            .all_frames()
+            .await?
+            .into_iter()
+            .filter(|frame| frame.parent_id() == Some(self.id()))
+            .collect())
+    }
+
+    /// Return the currently bound parent frame, if any.
+    pub async fn parent(&self) -> Result<Option<Frame>> {
+        let Some(parent_id) = self.parent_id().cloned() else {
+            return Ok(None);
+        };
+        self.inner.tab.frame_by_id(parent_id).await
+    }
+
+    async fn pinned_execution_context(&self) -> Result<ExecutionContextInfo> {
+        let (tx, rx) = oneshot_channel();
+        self.inner
+            .tab
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::GetPinnedExecutionContext {
+                dom_world: DOMWorldKind::Main,
+                frame_id: self.inner.frame_id.clone(),
+                expected_session_id: self.inner.session_id.clone(),
+                tx,
+            })
+            .await?;
+        let context = rx.await??.ok_or(CdpError::FrameNotReady)?;
+        if context.session_id != self.inner.session_id {
+            return Err(CdpError::FrameNotReady);
+        }
+        Ok(context)
+    }
+
+    async fn evaluate_expression(
+        &self,
+        mut expression: EvaluateParams,
+    ) -> Result<EvaluationResult> {
+        let context_id = self.pinned_context_id().await?;
+        expression.context_id = Some(context_id);
+        if expression.await_promise.is_none() {
+            expression.await_promise = Some(true);
+        }
+        if expression.return_by_value.is_none() {
+            expression.return_by_value = Some(true);
+        }
+        let fallback = expression
+            .eval_as_function_fallback
+            .is_some_and(|enabled| enabled)
+            .then(|| expression.clone());
+        let response = self.execute(expression).await?.result;
+        if let Some(exception) = response.exception_details {
+            return Err(CdpError::JavascriptException(Box::new(exception)));
+        }
+        let result = EvaluationResult::new(response.result);
+        if result.object().r#type == RemoteObjectType::Function {
+            if let Some(fallback) = fallback {
+                return self.evaluate_function(fallback.into()).await;
+            }
+        }
+        Ok(result)
+    }
+
+    async fn evaluate_function(
+        &self,
+        mut function: CallFunctionOnParams,
+    ) -> Result<EvaluationResult> {
+        let context_id = self.pinned_context_id().await?;
+        function.execution_context_id = Some(context_id);
+        if function.await_promise.is_none() {
+            function.await_promise = Some(true);
+        }
+        if function.return_by_value.is_none() {
+            function.return_by_value = Some(true);
+        }
+        let response = self.execute(function).await?.result;
+        if let Some(exception) = response.exception_details {
+            return Err(CdpError::JavascriptException(Box::new(exception)));
+        }
+        Ok(EvaluationResult::new(response.result))
+    }
+
+    async fn pinned_context_id(&self) -> Result<ExecutionContextId> {
+        Ok(self.pinned_execution_context().await?.context_id)
+    }
+
+    async fn release_remote_objects_best_effort(
+        &self,
+        remote_object_ids: impl IntoIterator<Item = RemoteObjectId>,
+    ) {
+        for remote_object_id in remote_object_ids {
+            if let Err(error) = self
+                .execute(ReleaseObjectParams::new(remote_object_id))
+                .await
+            {
+                // Cleanup must never replace the selector's original protocol
+                // or JavaScript error, especially during a concurrent swap.
+                tracing::warn!(%error, "failed to release temporary frame remote object");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{FutureExt, StreamExt};
+    use serde_json::json;
+
+    use chromiumoxide_cdp::cdp::browser_protocol::target::TargetId;
+    use chromiumoxide_types::{CallId, Response};
+
+    use super::*;
+    use crate::handler::PageHandle;
+
+    fn test_frame() -> (Frame, PageHandle) {
+        let page_handle = PageHandle::new(TargetId::new("target"), SessionId::new("main"), None);
+        let frame = Frame::from_info(
+            Arc::clone(page_handle.inner()),
+            FrameInfo {
+                frame_id: FrameId::new("child-frame"),
+                session_id: SessionId::new("child"),
+                main_session_id: SessionId::new("main"),
+                parent_id: Some(FrameId::new("main-frame")),
+                url: Some("https://child.example/".to_owned()),
+                security_origin: "https://child.example".to_owned(),
+            },
+        );
+        (frame, page_handle)
+    }
+
+    fn ok_response(result: serde_json::Value) -> Response {
+        Response {
+            id: CallId::new(1),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    async fn answer_pinned_context(page_handle: &mut PageHandle) {
+        let InternalTargetMessage::GetPinnedExecutionContext {
+            frame_id,
+            expected_session_id,
+            tx,
+            ..
+        } = page_handle
+            .internal_rx
+            .next()
+            .await
+            .expect("pinned context query is sent")
+        else {
+            panic!("expected pinned execution-context query")
+        };
+        assert_eq!(frame_id, FrameId::new("child-frame"));
+        assert_eq!(expected_session_id, SessionId::new("child"));
+        tx.send(Ok(Some(ExecutionContextInfo {
+            context_id: ExecutionContextId::new(42),
+            session_id: SessionId::new("child"),
+        })))
+        .expect("pinned context receiver remains live");
+    }
+
+    async fn answer_selector_call(page_handle: &mut PageHandle, result: serde_json::Value) {
+        let InternalTargetMessage::FrameCommand {
+            frame_id,
+            expected_session_id,
+            command,
+        } = page_handle
+            .internal_rx
+            .next()
+            .await
+            .expect("selector command is sent")
+        else {
+            panic!("expected selector frame command")
+        };
+        assert_eq!(frame_id, FrameId::new("child-frame"));
+        assert_eq!(expected_session_id, SessionId::new("child"));
+        assert_eq!(command.method.as_ref(), CallFunctionOnParams::IDENTIFIER);
+        assert_eq!(
+            command.params["functionDeclaration"],
+            "function(sel) { return document.querySelector(sel); }"
+        );
+        assert_eq!(command.params["arguments"][0]["value"], "#target");
+        assert_eq!(command.params["returnByValue"], false);
+        assert_eq!(command.params["executionContextId"], 42);
+        command
+            .sender
+            .send(Ok(ok_response(result)))
+            .expect("selector response receiver remains live");
+    }
+
+    #[tokio::test]
+    async fn frame_query_selector_returns_none_for_null() {
+        let (frame, mut page_handle) = test_frame();
+        let controller = async {
+            answer_pinned_context(&mut page_handle).await;
+            answer_selector_call(
+                &mut page_handle,
+                json!({
+                    "result": {
+                        "type": "object",
+                        "subtype": "null",
+                        "value": null
+                    }
+                }),
+            )
+            .await;
+        };
+
+        let (result, ()) = futures::join!(frame.query_selector("#target"), controller);
+        assert!(result.expect("null selector succeeds").is_none());
+        assert!(page_handle.internal_rx.next().now_or_never().is_none());
+    }
+
+    #[tokio::test]
+    async fn frame_query_selector_describes_the_remote_node_on_the_pinned_path() {
+        let (frame, mut page_handle) = test_frame();
+        let controller = async {
+            answer_pinned_context(&mut page_handle).await;
+            answer_selector_call(
+                &mut page_handle,
+                json!({
+                    "result": {
+                        "type": "object",
+                        "subtype": "node",
+                        "objectId": "node"
+                    }
+                }),
+            )
+            .await;
+
+            let InternalTargetMessage::FrameCommand {
+                frame_id,
+                expected_session_id,
+                command,
+            } = page_handle
+                .internal_rx
+                .next()
+                .await
+                .expect("describe command is sent")
+            else {
+                panic!("expected describe frame command")
+            };
+            assert_eq!(frame_id, FrameId::new("child-frame"));
+            assert_eq!(expected_session_id, SessionId::new("child"));
+            assert_eq!(command.method.as_ref(), DescribeNodeParams::IDENTIFIER);
+            assert_eq!(command.params["objectId"], "node");
+            command
+                .sender
+                .send(Ok(ok_response(json!({
+                    "node": {
+                        "nodeId": 0,
+                        "backendNodeId": 7,
+                        "nodeType": 1,
+                        "nodeName": "BUTTON",
+                        "localName": "button",
+                        "nodeValue": ""
+                    }
+                }))))
+                .expect("describe response receiver remains live");
+        };
+
+        let (result, ()) = futures::join!(frame.query_selector("#target"), controller);
+        let element = result
+            .expect("selector succeeds")
+            .expect("selector returns an element");
+        assert_eq!(element.remote_object_id, RemoteObjectId::new("node"));
+        assert_eq!(
+            element.backend_node_id,
+            chromiumoxide_cdp::cdp::browser_protocol::dom::BackendNodeId::new(7)
+        );
+        assert!(element.node_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn frame_query_selector_releases_both_exception_object_ids() {
+        let (frame, mut page_handle) = test_frame();
+        let controller = async {
+            answer_pinned_context(&mut page_handle).await;
+            answer_selector_call(
+                &mut page_handle,
+                json!({
+                    "result": { "type": "object", "objectId": "result" },
+                    "exceptionDetails": {
+                        "exceptionId": 1,
+                        "text": "boom",
+                        "lineNumber": 0,
+                        "columnNumber": 0,
+                        "exception": { "type": "object", "objectId": "exception" }
+                    }
+                }),
+            )
+            .await;
+
+            for expected_object_id in ["result", "exception"] {
+                let InternalTargetMessage::FrameCommand {
+                    frame_id,
+                    expected_session_id,
+                    command,
+                } = page_handle
+                    .internal_rx
+                    .next()
+                    .await
+                    .expect("cleanup command is sent")
+                else {
+                    panic!("expected cleanup frame command")
+                };
+                assert_eq!(frame_id, FrameId::new("child-frame"));
+                assert_eq!(expected_session_id, SessionId::new("child"));
+                assert_eq!(command.method.as_ref(), ReleaseObjectParams::IDENTIFIER);
+                assert_eq!(command.params["objectId"], expected_object_id);
+                command
+                    .sender
+                    .send(Ok(ok_response(json!({}))))
+                    .expect("cleanup response receiver remains live");
+            }
+        };
+
+        let (result, ()) = futures::join!(frame.query_selector("#target"), controller);
+        assert!(matches!(result, Err(CdpError::JavascriptException(_))));
+    }
+
+    #[tokio::test]
+    async fn frame_execute_rejects_navigate_without_emitting_work() {
+        let (frame, mut page_handle) = test_frame();
+        let result = frame
+            .execute(NavigateParams::new("https://child.example/next"))
+            .await;
+        match result {
+            Err(CdpError::NotAllowed(message)) => {
+                assert!(
+                    message.contains("Frame::goto"),
+                    "message names the supported path: {message}"
+                );
+            }
+            Err(other) => panic!("expected NotAllowed rejection, got {other:?}"),
+            Ok(_) => panic!("expected NotAllowed rejection, got Ok"),
+        }
+        // The rejection must be immediate: no FrameCommand/FrameNavigate event
+        // and therefore no CDP request may reach the target.
+        assert!(page_handle.internal_rx.next().now_or_never().is_none());
+    }
+}

--- a/src/handler/emulation.rs
+++ b/src/handler/emulation.rs
@@ -2,7 +2,7 @@ use chromiumoxide_cdp::cdp::browser_protocol::emulation::{
     ScreenOrientation, ScreenOrientationType, SetDeviceMetricsOverrideParams,
     SetTouchEmulationEnabledParams,
 };
-use chromiumoxide_types::Method;
+use chromiumoxide_types::{Method, MethodId};
 
 use crate::cmd::CommandChain;
 use crate::handler::viewport::Viewport;
@@ -27,6 +27,16 @@ impl EmulationManager {
     }
 
     pub fn init_commands(&mut self, viewport: &Viewport) -> CommandChain {
+        let cmds = Self::viewport_commands(viewport);
+
+        let chain = CommandChain::new(cmds, self.request_timeout);
+
+        self.needs_reload = self.emulating_mobile != viewport.emulating_mobile
+            || self.has_touch != viewport.has_touch;
+        chain
+    }
+
+    pub(crate) fn viewport_commands(viewport: &Viewport) -> Vec<(MethodId, serde_json::Value)> {
         let orientation = if viewport.is_landscape {
             ScreenOrientation::new(ScreenOrientationType::LandscapePrimary, 90)
         } else {
@@ -44,22 +54,15 @@ impl EmulationManager {
 
         let set_touch = SetTouchEmulationEnabledParams::new(true);
 
-        let chain = CommandChain::new(
-            vec![
-                (
-                    set_device.identifier(),
-                    serde_json::to_value(set_device).unwrap(),
-                ),
-                (
-                    set_touch.identifier(),
-                    serde_json::to_value(set_touch).unwrap(),
-                ),
-            ],
-            self.request_timeout,
-        );
-
-        self.needs_reload = self.emulating_mobile != viewport.emulating_mobile
-            || self.has_touch != viewport.has_touch;
-        chain
+        vec![
+            (
+                set_device.identifier(),
+                serde_json::to_value(set_device).unwrap(),
+            ),
+            (
+                set_touch.identifier(),
+                serde_json::to_value(set_touch).unwrap(),
+            ),
+        ]
     }
 }

--- a/src/handler/frame.rs
+++ b/src/handler/frame.rs
@@ -3,15 +3,17 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use futures::channel::oneshot::Sender as OneshotSender;
 use serde_json::map::Entry;
 
 use chromiumoxide_cdp::cdp::browser_protocol::network::LoaderId;
 use chromiumoxide_cdp::cdp::browser_protocol::page::{
     AddScriptToEvaluateOnNewDocumentParams, CreateIsolatedWorldParams, EventFrameDetached,
     EventFrameStartedLoading, EventFrameStoppedLoading, EventLifecycleEvent,
-    EventNavigatedWithinDocument, Frame as CdpFrame, FrameTree,
+    EventNavigatedWithinDocument, Frame as CdpFrame, FrameDetachedReason, FrameTree,
+    ScriptIdentifier,
 };
-use chromiumoxide_cdp::cdp::browser_protocol::target::EventAttachedToTarget;
+use chromiumoxide_cdp::cdp::browser_protocol::target::{EventAttachedToTarget, SessionId};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::*;
 use chromiumoxide_cdp::cdp::{
     browser_protocol::page::{self, FrameId},
@@ -19,13 +21,14 @@ use chromiumoxide_cdp::cdp::{
 };
 use chromiumoxide_types::{Method, MethodId, Request};
 
-use crate::error::DeadlineExceeded;
+use crate::error::{CdpError, DeadlineExceeded, Result};
 use crate::handler::REQUEST_TIMEOUT;
 use crate::handler::domworld::DOMWorld;
 use crate::handler::http::HttpRequest;
 use crate::{ArcHttpRequest, cmd::CommandChain};
 
 pub const UTILITY_WORLD_NAME: &str = "__chromiumoxide_utility_world__";
+pub(crate) const HTTP_RESPONSE_CODE_FAILURE: &str = "net::ERR_HTTP_RESPONSE_CODE_FAILURE";
 const EVALUATION_SCRIPT_URL: &str = "____chromiumoxide_utility_world___evaluation_script__";
 
 /// Represents a frame on the page
@@ -44,6 +47,11 @@ pub struct Frame {
     /// The frames contained in this frame
     child_frames: HashSet<FrameId>,
     name: Option<String>,
+    /// Session that currently owns this frame. `None` is a real transient
+    /// unbound state and must never be serialized as an empty session id.
+    session_id: Option<SessionId>,
+    /// Last security origin reported by `Page.frameNavigated`.
+    security_origin: String,
     /// The received lifecycle events
     lifecycle_events: HashSet<MethodId>,
 }
@@ -60,6 +68,8 @@ impl Frame {
             http_request: None,
             child_frames: Default::default(),
             name: None,
+            session_id: None,
+            security_origin: String::new(),
             lifecycle_events: Default::default(),
         }
     }
@@ -76,6 +86,8 @@ impl Frame {
             http_request: None,
             child_frames: Default::default(),
             name: None,
+            session_id: None,
+            security_origin: String::new(),
             lifecycle_events: Default::default(),
         }
     }
@@ -94,6 +106,33 @@ impl Frame {
 
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
+    }
+
+    pub(crate) fn session_id(&self) -> Option<&SessionId> {
+        self.session_id.as_ref()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn require_session_id(&self) -> Result<&SessionId> {
+        self.session_id.as_ref().ok_or(CdpError::FrameNotReady)
+    }
+
+    pub(crate) fn set_session_id(&mut self, session_id: SessionId) {
+        if self.session_id.as_ref() != Some(&session_id) {
+            self.clear_contexts();
+        }
+        self.session_id = Some(session_id);
+    }
+
+    pub(crate) fn is_out_of_process(&self, main_session_id: &SessionId) -> bool {
+        self.session_id
+            .as_ref()
+            .is_some_and(|session_id| session_id != main_session_id)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn security_origin(&self) -> &str {
+        &self.security_origin
     }
 
     pub fn main_world(&self) -> &DOMWorld {
@@ -120,6 +159,7 @@ impl Frame {
             frame.url.clone()
         };
         self.url = Some(url);
+        self.security_origin.clone_from(&frame.security_origin);
     }
 
     fn navigated_within_url(&mut self, url: String) {
@@ -174,6 +214,8 @@ impl From<CdpFrame> for Frame {
             http_request: None,
             child_frames: Default::default(),
             name: frame.name,
+            session_id: None,
+            security_origin: frame.security_origin,
             lifecycle_events: Default::default(),
         }
     }
@@ -182,20 +224,99 @@ impl From<CdpFrame> for Frame {
 /// Maintains the state of the pages frame and listens to events produced by
 /// chromium targeting the `Target`. Also listens for events that indicate that
 /// a navigation was completed
+type NavigationKey = (Option<SessionId>, FrameId);
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum NavigationCompletion {
+    SameDocument,
+    NewDocument,
+}
+
+#[derive(Debug)]
+struct NavigationEntry {
+    watcher: Option<NavigationWatcher>,
+    /// Loader captured before an anticipated navigation begins.
+    pre_loader_id: Option<LoaderId>,
+    deadline: Instant,
+    waiters: Vec<OneshotSender<std::result::Result<(), FrameWaitError>>>,
+}
+
+/// The `(session, numeric context id)` pair that uniquely identifies a live
+/// execution context. Numeric context ids are only unique inside a CDP session,
+/// and Chrome reuses them, so both fields are required.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ContextKey {
+    session_id: SessionId,
+    context_id: ExecutionContextId,
+}
+
+/// The frame a [`ContextKey`] currently maps to, tagged with the CDP unique id
+/// that created the mapping. The unique id lets a late `executionContextDestroyed`
+/// (whose numeric id may already have been reused by another context on the same
+/// frame) delete only the mapping it actually created.
+#[derive(Debug, Clone)]
+struct ContextBinding {
+    /// The mapping's payload: the frame owning this `(session, numeric)` key.
+    /// Not yet read on any production path (the forward map is write-only in
+    /// Phase 1); tests assert it, and Phase 2 context->frame routing will read
+    /// it. Kept checked in test builds, silenced in release until a reader lands.
+    #[cfg_attr(not(test), allow(dead_code))]
+    frame_id: FrameId,
+    unique_id: String,
+}
+
+/// Reverse-index entry: the frame owning a CDP unique context id, plus the
+/// forward `(session, numeric)` key when the context is session-bound. The
+/// legacy pre-OOPIF path has no session and therefore no forward key.
+#[derive(Debug, Clone)]
+struct UniqueContext {
+    frame_id: FrameId,
+    key: Option<ContextKey>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum IsolatedWorldState {
+    Pending,
+    Confirmed,
+}
+
 #[derive(Debug)]
 pub struct FrameManager {
     main_frame: Option<FrameId>,
     frames: HashMap<FrameId, Frame>,
-    /// The contexts mapped with their frames
-    context_ids: HashMap<String, FrameId>,
-    isolated_worlds: HashSet<String>,
+    /// Reverse index: CDP unique context id -> owning frame and, when bound, its
+    /// `(session, numeric)` key. Destroy events carry only the unique id, so
+    /// this resolves both the frame and the forward key to delete.
+    context_by_unique: HashMap<String, UniqueContext>,
+    /// Numeric context ids are only unique inside a CDP session. The binding
+    /// records the unique id so destroy is idempotent under numeric-id reuse.
+    context_to_frame: HashMap<ContextKey, ContextBinding>,
+    /// Sessions known to represent OOP child targets.
+    session_frames: HashSet<SessionId>,
+    /// Stable, full-parameter preload records used for child-session replay.
+    preload_scripts: Vec<PreloadScript>,
+    /// Tracks in-flight registration and browser-side evidence for named
+    /// isolated worlds. `Confirmed` means either the registration ACK arrived
+    /// or Chrome emitted a context for that world; observing the context is
+    /// monotonic evidence and a later protocol error must not downgrade it.
+    /// Current initialization has no production re-trigger after a failure.
+    /// Any future recovery path must split registration from context presence,
+    /// or add generation-aware late-response attribution before retrying.
+    isolated_worlds: HashMap<(SessionId, String), IsolatedWorldState>,
+    /// Preserves the old standalone behavior before a main session is bound.
+    legacy_isolated_worlds: HashSet<String>,
+    main_session_id: Option<SessionId>,
     /// Timeout after which an anticipated event (related to navigation) doesn't
     /// arrive results in an error
     request_timeout: Duration,
-    /// Track currently in progress navigation
-    pending_navigations: VecDeque<(FrameNavigationRequest, NavigationWatcher)>,
-    /// The currently ongoing navigation
-    navigation: Option<(NavigationWatcher, Instant)>,
+    /// Cleanup paths enqueue cross-layer results here; polling always drains
+    /// them before scanning ordinary navigation progress.
+    queued_events: VecDeque<FrameEvent>,
+    /// One active navigation lane per `(session, frame)` pair.
+    navigation: HashMap<NavigationKey, NavigationEntry>,
+    /// Additional commands wait behind the active lane for their own key.
+    pending_navigations:
+        HashMap<NavigationKey, VecDeque<(FrameNavigationRequest, NavigationWatcher)>>,
 }
 
 impl FrameManager {
@@ -203,11 +324,17 @@ impl FrameManager {
         FrameManager {
             main_frame: None,
             frames: Default::default(),
-            context_ids: Default::default(),
+            context_by_unique: Default::default(),
+            context_to_frame: Default::default(),
+            session_frames: Default::default(),
+            preload_scripts: Default::default(),
             isolated_worlds: Default::default(),
+            legacy_isolated_worlds: Default::default(),
+            main_session_id: None,
             request_timeout,
+            queued_events: Default::default(),
             pending_navigations: Default::default(),
-            navigation: None,
+            navigation: Default::default(),
         }
     }
 
@@ -257,6 +384,75 @@ impl FrameManager {
         self.frames.get(id)
     }
 
+    pub(crate) fn set_main_session_id(&mut self, session_id: SessionId) {
+        self.main_session_id = Some(session_id);
+    }
+
+    pub(crate) fn main_session_id(&self) -> Option<&SessionId> {
+        self.main_session_id.as_ref()
+    }
+
+    pub(crate) fn is_child_session(&self, session_id: &SessionId) -> bool {
+        self.session_frames.contains(session_id)
+    }
+
+    pub(crate) fn child_sessions(&self) -> impl Iterator<Item = &SessionId> {
+        self.session_frames.iter()
+    }
+
+    pub(crate) fn add_preload_script(
+        &mut self,
+        params: AddScriptToEvaluateOnNewDocumentParams,
+        main_id: ScriptIdentifier,
+    ) -> PreloadId {
+        let id = self.preload_scripts.len();
+        self.preload_scripts.push(PreloadScript {
+            id,
+            params,
+            main_id,
+            per_session_ids: HashMap::new(),
+            state: PreloadState::Live,
+        });
+        id
+    }
+
+    pub(crate) fn preload_snapshot(
+        &self,
+    ) -> Vec<(PreloadId, AddScriptToEvaluateOnNewDocumentParams)> {
+        self.preload_scripts
+            .iter()
+            .map(|preload| {
+                debug_assert_eq!(preload.state, PreloadState::Live);
+                (preload.id, preload.params.clone())
+            })
+            .collect()
+    }
+
+    pub(crate) fn set_preload_id(
+        &mut self,
+        preload_id: PreloadId,
+        session_id: SessionId,
+        script_id: ScriptIdentifier,
+    ) -> bool {
+        if !self.session_frames.contains(&session_id) {
+            return false;
+        }
+        let Some(preload) = self.preload_scripts.get_mut(preload_id) else {
+            return false;
+        };
+        match preload.state {
+            PreloadState::Live => {
+                preload.per_session_ids.insert(session_id, script_id);
+                true
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn preload_script(&self, preload_id: PreloadId) -> Option<&PreloadScript> {
+        self.preload_scripts.get(preload_id)
+    }
+
     fn check_lifecycle(&self, watcher: &NavigationWatcher, frame: &Frame) -> bool {
         watcher.expected_lifecycle.iter().all(|ev| {
             frame.lifecycle_events.contains(ev)
@@ -272,7 +468,7 @@ impl FrameManager {
         &self,
         watcher: &NavigationWatcher,
         frame: &Frame,
-    ) -> Option<NavigationOk> {
+    ) -> Option<NavigationCompletion> {
         if !self.check_lifecycle(watcher, frame) {
             return None;
         }
@@ -280,10 +476,10 @@ impl FrameManager {
             return None;
         }
         if watcher.same_document_navigation {
-            return Some(NavigationOk::SameDocumentNavigation(watcher.id));
+            return Some(NavigationCompletion::SameDocument);
         }
         if frame.loader_id != watcher.loader_id {
-            return Some(NavigationOk::NewDocumentNavigation(watcher.id));
+            return Some(NavigationCompletion::NewDocument);
         }
         None
     }
@@ -298,152 +494,792 @@ impl FrameManager {
     }
 
     pub fn poll(&mut self, now: Instant) -> Option<FrameEvent> {
-        // check if the navigation completed
-        if let Some((watcher, deadline)) = self.navigation.take() {
-            if now > deadline {
-                // navigation request timed out
-                return Some(FrameEvent::NavigationResult(Err(
-                    NavigationError::Timeout {
-                        err: DeadlineExceeded::new(now, deadline),
-                        id: watcher.id,
-                    },
-                )));
-            }
-            if let Some(frame) = self.frames.get(&watcher.frame_id) {
-                if let Some(nav) = self.check_lifecycle_complete(&watcher, frame) {
-                    // request is complete if the frame's lifecycle is complete = frame received all
-                    // required events
-                    return Some(FrameEvent::NavigationResult(Ok(nav)));
-                } else {
-                    // not finished yet
-                    self.navigation = Some((watcher, deadline));
+        if let Some(event) = self.queued_events.pop_front() {
+            return Some(event);
+        }
+
+        #[derive(Debug)]
+        enum ScanOutcome {
+            Timeout(Instant),
+            FrameMissing(FrameId),
+            Complete(NavigationCompletion),
+        }
+
+        let navigation_keys = self.navigation.keys().cloned().collect::<Vec<_>>();
+        let mut completed = Vec::new();
+        for key in navigation_keys {
+            let Some(entry) = self.navigation.get(&key) else {
+                continue;
+            };
+            let outcome = if now > entry.deadline {
+                Some(ScanOutcome::Timeout(entry.deadline))
+            } else if let Some(watcher) = entry.watcher.as_ref() {
+                match self.frames.get(&watcher.frame_id) {
+                    Some(frame) => self
+                        .check_lifecycle_complete(watcher, frame)
+                        .map(ScanOutcome::Complete),
+                    None => Some(ScanOutcome::FrameMissing(watcher.frame_id.clone())),
                 }
             } else {
-                return Some(FrameEvent::NavigationResult(Err(
-                    NavigationError::FrameNotFound {
-                        frame: watcher.frame_id,
-                        id: watcher.id,
-                    },
-                )));
+                None
+            };
+            if let Some(outcome) = outcome {
+                completed.push((key, outcome));
             }
-        } else if let Some((req, watcher)) = self.pending_navigations.pop_front() {
-            // queue in the next navigation that is must be fulfilled until `deadline`
-            let deadline = Instant::now() + req.timeout;
-            self.navigation = Some((watcher, deadline));
-            return Some(FrameEvent::NavigationRequest(req.id, req.req));
         }
-        None
+
+        // Complete every waiter-only entry in this pass. Handler-facing
+        // results are queued and returned one at a time after the full scan.
+        for (key, outcome) in completed {
+            let Some(entry) = self.navigation.remove(&key) else {
+                continue;
+            };
+            match outcome {
+                ScanOutcome::Timeout(deadline) => {
+                    for waiter in entry.waiters {
+                        let _ = waiter.send(Err(FrameWaitError::Timeout));
+                    }
+                    if let Some(id) = entry.watcher.and_then(|watcher| watcher.id) {
+                        self.queued_events
+                            .push_back(FrameEvent::NavigationResult(Err(
+                                NavigationError::Timeout {
+                                    id,
+                                    err: DeadlineExceeded::new(now, deadline),
+                                },
+                            )));
+                    }
+                }
+                ScanOutcome::FrameMissing(frame_id) => {
+                    for waiter in entry.waiters {
+                        let _ = waiter.send(Err(FrameWaitError::FrameNotFound {
+                            frame: frame_id.clone(),
+                        }));
+                    }
+                    if let Some(id) = entry.watcher.and_then(|watcher| watcher.id) {
+                        self.queued_events
+                            .push_back(FrameEvent::NavigationResult(Err(
+                                NavigationError::FrameNotFound {
+                                    id,
+                                    frame: frame_id,
+                                },
+                            )));
+                    }
+                }
+                ScanOutcome::Complete(completion) => {
+                    for waiter in entry.waiters {
+                        let _ = waiter.send(Ok(()));
+                    }
+                    if let Some(id) = entry.watcher.and_then(|watcher| watcher.id) {
+                        let result = match completion {
+                            NavigationCompletion::SameDocument => {
+                                NavigationOk::SameDocumentNavigation(id)
+                            }
+                            NavigationCompletion::NewDocument => {
+                                NavigationOk::NewDocumentNavigation(id)
+                            }
+                        };
+                        self.queued_events
+                            .push_back(FrameEvent::NavigationResult(Ok(result)));
+                    }
+                }
+            }
+        }
+
+        if let Some(event) = self.queued_events.pop_front() {
+            return Some(event);
+        }
+
+        let pending_keys = self.pending_navigations.keys().cloned().collect::<Vec<_>>();
+        for key in pending_keys {
+            if self
+                .navigation
+                .get(&key)
+                .is_some_and(|entry| entry.watcher.is_some())
+            {
+                continue;
+            }
+
+            let next = self
+                .pending_navigations
+                .get_mut(&key)
+                .and_then(VecDeque::pop_front);
+            let Some((req, watcher)) = next else {
+                continue;
+            };
+            if self
+                .pending_navigations
+                .get(&key)
+                .is_some_and(VecDeque::is_empty)
+            {
+                self.pending_navigations.remove(&key);
+            }
+
+            let deadline = now + req.timeout;
+            if let Some(entry) = self.navigation.get_mut(&key) {
+                entry.watcher = Some(watcher);
+                entry.deadline = deadline;
+            } else {
+                self.navigation.insert(
+                    key,
+                    NavigationEntry {
+                        watcher: Some(watcher),
+                        pre_loader_id: None,
+                        deadline,
+                        waiters: Vec::new(),
+                    },
+                );
+            }
+            self.queued_events
+                .push_back(FrameEvent::NavigationRequest(req.id, req.req));
+        }
+
+        self.queued_events.pop_front()
     }
 
     /// Entrypoint for page navigation
     pub fn goto(&mut self, req: FrameNavigationRequest) {
         if let Some(frame_id) = self.main_frame.clone() {
-            self.navigate_frame(frame_id, req);
+            if let Some(session_id) = self.main_session_id.clone() {
+                self.navigate_frame_in_session(session_id, frame_id, req);
+            } else {
+                self.navigate_frame(frame_id, req);
+            }
         }
     }
 
     /// Navigate a specific frame
-    pub fn navigate_frame(&mut self, frame_id: FrameId, mut req: FrameNavigationRequest) {
+    pub fn navigate_frame(&mut self, frame_id: FrameId, req: FrameNavigationRequest) {
+        let session_id = self
+            .frames
+            .get(&frame_id)
+            .and_then(|frame| frame.session_id().cloned())
+            .or_else(|| {
+                req.req
+                    .session_id
+                    .as_ref()
+                    .map(|session_id| SessionId::new(session_id.clone()))
+            });
+        if let Some(session_id) = session_id {
+            self.navigate_frame_in_session(session_id, frame_id, req);
+        } else {
+            self.register_pending(None, frame_id, req);
+        }
+    }
+
+    pub(crate) fn navigate_frame_in_session(
+        &mut self,
+        session_id: SessionId,
+        frame_id: FrameId,
+        mut req: FrameNavigationRequest,
+    ) {
         let loader_id = self.frames.get(&frame_id).and_then(|f| f.loader_id.clone());
+        req.req.session_id = Some(session_id.clone().into());
+        self.register_pending_with_loader(Some(session_id), frame_id, req, loader_id);
+    }
+
+    fn register_pending(
+        &mut self,
+        session_id: Option<SessionId>,
+        frame_id: FrameId,
+        req: FrameNavigationRequest,
+    ) {
+        let loader_id = self.frames.get(&frame_id).and_then(|f| f.loader_id.clone());
+        self.register_pending_with_loader(session_id, frame_id, req, loader_id);
+    }
+
+    fn register_pending_with_loader(
+        &mut self,
+        session_id: Option<SessionId>,
+        frame_id: FrameId,
+        mut req: FrameNavigationRequest,
+        loader_id: Option<LoaderId>,
+    ) {
+        self.evict_other_lane(&frame_id, &session_id);
         let watcher = NavigationWatcher::until_page_load(req.id, frame_id.clone(), loader_id);
-        // insert the frame_id in the request if not present
-        req.set_frame_id(frame_id);
-        self.pending_navigations.push_back((req, watcher))
+        req.set_frame_id(frame_id.clone());
+        self.pending_navigations
+            .entry((session_id, frame_id))
+            .or_default()
+            .push_back((req, watcher));
+    }
+
+    fn keys_for_frame(&self, frame_id: &FrameId) -> Vec<Option<SessionId>> {
+        self.navigation
+            .keys()
+            .chain(self.pending_navigations.keys())
+            .filter(|(_, candidate)| candidate == frame_id)
+            .map(|(session_id, _)| session_id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn evict_other_lane(&mut self, frame_id: &FrameId, desired_session: &Option<SessionId>) {
+        let victims = self
+            .keys_for_frame(frame_id)
+            .into_iter()
+            .filter(|session_id| session_id != desired_session)
+            .collect::<Vec<_>>();
+        for session_id in victims {
+            self.fail_navigation_key(
+                &(session_id, frame_id.clone()),
+                FrameWaitError::FrameSwappedOrDetached,
+            );
+        }
+    }
+
+    fn fail_navigation_key(&mut self, key: &NavigationKey, waiter_error: FrameWaitError) {
+        if let Some(entry) = self.navigation.remove(key) {
+            for waiter in entry.waiters {
+                let _ = waiter.send(Err(waiter_error.clone()));
+            }
+            if let Some(watcher) = entry.watcher {
+                if let Some(id) = watcher.id {
+                    self.queued_events
+                        .push_back(FrameEvent::NavigationResult(Err(
+                            NavigationError::FrameNotFound {
+                                id,
+                                frame: watcher.frame_id,
+                            },
+                        )));
+                }
+            }
+        }
+        if let Some(pending) = self.pending_navigations.remove(key) {
+            for (_, watcher) in pending {
+                if let Some(id) = watcher.id {
+                    self.queued_events
+                        .push_back(FrameEvent::NavigationResult(Err(
+                            NavigationError::FrameNotFound {
+                                id,
+                                frame: watcher.frame_id,
+                            },
+                        )));
+                }
+            }
+        }
+    }
+
+    /// Settle every navigation lane owned by one CDP session. Calling this at
+    /// the draining tombstone boundary prevents waiters and queued navigations
+    /// from surviving until the later detach notification.
+    pub(crate) fn fail_navigation_state_for_session(
+        &mut self,
+        session_id: &SessionId,
+        waiter_error: FrameWaitError,
+    ) {
+        let navigation_keys = self
+            .navigation
+            .keys()
+            .chain(self.pending_navigations.keys())
+            .filter(|(candidate, _)| candidate.as_ref() == Some(session_id))
+            .cloned()
+            .collect::<HashSet<_>>();
+        for key in navigation_keys {
+            self.fail_navigation_key(&key, waiter_error.clone());
+        }
+    }
+
+    /// Settle every registered navigation waiter during a whole-target or
+    /// connection teardown, so a pending [`crate::Frame::wait_for_navigation`]
+    /// observes a typed error instead of an opaque channel cancellation.
+    ///
+    /// Unlike [`Self::fail_navigation_key`], this deliberately does not enqueue
+    /// Handler-facing `NavigationResult` events: the explicit `Page::goto` /
+    /// `Frame::goto` sender is owned by the Handler's own pending-navigation
+    /// bookkeeping, which settles it separately, and this `FrameManager` (with
+    /// its `queued_events`) is about to be dropped, so any event pushed here
+    /// would have no consumer.
+    ///
+    /// Scope: this is the whole-target path (target destroyed, main-session
+    /// detach, connection close). Child-session draining is settled earlier by
+    /// `fail_navigation_state_for_session` at the draining tombstone boundary;
+    /// the later detach repeats that per-session sweep as a harmless no-op.
+    pub(crate) fn fail_all_navigation_state(&mut self, waiter_error: FrameWaitError) {
+        for entry in self.navigation.values_mut() {
+            for waiter in entry.waiters.drain(..) {
+                let _ = waiter.send(Err(waiter_error.clone()));
+            }
+        }
+        self.navigation.clear();
+        self.pending_navigations.clear();
     }
 
     /// Fired when a frame moved to another session
-    pub fn on_attached_to_target(&mut self, _event: &EventAttachedToTarget) {
-        // _onFrameMoved
+    pub fn on_attached_to_target(&mut self, event: &EventAttachedToTarget) {
+        if self.main_session_id.is_some() {
+            self.on_attached_to_target_in_session(event, event.session_id.clone());
+        }
+    }
+
+    pub(crate) fn on_attached_to_target_in_session(
+        &mut self,
+        event: &EventAttachedToTarget,
+        child_session_id: SessionId,
+    ) {
+        let frame_id = FrameId::new(event.target_info.target_id.as_ref());
+        if !self.frames.contains_key(&frame_id) {
+            if let Some(parent_id) = event.target_info.parent_frame_id.clone() {
+                let _ = self.on_frame_attached_in_session(
+                    frame_id.clone(),
+                    Some(parent_id),
+                    child_session_id.clone(),
+                );
+            }
+        }
+        if self.frames.contains_key(&frame_id) {
+            self.rebind_frame_session(&frame_id, child_session_id.clone());
+        }
+        if self.main_session_id.as_ref() != Some(&child_session_id) {
+            self.session_frames.insert(child_session_id);
+        }
     }
 
     pub fn on_frame_tree(&mut self, frame_tree: FrameTree) {
-        self.on_frame_attached(
+        if let Some(session_id) = self.main_session_id.clone() {
+            let _ = self.on_frame_tree_in_session(frame_tree, session_id);
+        } else {
+            self.on_frame_tree_core(frame_tree);
+        }
+    }
+
+    fn on_frame_tree_core(&mut self, frame_tree: FrameTree) {
+        self.on_frame_attached_core(
             frame_tree.frame.id.clone(),
             frame_tree.frame.parent_id.clone(),
+            None,
         );
-        self.on_frame_navigated(&frame_tree.frame);
+        self.on_frame_navigated_core(&frame_tree.frame, None);
         if let Some(children) = frame_tree.child_frames {
             for child_tree in children {
-                self.on_frame_tree(child_tree);
+                self.on_frame_tree_core(child_tree);
+            }
+        }
+    }
+
+    pub(crate) fn on_frame_tree_in_session(
+        &mut self,
+        frame_tree: FrameTree,
+        session_id: SessionId,
+    ) -> Vec<SessionId> {
+        let mut swapped_sessions = Vec::new();
+        self.on_frame_tree_in_session_inner(frame_tree, &session_id, &mut swapped_sessions);
+        swapped_sessions
+    }
+
+    fn on_frame_tree_in_session_inner(
+        &mut self,
+        frame_tree: FrameTree,
+        session_id: &SessionId,
+        swapped_sessions: &mut Vec<SessionId>,
+    ) {
+        if let Some(old_session_id) = self.on_frame_attached_in_session(
+            frame_tree.frame.id.clone(),
+            frame_tree.frame.parent_id.clone(),
+            session_id.clone(),
+        ) {
+            swapped_sessions.push(old_session_id);
+        }
+        self.on_frame_navigated_in_session(&frame_tree.frame, session_id.clone());
+        if let Some(children) = frame_tree.child_frames {
+            for child_tree in children {
+                self.on_frame_tree_in_session_inner(child_tree, session_id, swapped_sessions);
             }
         }
     }
 
     pub fn on_frame_attached(&mut self, frame_id: FrameId, parent_frame_id: Option<FrameId>) {
-        if self.frames.contains_key(&frame_id) {
-            return;
+        if let Some(session_id) = self.main_session_id.clone() {
+            let _ = self.on_frame_attached_in_session(frame_id, parent_frame_id, session_id);
+        } else {
+            self.on_frame_attached_core(frame_id, parent_frame_id, None);
         }
+    }
+
+    pub(crate) fn on_frame_attached_in_session(
+        &mut self,
+        frame_id: FrameId,
+        parent_frame_id: Option<FrameId>,
+        session_id: SessionId,
+    ) -> Option<SessionId> {
+        self.on_frame_attached_core(frame_id, parent_frame_id, Some(&session_id))
+    }
+
+    fn on_frame_attached_core(
+        &mut self,
+        frame_id: FrameId,
+        parent_frame_id: Option<FrameId>,
+        event_session_id: Option<&SessionId>,
+    ) -> Option<SessionId> {
+        if self.frames.contains_key(&frame_id) {
+            let swap_back = match (event_session_id, parent_frame_id.as_ref()) {
+                (Some(event_session_id), Some(parent_frame_id)) => {
+                    let parent_session_id =
+                        self.frames.get(parent_frame_id).and_then(Frame::session_id);
+                    let frame = self.frames.get(&frame_id);
+                    let main_session_id = self.main_session_id.as_ref();
+                    frame.is_some_and(|frame| {
+                        parent_session_id == Some(event_session_id)
+                            && main_session_id.is_some_and(|main| frame.is_out_of_process(main))
+                            && frame.session_id() != Some(event_session_id)
+                    })
+                }
+                (Some(_), None) | (None, Some(_)) | (None, None) => false,
+            };
+
+            if swap_back {
+                let old_session_id = self
+                    .frames
+                    .get(&frame_id)
+                    .and_then(Frame::session_id)
+                    .cloned()
+                    .expect("a swapped OOP frame has a bound session");
+                self.clear_frame_contexts_for_session(&frame_id, &old_session_id);
+                self.rebind_frame_session(
+                    &frame_id,
+                    event_session_id
+                        .expect("swap-back requires an event session")
+                        .clone(),
+                );
+                return Some(old_session_id);
+            }
+
+            if let Some(event_session_id) = event_session_id {
+                if self
+                    .frames
+                    .get(&frame_id)
+                    .is_some_and(|frame| frame.session_id().is_none())
+                {
+                    self.rebind_frame_session(&frame_id, event_session_id.clone());
+                }
+            }
+            return None;
+        }
+
         if let Some(parent_frame_id) = parent_frame_id {
             if let Some(parent_frame) = self.frames.get_mut(&parent_frame_id) {
-                let frame = Frame::with_parent(frame_id.clone(), parent_frame);
+                let mut frame = Frame::with_parent(frame_id.clone(), parent_frame);
+                if let Some(event_session_id) = event_session_id {
+                    frame.set_session_id(event_session_id.clone());
+                    if self.main_session_id.as_ref() != Some(event_session_id) {
+                        self.session_frames.insert(event_session_id.clone());
+                    }
+                }
                 self.frames.insert(frame_id, frame);
+            }
+        }
+        None
+    }
+
+    pub fn on_frame_detached(&mut self, event: &EventFrameDetached) {
+        match event.reason {
+            FrameDetachedReason::Swap => self.clear_frame_contexts(&event.frame_id),
+            FrameDetachedReason::Remove => {
+                self.remove_frames_recursively(&event.frame_id);
             }
         }
     }
 
-    pub fn on_frame_detached(&mut self, event: &EventFrameDetached) {
-        self.remove_frames_recursively(&event.frame_id);
+    pub fn on_frame_navigated(&mut self, frame: &CdpFrame) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_frame_navigated_in_session(frame, session_id);
+        } else {
+            self.on_frame_navigated_core(frame, None);
+        }
     }
 
-    pub fn on_frame_navigated(&mut self, frame: &CdpFrame) {
+    pub(crate) fn on_frame_navigated_in_session(
+        &mut self,
+        frame: &CdpFrame,
+        session_id: SessionId,
+    ) {
+        self.on_frame_navigated_core(frame, Some(&session_id));
+    }
+
+    fn on_frame_navigated_core(&mut self, frame: &CdpFrame, session_id: Option<&SessionId>) {
         if frame.parent_id.is_some() {
             if let Some((id, mut f)) = self.frames.remove_entry(&frame.id) {
-                for child in &f.child_frames {
-                    self.remove_frames_recursively(child);
+                let same_session = session_id
+                    .map(|session_id| f.session_id() == Some(session_id))
+                    .unwrap_or(true);
+                if same_session {
+                    let child_frames = f.child_frames.iter().cloned().collect::<Vec<_>>();
+                    for child in child_frames {
+                        self.remove_frames_recursively(&child);
+                    }
+                    f.child_frames.clear();
                 }
-                // this is necessary since we can't borrow mut and then remove recursively
-                f.child_frames.clear();
                 f.navigated(frame);
                 self.frames.insert(id, f);
             }
         } else {
             let mut f = if let Some(main) = self.main_frame.take() {
-                // update main frame
-                let mut main_frame = self.frames.remove(&main).expect("Main frame is tracked.");
-                for child in &main_frame.child_frames {
-                    self.remove_frames_recursively(child);
+                let mut main_frame = self
+                    .frames
+                    .remove(&main)
+                    .unwrap_or_else(|| Frame::new(frame.id.clone()));
+                let child_frames = main_frame.child_frames.iter().cloned().collect::<Vec<_>>();
+                for child in child_frames {
+                    self.remove_frames_recursively(&child);
                 }
-                // this is necessary since we can't borrow mut and then remove recursively
                 main_frame.child_frames.clear();
                 main_frame.id = frame.id.clone();
                 main_frame
             } else {
-                // initial main frame navigation
                 Frame::new(frame.id.clone())
             };
+            if let Some(session_id) = session_id {
+                f.set_session_id(session_id.clone());
+            }
             f.navigated(frame);
             self.main_frame = Some(f.id.clone());
             self.frames.insert(f.id.clone(), f);
         }
+
+        if let Some(session_id) = session_id {
+            let key = (Some(session_id.clone()), frame.id.clone());
+            if self
+                .frames
+                .get(&frame.id)
+                .is_some_and(|tracked| tracked.session_id() == Some(session_id))
+            {
+                if let Some(entry) = self.navigation.get_mut(&key) {
+                    if entry.watcher.is_none() {
+                        entry.watcher = Some(NavigationWatcher::anticipated_page_load(
+                            frame.id.clone(),
+                            entry.pre_loader_id.clone(),
+                        ));
+                    }
+                }
+            }
+        }
     }
 
     pub fn on_frame_navigated_within_document(&mut self, event: &EventNavigatedWithinDocument) {
-        if let Some(frame) = self.frames.get_mut(&event.frame_id) {
-            frame.navigated_within_url(event.url.clone());
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_frame_navigated_within_document_in_session(event, session_id);
+        } else {
+            self.on_frame_navigated_within_document_core(event, None);
         }
-        if let Some((watcher, _)) = self.navigation.as_mut() {
-            watcher.on_frame_navigated_within_document(event);
+    }
+
+    pub(crate) fn on_frame_navigated_within_document_in_session(
+        &mut self,
+        event: &EventNavigatedWithinDocument,
+        session_id: SessionId,
+    ) {
+        self.on_frame_navigated_within_document_core(event, Some(&session_id));
+    }
+
+    fn on_frame_navigated_within_document_core(
+        &mut self,
+        event: &EventNavigatedWithinDocument,
+        session_id: Option<&SessionId>,
+    ) {
+        if let Some(frame) = self.frames.get_mut(&event.frame_id) {
+            let belongs_to_session = session_id
+                .map(|session_id| frame.session_id() == Some(session_id))
+                .unwrap_or(true);
+            if belongs_to_session {
+                frame.navigated_within_url(event.url.clone());
+            }
+        }
+        let key = (session_id.cloned(), event.frame_id.clone());
+        if let Some(entry) = self.navigation.get_mut(&key) {
+            if let Some(watcher) = entry.watcher.as_mut() {
+                watcher.on_frame_navigated_within_document(event);
+            }
         }
     }
 
     pub fn on_frame_stopped_loading(&mut self, event: &EventFrameStoppedLoading) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_frame_stopped_loading_in_session(event, session_id);
+        } else {
+            self.on_frame_stopped_loading_core(event, None);
+        }
+    }
+
+    pub(crate) fn on_frame_stopped_loading_in_session(
+        &mut self,
+        event: &EventFrameStoppedLoading,
+        session_id: SessionId,
+    ) {
+        self.on_frame_stopped_loading_core(event, Some(&session_id));
+    }
+
+    fn on_frame_stopped_loading_core(
+        &mut self,
+        event: &EventFrameStoppedLoading,
+        session_id: Option<&SessionId>,
+    ) {
         if let Some(frame) = self.frames.get_mut(&event.frame_id) {
-            frame.on_loading_stopped();
+            if session_id
+                .map(|session_id| frame.session_id() == Some(session_id))
+                .unwrap_or(true)
+            {
+                frame.on_loading_stopped();
+            }
         }
     }
 
     /// Fired when frame has started loading.
     pub fn on_frame_started_loading(&mut self, event: &EventFrameStartedLoading) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_frame_started_loading_in_session(event, session_id);
+        } else {
+            self.on_frame_started_loading_core(event, None);
+        }
+    }
+
+    pub(crate) fn on_frame_started_loading_in_session(
+        &mut self,
+        event: &EventFrameStartedLoading,
+        session_id: SessionId,
+    ) {
+        self.on_frame_started_loading_core(event, Some(&session_id));
+    }
+
+    fn on_frame_started_loading_core(
+        &mut self,
+        event: &EventFrameStartedLoading,
+        session_id: Option<&SessionId>,
+    ) {
         if let Some(frame) = self.frames.get_mut(&event.frame_id) {
-            frame.on_loading_started();
+            if session_id
+                .map(|session_id| frame.session_id() == Some(session_id))
+                .unwrap_or(true)
+            {
+                frame.on_loading_started();
+            }
         }
     }
 
     /// Notification is issued every time when binding is called
-    pub fn on_runtime_binding_called(&mut self, _ev: &EventBindingCalled) {}
+    pub fn on_runtime_binding_called(&mut self, event: &EventBindingCalled) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_runtime_binding_called_in_session(event, session_id);
+        }
+    }
+
+    pub(crate) fn on_runtime_binding_called_in_session(
+        &mut self,
+        _event: &EventBindingCalled,
+        _session_id: SessionId,
+    ) {
+        // Binding delivery is intentionally inert until cross-frame binding
+        // propagation is implemented. Keeping the session-aware entry point
+        // prevents future code from guessing a context's owner globally.
+    }
 
     /// Issued when new execution context is created
     pub fn on_frame_execution_context_created(&mut self, event: &EventExecutionContextCreated) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_frame_execution_context_created_in_session(event, session_id);
+        } else {
+            self.on_frame_execution_context_created_core(event, None);
+        }
+    }
+
+    /// Record a newly created execution context in both context indices. The
+    /// forward `context_to_frame` map only exists for session-bound contexts;
+    /// the reverse `context_by_unique` map always records the frame so destroy
+    /// works on the legacy path too.
+    fn insert_context(
+        &mut self,
+        session_id: Option<&SessionId>,
+        context_id: ExecutionContextId,
+        unique_id: String,
+        frame_id: FrameId,
+    ) {
+        let key = session_id.map(|session_id| ContextKey {
+            session_id: session_id.clone(),
+            context_id,
+        });
+        if let Some(key) = key.clone() {
+            self.context_to_frame.insert(
+                key,
+                ContextBinding {
+                    frame_id: frame_id.clone(),
+                    unique_id: unique_id.clone(),
+                },
+            );
+        }
+        self.context_by_unique
+            .insert(unique_id, UniqueContext { frame_id, key });
+    }
+
+    /// Remove the context a `executionContextDestroyed` names, keyed by its CDP
+    /// unique id. The forward map is only deleted when its binding still carries
+    /// this exact unique id, so a late destroy cannot evict a mapping whose
+    /// numeric id was already reused by a newer context. Returns the owning
+    /// frame id, if the context was tracked.
+    fn remove_context_by_unique(&mut self, unique_id: &str) -> Option<FrameId> {
+        let context = self.context_by_unique.remove(unique_id)?;
+        if let Some(key) = context.key {
+            let still_ours = self
+                .context_to_frame
+                .get(&key)
+                .is_some_and(|binding| binding.unique_id == unique_id);
+            if still_ours {
+                self.context_to_frame.remove(&key);
+            }
+        }
+        Some(context.frame_id)
+    }
+
+    /// Bulk-remove contexts through the single owning index, keeping both maps
+    /// consistent. The context is dropped when `keep` returns false; `keep`
+    /// receives the owning frame id and the forward key (absent on the legacy
+    /// path). All bulk clearing paths funnel through here so the two indices
+    /// cannot drift.
+    ///
+    /// `keep` must be a pure, side-effect-free predicate: it is invoked once per
+    /// reverse entry and may be evaluated for entries in any order.
+    ///
+    /// The forward map is driven entirely by the reverse map: a `context_to_frame`
+    /// entry is removed only when the reverse entry that owns its exact `unique_id`
+    /// is being dropped. This preserves the same numeric-id-reuse protection as
+    /// [`Self::remove_context_by_unique`] — if a newer context reused this
+    /// `(session, numeric)` key, its forward binding carries a different
+    /// `unique_id` and is left intact. `insert_context` always writes both maps
+    /// together, so every forward entry has a matching reverse entry; no separate
+    /// forward scan is needed (and one would mis-delete the reused key).
+    fn retain_contexts(&mut self, mut keep: impl FnMut(&FrameId, Option<&ContextKey>) -> bool) {
+        let mut removed = Vec::new();
+        self.context_by_unique.retain(|unique_id, context| {
+            let keep = keep(&context.frame_id, context.key.as_ref());
+            if !keep {
+                if let Some(key) = context.key.clone() {
+                    removed.push((key, unique_id.clone()));
+                }
+            }
+            keep
+        });
+        for (key, unique_id) in removed {
+            let still_ours = self
+                .context_to_frame
+                .get(&key)
+                .is_some_and(|binding| binding.unique_id == unique_id);
+            if still_ours {
+                self.context_to_frame.remove(&key);
+            }
+        }
+    }
+
+    pub(crate) fn on_frame_execution_context_created_in_session(
+        &mut self,
+        event: &EventExecutionContextCreated,
+        session_id: SessionId,
+    ) {
+        self.on_frame_execution_context_created_core(event, Some(&session_id));
+    }
+
+    fn on_frame_execution_context_created_core(
+        &mut self,
+        event: &EventExecutionContextCreated,
+        session_id: Option<&SessionId>,
+    ) {
         if let Some(frame_id) = event
             .context
             .aux_data
@@ -451,6 +1287,12 @@ impl FrameManager {
             .and_then(|v| v["frameId"].as_str())
         {
             if let Some(frame) = self.frames.get_mut(frame_id) {
+                if session_id
+                    .map(|session_id| frame.session_id() != Some(session_id))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
                 if event
                     .context
                     .aux_data
@@ -468,56 +1310,170 @@ impl FrameManager {
                         .secondary_world
                         .set_context(event.context.id, event.context.unique_id.clone());
                 }
-                self.context_ids
-                    .insert(event.context.unique_id.clone(), frame.id.clone());
+                let frame_id = frame.id.clone();
+                self.insert_context(
+                    session_id,
+                    event.context.id,
+                    event.context.unique_id.clone(),
+                    frame_id,
+                );
             }
         }
-        if event
-            .context
-            .aux_data
-            .as_ref()
-            .filter(|v| v["type"].as_str() == Some("isolated"))
-            .is_some()
+        if !event.context.name.is_empty()
+            && event
+                .context
+                .aux_data
+                .as_ref()
+                .is_some_and(|v| v["type"].as_str() == Some("isolated"))
         {
-            self.isolated_worlds.insert(event.context.name.clone());
+            // Context observation is stronger browser-side evidence than an
+            // ACK and can confirm a world without a preceding Pending marker.
+            // This intentionally records every named isolated world Chrome
+            // exposes, including extension/user worlds not created by
+            // `ensure_*`. The real name keeps those keys independent from the
+            // utility world, and owning-session teardown bounds their lifetime.
+            if let Some(session_id) = session_id {
+                self.isolated_worlds.insert(
+                    (session_id.clone(), event.context.name.clone()),
+                    IsolatedWorldState::Confirmed,
+                );
+            } else {
+                self.legacy_isolated_worlds
+                    .insert(event.context.name.clone());
+            }
         }
     }
 
     /// Issued when execution context is destroyed
     pub fn on_frame_execution_context_destroyed(&mut self, event: &EventExecutionContextDestroyed) {
-        if let Some(id) = self.context_ids.remove(&event.execution_context_unique_id) {
-            if let Some(frame) = self.frames.get_mut(&id) {
-                frame.destroy_context(&event.execution_context_unique_id);
-            }
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_frame_execution_context_destroyed_in_session(event, session_id);
+        } else {
+            self.on_frame_execution_context_destroyed_core(event, None);
+        }
+    }
+
+    pub(crate) fn on_frame_execution_context_destroyed_in_session(
+        &mut self,
+        event: &EventExecutionContextDestroyed,
+        session_id: SessionId,
+    ) {
+        self.on_frame_execution_context_destroyed_core(event, Some(&session_id));
+    }
+
+    fn on_frame_execution_context_destroyed_core(
+        &mut self,
+        event: &EventExecutionContextDestroyed,
+        session_id: Option<&SessionId>,
+    ) {
+        let frame_id = self
+            .context_by_unique
+            .get(&event.execution_context_unique_id)
+            .map(|context| context.frame_id.clone());
+        let Some(frame_id) = frame_id else {
+            return;
+        };
+        // A cross-session destroy must not evict a context owned by a frame that
+        // currently lives in another session.
+        if session_id.is_some_and(|session_id| {
+            self.frames
+                .get(&frame_id)
+                .is_some_and(|frame| frame.session_id() != Some(session_id))
+        }) {
+            return;
+        }
+
+        // Removing by unique id keeps the numeric-keyed forward map consistent
+        // even when Chrome has already reused this numeric id for another context.
+        self.remove_context_by_unique(&event.execution_context_unique_id);
+        if let Some(frame) = self.frames.get_mut(&frame_id) {
+            frame.destroy_context(&event.execution_context_unique_id);
         }
     }
 
     /// Issued when all executionContexts were cleared
     pub fn on_execution_contexts_cleared(&mut self) {
-        for id in self.context_ids.values() {
-            if let Some(frame) = self.frames.get_mut(id) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_execution_contexts_cleared_in_session(session_id);
+        } else {
+            for frame in self.frames.values_mut() {
+                frame.clear_contexts();
+            }
+            self.context_by_unique.clear();
+            self.context_to_frame.clear();
+        }
+    }
+
+    pub(crate) fn on_execution_contexts_cleared_in_session(&mut self, session_id: SessionId) {
+        let frame_ids = self
+            .frames
+            .iter()
+            .filter(|(_, frame)| frame.session_id() == Some(&session_id))
+            .map(|(frame_id, _)| frame_id.clone())
+            .collect::<HashSet<_>>();
+        for frame_id in &frame_ids {
+            if let Some(frame) = self.frames.get_mut(frame_id) {
                 frame.clear_contexts();
             }
         }
-        self.context_ids.clear()
+        self.retain_contexts(|frame_id, key| {
+            // Drop contexts owned by a cleared frame, and any context bound to
+            // the cleared session (keeps the forward map free of the session).
+            !frame_ids.contains(frame_id) && key.is_none_or(|key| key.session_id != session_id)
+        });
     }
 
     /// Fired for top level page lifecycle events (nav, load, paint, etc.)
     pub fn on_page_lifecycle_event(&mut self, event: &EventLifecycleEvent) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.on_page_lifecycle_event_in_session(event, session_id);
+        } else {
+            self.on_page_lifecycle_event_core(event, None);
+        }
+    }
+
+    pub(crate) fn on_page_lifecycle_event_in_session(
+        &mut self,
+        event: &EventLifecycleEvent,
+        session_id: SessionId,
+    ) {
+        self.on_page_lifecycle_event_core(event, Some(&session_id));
+    }
+
+    fn on_page_lifecycle_event_core(
+        &mut self,
+        event: &EventLifecycleEvent,
+        session_id: Option<&SessionId>,
+    ) {
         if let Some(frame) = self.frames.get_mut(&event.frame_id) {
-            if event.name == "init" {
-                frame.loader_id = Some(event.loader_id.clone());
-                frame.lifecycle_events.clear();
+            if session_id
+                .map(|session_id| frame.session_id() == Some(session_id))
+                .unwrap_or(true)
+            {
+                if event.name == "init" {
+                    frame.loader_id = Some(event.loader_id.clone());
+                    frame.lifecycle_events.clear();
+                }
+                frame.lifecycle_events.insert(event.name.clone().into());
             }
-            frame.lifecycle_events.insert(event.name.clone().into());
         }
     }
 
     /// Detach all child frames
     fn remove_frames_recursively(&mut self, id: &FrameId) -> Option<Frame> {
         if let Some(mut frame) = self.frames.remove(id) {
-            for child in &frame.child_frames {
-                self.remove_frames_recursively(child);
+            let children = frame.child_frames.iter().cloned().collect::<Vec<_>>();
+            for child in children {
+                self.remove_frames_recursively(&child);
+            }
+            self.retain_contexts(|frame_id, _| frame_id != id);
+            let navigation_keys = self
+                .keys_for_frame(id)
+                .into_iter()
+                .map(|session_id| (session_id, id.clone()))
+                .collect::<Vec<_>>();
+            for key in navigation_keys {
+                self.fail_navigation_key(&key, FrameWaitError::FrameNotFound { frame: id.clone() });
             }
             if let Some(parent_id) = frame.parent_frame.take() {
                 if let Some(parent) = self.frames.get_mut(&parent_id) {
@@ -530,11 +1486,186 @@ impl FrameManager {
         }
     }
 
+    fn clear_frame_contexts(&mut self, frame_id: &FrameId) {
+        self.retain_contexts(|mapped_frame_id, _| mapped_frame_id != frame_id);
+        if let Some(frame) = self.frames.get_mut(frame_id) {
+            frame.clear_contexts();
+        }
+    }
+
+    fn clear_frame_contexts_for_session(&mut self, frame_id: &FrameId, session_id: &SessionId) {
+        self.retain_contexts(|mapped_frame_id, key| {
+            mapped_frame_id != frame_id || key.is_none_or(|key| &key.session_id != session_id)
+        });
+        if let Some(frame) = self.frames.get_mut(frame_id) {
+            frame.clear_contexts();
+        }
+    }
+
+    fn rebind_frame_session(&mut self, frame_id: &FrameId, session_id: SessionId) {
+        self.evict_other_lane(frame_id, &Some(session_id.clone()));
+        self.clear_frame_contexts(frame_id);
+        if let Some(frame) = self.frames.get_mut(frame_id) {
+            frame.set_session_id(session_id);
+        }
+    }
+
+    pub(crate) fn on_detached_from_target(
+        &mut self,
+        child_session_id: &SessionId,
+        parent_session_id: &SessionId,
+    ) {
+        let child_frame_ids = self
+            .frames
+            .iter()
+            .filter(|(_, frame)| frame.session_id() == Some(child_session_id))
+            .map(|(frame_id, _)| frame_id.clone())
+            .collect::<HashSet<_>>();
+
+        self.retain_contexts(|frame_id, key| {
+            !child_frame_ids.contains(frame_id)
+                && key.is_none_or(|key| &key.session_id != child_session_id)
+        });
+
+        self.fail_navigation_state_for_session(
+            child_session_id,
+            FrameWaitError::FrameSwappedOrDetached,
+        );
+
+        self.isolated_worlds
+            .retain(|(session_id, _), _| session_id != child_session_id);
+        for preload in &mut self.preload_scripts {
+            preload.per_session_ids.remove(child_session_id);
+        }
+        for frame_id in child_frame_ids {
+            self.rebind_frame_session(&frame_id, parent_session_id.clone());
+        }
+        self.session_frames.remove(child_session_id);
+    }
+
+    pub(crate) fn wait_for_navigation(
+        &mut self,
+        session_id: SessionId,
+        frame_id: FrameId,
+        tx: OneshotSender<std::result::Result<(), FrameWaitError>>,
+    ) {
+        let Some(frame) = self.frames.get(&frame_id) else {
+            let _ = tx.send(Err(FrameWaitError::FrameNotFound { frame: frame_id }));
+            return;
+        };
+        if frame.session_id() != Some(&session_id) {
+            let _ = tx.send(Err(FrameWaitError::FrameSwappedOrDetached));
+            return;
+        }
+        let pre_loader_id = frame.loader_id.clone();
+        let key = (Some(session_id), frame_id.clone());
+        self.evict_other_lane(&frame_id, &key.0);
+        if let Some(entry) = self.navigation.get_mut(&key) {
+            entry.waiters.push(tx);
+        } else {
+            self.navigation.insert(
+                key,
+                NavigationEntry {
+                    watcher: None,
+                    pre_loader_id,
+                    deadline: Instant::now() + self.request_timeout,
+                    waiters: vec![tx],
+                },
+            );
+        }
+    }
+
+    pub(crate) fn fail_navigation_by_nav_id(
+        &mut self,
+        navigation_id: NavigationId,
+        error_text: String,
+    ) {
+        let key = self.navigation.iter().find_map(|(key, entry)| {
+            entry
+                .watcher
+                .as_ref()
+                .is_some_and(|watcher| watcher.id == Some(navigation_id))
+                .then(|| key.clone())
+        });
+        if let Some(key) = key {
+            if let Some(entry) = self.navigation.remove(&key) {
+                for waiter in entry.waiters {
+                    let _ = waiter.send(Err(FrameWaitError::NavigationFailed(error_text.clone())));
+                }
+            }
+        }
+    }
+
     pub fn ensure_isolated_world(&mut self, world_name: &str) -> Option<CommandChain> {
-        if self.isolated_worlds.contains(world_name) {
+        if let Some(session_id) = self.main_session_id.clone() {
+            self.ensure_isolated_world_in_session(world_name, session_id)
+        } else {
+            self.ensure_isolated_world_core(world_name, None)
+        }
+    }
+
+    pub(crate) fn ensure_isolated_world_in_session(
+        &mut self,
+        world_name: &str,
+        session_id: SessionId,
+    ) -> Option<CommandChain> {
+        self.ensure_isolated_world_core(world_name, Some(&session_id))
+    }
+
+    /// Install the world for the document that will commit after a paused
+    /// child target resumes. Creating the world explicitly while that target
+    /// is paused can wait forever for a document that has not committed yet.
+    pub(crate) fn ensure_isolated_world_on_next_document_in_session(
+        &mut self,
+        world_name: &str,
+        session_id: SessionId,
+    ) -> Option<CommandChain> {
+        match self
+            .isolated_worlds
+            .entry((session_id, world_name.to_owned()))
+        {
+            std::collections::hash_map::Entry::Occupied(_) => return None,
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(IsolatedWorldState::Pending);
+            }
+        }
+        let command = AddScriptToEvaluateOnNewDocumentParams::builder()
+            .source(format!("//# sourceURL={EVALUATION_SCRIPT_URL}"))
+            .world_name(world_name)
+            .build()
+            .expect("isolated-world script parameters are complete");
+        Some(CommandChain::new(
+            vec![(
+                command.identifier(),
+                serde_json::to_value(command).expect("isolated-world script should serialize"),
+            )],
+            self.request_timeout,
+        ))
+    }
+
+    fn ensure_isolated_world_core(
+        &mut self,
+        world_name: &str,
+        session_id: Option<&SessionId>,
+    ) -> Option<CommandChain> {
+        let already_registered = if let Some(session_id) = session_id {
+            match self
+                .isolated_worlds
+                .entry((session_id.clone(), world_name.to_owned()))
+            {
+                std::collections::hash_map::Entry::Occupied(_) => true,
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(IsolatedWorldState::Pending);
+                    false
+                }
+            }
+        } else {
+            !self.legacy_isolated_worlds.insert(world_name.to_owned())
+        };
+        if already_registered {
             return None;
         }
-        self.isolated_worlds.insert(world_name.to_string());
+
         let cmd = AddScriptToEvaluateOnNewDocumentParams::builder()
             .source(format!("//# sourceURL={EVALUATION_SCRIPT_URL}"))
             .world_name(world_name)
@@ -545,23 +1676,91 @@ impl FrameManager {
 
         cmds.push((cmd.identifier(), serde_json::to_value(cmd).unwrap()));
 
-        cmds.extend(self.frames.keys().map(|id| {
+        cmds.extend(self.frames.iter().filter_map(|(id, frame)| {
+            if session_id
+                .map(|session_id| frame.session_id() != Some(session_id))
+                .unwrap_or(false)
+            {
+                return None;
+            }
             let cmd = CreateIsolatedWorldParams::builder()
                 .frame_id(id.clone())
                 .grant_univeral_access(true)
                 .world_name(world_name)
                 .build()
                 .unwrap();
-            (cmd.identifier(), serde_json::to_value(cmd).unwrap())
+            Some((cmd.identifier(), serde_json::to_value(cmd).unwrap()))
         }));
         Some(CommandChain::new(cmds, self.request_timeout))
+    }
+
+    pub(crate) fn settle_isolated_world_registration(
+        &mut self,
+        session_id: &SessionId,
+        world_name: &str,
+        succeeded: bool,
+    ) {
+        let key = (session_id.clone(), world_name.to_owned());
+        if succeeded {
+            if let Some(state) = self.isolated_worlds.get_mut(&key) {
+                if *state == IsolatedWorldState::Pending {
+                    *state = IsolatedWorldState::Confirmed;
+                }
+            }
+            // A missing entry, whether never tracked or removed by
+            // owning-session teardown, is not recreated by a late success.
+        } else if self
+            .isolated_worlds
+            .get(&key)
+            .is_some_and(|state| *state == IsolatedWorldState::Pending)
+        {
+            // An explicit protocol failure removes local registration state.
+            // It cannot override a context Chrome has already exposed.
+            self.isolated_worlds.remove(&key);
+        }
+    }
+
+    /// Drop named-world registration bookkeeping when its owning target is gone.
+    pub(crate) fn clear_isolated_world_registrations(&mut self) {
+        self.isolated_worlds.clear();
+    }
+}
+
+#[cfg(test)]
+impl FrameManager {
+    pub(crate) fn test_set_frame_parent(&mut self, frame_id: &FrameId, parent_id: Option<FrameId>) {
+        self.frames
+            .get_mut(frame_id)
+            .expect("test frame exists")
+            .parent_frame = parent_id;
+    }
+
+    pub(crate) fn test_unbind_frame(&mut self, frame_id: &FrameId) {
+        self.frames
+            .get_mut(frame_id)
+            .expect("test frame exists")
+            .session_id = None;
+    }
+
+    pub(crate) fn isolated_world_state(
+        &self,
+        session_id: &SessionId,
+        world_name: &str,
+    ) -> Option<IsolatedWorldState> {
+        self.isolated_worlds
+            .get(&(session_id.clone(), world_name.to_owned()))
+            .copied()
+    }
+
+    pub(crate) fn test_remove_frame_without_descendants(&mut self, frame_id: &FrameId) {
+        self.frames.remove(frame_id).expect("test frame exists");
     }
 }
 
 #[derive(Debug)]
 pub enum FrameEvent {
     /// A previously submitted navigation has finished
-    NavigationResult(Result<NavigationOk, NavigationError>),
+    NavigationResult(std::result::Result<NavigationOk, NavigationError>),
     /// A new navigation request needs to be submitted
     NavigationRequest(NavigationId, Request),
     /* /// The initial page of the target has been loaded
@@ -607,7 +1806,9 @@ impl NavigationOk {
 /// Tracks the progress of an issued `Page.navigate` request until completion.
 #[derive(Debug)]
 pub struct NavigationWatcher {
-    id: NavigationId,
+    /// `None` denotes an anticipated waiter registered before a concrete
+    /// `Page.navigate` command exists.
+    id: Option<NavigationId>,
     expected_lifecycle: HashSet<MethodId>,
     frame_id: FrameId,
     loader_id: Option<LoaderId>,
@@ -620,6 +1821,14 @@ pub struct NavigationWatcher {
 
 impl NavigationWatcher {
     pub fn until_page_load(id: NavigationId, frame: FrameId, loader_id: Option<LoaderId>) -> Self {
+        Self::new(Some(id), frame, loader_id)
+    }
+
+    fn anticipated_page_load(frame: FrameId, loader_id: Option<LoaderId>) -> Self {
+        Self::new(None, frame, loader_id)
+    }
+
+    fn new(id: Option<NavigationId>, frame: FrameId, loader_id: Option<LoaderId>) -> Self {
         Self {
             id,
             expected_lifecycle: std::iter::once("load".into()).collect(),
@@ -644,6 +1853,44 @@ impl NavigationWatcher {
 /// An identifier for an ongoing navigation
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub struct NavigationId(pub usize);
+
+/// Stable index of a preload script tracked for replay into child sessions.
+///
+/// Entries are not recycled, so an identifier never changes meaning while the
+/// target is alive.
+pub(crate) type PreloadId = usize;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum PreloadState {
+    Live,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PreloadScript {
+    pub(crate) id: PreloadId,
+    pub(crate) params: AddScriptToEvaluateOnNewDocumentParams,
+    #[allow(dead_code)]
+    pub(crate) main_id: ScriptIdentifier,
+    pub(crate) per_session_ids: HashMap<SessionId, ScriptIdentifier>,
+    state: PreloadState,
+}
+
+/// Why a frame-scoped navigation waiter stopped waiting.
+///
+/// These errors intentionally do not carry a [`NavigationId`]: anticipated
+/// waiters can be registered before a concrete navigation command exists.
+#[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
+#[allow(dead_code)]
+pub(crate) enum FrameWaitError {
+    #[error("The frame navigation waiter timed out.")]
+    Timeout,
+    #[error("The frame changed sessions or was detached while waiting.")]
+    FrameSwappedOrDetached,
+    #[error("FrameId {frame:?} not found.")]
+    FrameNotFound { frame: FrameId },
+    #[error("The frame navigation failed: {0}")]
+    NavigationFailed(String),
+}
 
 /// Represents a the request for a navigation
 #[derive(Debug)]
@@ -692,5 +1939,1099 @@ impl AsRef<str> for LifecycleEvent {
             LifecycleEvent::NetworkIdle => "networkIdle",
             LifecycleEvent::NetworkAlmostIdle => "networkAlmostIdle",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::channel::oneshot;
+    use futures::executor::block_on;
+    use serde_json::json;
+
+    use chromiumoxide_cdp::cdp::browser_protocol::page::{
+        CrossOriginIsolatedContextType, GatedApiFeatures, NavigatedWithinDocumentNavigationType,
+        SecureContextType,
+    };
+    use chromiumoxide_cdp::cdp::browser_protocol::target::{TargetId, TargetInfo};
+    use chromiumoxide_cdp::cdp::js_protocol::runtime::ExecutionContextDescription;
+
+    use super::*;
+
+    fn session(id: &str) -> SessionId {
+        SessionId::new(id)
+    }
+
+    fn ctx_key(session_id: &SessionId, context_id: i64) -> ContextKey {
+        ContextKey {
+            session_id: session_id.clone(),
+            context_id: ExecutionContextId::new(context_id),
+        }
+    }
+
+    fn cdp_frame(id: &str, parent_id: Option<&str>, loader_id: &str) -> CdpFrame {
+        let mut builder = CdpFrame::builder()
+            .id(FrameId::new(id))
+            .loader_id(LoaderId::new(loader_id))
+            .url(format!("https://{id}.example/"))
+            .domain_and_registry("example")
+            .security_origin(format!("https://{id}.example"))
+            .mime_type("text/html")
+            .secure_context_type(SecureContextType::Secure)
+            .cross_origin_isolated_context_type(CrossOriginIsolatedContextType::NotIsolated)
+            .gated_api_features(Vec::<GatedApiFeatures>::new());
+        if let Some(parent_id) = parent_id {
+            builder = builder.parent_id(FrameId::new(parent_id));
+        }
+        builder
+            .build()
+            .expect("frame fixture has all mandatory fields")
+    }
+
+    fn target_info(frame_id: &str, parent_id: &str) -> TargetInfo {
+        TargetInfo::builder()
+            .target_id(TargetId::new(frame_id))
+            .r#type("iframe")
+            .title("iframe")
+            .url(format!("https://{frame_id}.example/"))
+            .attached(true)
+            .can_access_opener(false)
+            .parent_frame_id(FrameId::new(parent_id))
+            .build()
+            .expect("target fixture has all mandatory fields")
+    }
+
+    fn attached_event(
+        frame_id: &str,
+        parent_id: &str,
+        child_session: &SessionId,
+    ) -> EventAttachedToTarget {
+        EventAttachedToTarget {
+            session_id: child_session.clone(),
+            target_info: target_info(frame_id, parent_id),
+            waiting_for_debugger: true,
+        }
+    }
+
+    fn navigation_request(id: usize) -> FrameNavigationRequest {
+        FrameNavigationRequest::new(
+            NavigationId(id),
+            Request::new(
+                "Page.navigate".into(),
+                json!({ "url": format!("https://nav{id}.example/") }),
+            ),
+        )
+    }
+
+    fn manager_with_main() -> (FrameManager, SessionId, FrameId) {
+        let main_session = session("main");
+        let main_frame_id = FrameId::new("main-frame");
+        let mut manager = FrameManager::new(Duration::from_millis(100));
+        manager.set_main_session_id(main_session.clone());
+        manager.on_frame_navigated_in_session(
+            &cdp_frame("main-frame", None, "main-loader"),
+            main_session.clone(),
+        );
+        let frame = manager
+            .frames
+            .get_mut(&main_frame_id)
+            .expect("main frame is tracked");
+        frame.loader_id = Some(LoaderId::new("main-loader"));
+        frame.on_loading_stopped();
+        (manager, main_session, main_frame_id)
+    }
+
+    fn add_child(
+        manager: &mut FrameManager,
+        frame_id: &str,
+        parent_id: &str,
+        session_id: &SessionId,
+    ) {
+        assert_eq!(
+            manager.on_frame_attached_in_session(
+                FrameId::new(frame_id),
+                Some(FrameId::new(parent_id)),
+                session_id.clone(),
+            ),
+            None
+        );
+        manager.on_frame_navigated_in_session(
+            &cdp_frame(frame_id, Some(parent_id), &format!("{frame_id}-loader")),
+            session_id.clone(),
+        );
+        let frame = manager
+            .frames
+            .get_mut(&FrameId::new(frame_id))
+            .expect("child frame is tracked");
+        frame.loader_id = Some(LoaderId::new(format!("{frame_id}-loader")));
+        frame.on_loading_stopped();
+    }
+
+    fn execution_context(
+        frame_id: &str,
+        context_id: i64,
+        unique_id: &str,
+    ) -> EventExecutionContextCreated {
+        EventExecutionContextCreated {
+            context: ExecutionContextDescription::builder()
+                .id(ExecutionContextId::new(context_id))
+                .origin("https://example.test")
+                .name("")
+                .unique_id(unique_id)
+                .aux_data(json!({
+                    "frameId": frame_id,
+                    "isDefault": true,
+                    "type": "default"
+                }))
+                .build()
+                .expect("context fixture has all mandatory fields"),
+        }
+    }
+
+    /// A third-class isolated world: neither the default main world nor the
+    /// utility world chromiumoxide creates. Chrome emits these for injected /
+    /// extension content scripts and `about:blank` isolated worlds.
+    fn isolated_execution_context(
+        frame_id: &str,
+        context_id: i64,
+        unique_id: &str,
+        name: &str,
+    ) -> EventExecutionContextCreated {
+        EventExecutionContextCreated {
+            context: ExecutionContextDescription::builder()
+                .id(ExecutionContextId::new(context_id))
+                .origin("https://example.test")
+                .name(name)
+                .unique_id(unique_id)
+                .aux_data(json!({
+                    "frameId": frame_id,
+                    "isDefault": false,
+                    "type": "isolated"
+                }))
+                .build()
+                .expect("context fixture has all mandatory fields"),
+        }
+    }
+
+    fn destroyed(unique_id: &str) -> EventExecutionContextDestroyed {
+        EventExecutionContextDestroyed {
+            execution_context_unique_id: unique_id.to_owned(),
+        }
+    }
+
+    #[test]
+    fn isolated_world_registration_tracks_pending_confirmed_and_absent() {
+        let (mut manager, main_session, _) = manager_with_main();
+
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_some()
+        );
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            Some(IsolatedWorldState::Pending)
+        );
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_none(),
+            "an in-flight registration must be deduplicated"
+        );
+
+        manager.settle_isolated_world_registration(&main_session, UTILITY_WORLD_NAME, false);
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            None
+        );
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_some(),
+            "an explicit protocol failure restores the absent state"
+        );
+
+        manager.settle_isolated_world_registration(&main_session, UTILITY_WORLD_NAME, true);
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            Some(IsolatedWorldState::Confirmed)
+        );
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_none()
+        );
+
+        let child_session = session("child");
+        assert!(
+            manager
+                .ensure_isolated_world_on_next_document_in_session(
+                    UTILITY_WORLD_NAME,
+                    child_session.clone(),
+                )
+                .is_some()
+        );
+        manager.on_detached_from_target(&child_session, &main_session);
+        assert_eq!(
+            manager.isolated_world_state(&child_session, UTILITY_WORLD_NAME),
+            None
+        );
+    }
+
+    #[test]
+    fn isolated_world_late_success_does_not_recreate_cleared_registration() {
+        let (mut manager, main_session, _) = manager_with_main();
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_some()
+        );
+        manager.clear_isolated_world_registrations();
+        manager.settle_isolated_world_registration(&main_session, UTILITY_WORLD_NAME, true);
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            None,
+            "whole-target cleanup must not be undone by a late success"
+        );
+
+        let child_session = session("child");
+        assert!(
+            manager
+                .ensure_isolated_world_on_next_document_in_session(
+                    UTILITY_WORLD_NAME,
+                    child_session.clone(),
+                )
+                .is_some()
+        );
+        manager.on_detached_from_target(&child_session, &main_session);
+        manager.settle_isolated_world_registration(&child_session, UTILITY_WORLD_NAME, true);
+        assert_eq!(
+            manager.isolated_world_state(&child_session, UTILITY_WORLD_NAME),
+            None,
+            "child detach cleanup must not be undone by a late success"
+        );
+    }
+
+    #[test]
+    fn isolated_world_context_then_protocol_error_stays_confirmed() {
+        let (mut manager, main_session, _) = manager_with_main();
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_some()
+        );
+
+        manager.on_frame_execution_context_created_in_session(
+            &execution_context("main-frame", 90, "default-context"),
+            main_session.clone(),
+        );
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            Some(IsolatedWorldState::Pending),
+            "a default context must not confirm the named utility world"
+        );
+
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("main-frame", 93, "extension-context", "extension"),
+            main_session.clone(),
+        );
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            Some(IsolatedWorldState::Pending),
+            "a differently named isolated context must not confirm the utility key"
+        );
+        assert_eq!(
+            manager.isolated_world_state(&main_session, "extension"),
+            Some(IsolatedWorldState::Confirmed),
+            "the observed extension world is tracked under its own real name"
+        );
+
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("main-frame", 91, "utility-context", UTILITY_WORLD_NAME),
+            main_session.clone(),
+        );
+        manager.settle_isolated_world_registration(&main_session, UTILITY_WORLD_NAME, false);
+
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            Some(IsolatedWorldState::Confirmed)
+        );
+    }
+
+    #[test]
+    fn isolated_world_protocol_error_then_context_becomes_confirmed() {
+        let (mut manager, main_session, _) = manager_with_main();
+        assert!(
+            manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone())
+                .is_some()
+        );
+        manager.settle_isolated_world_registration(&main_session, UTILITY_WORLD_NAME, false);
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            None
+        );
+
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context(
+                "main-frame",
+                92,
+                "late-utility-context",
+                UTILITY_WORLD_NAME,
+            ),
+            main_session.clone(),
+        );
+
+        assert_eq!(
+            manager.isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            Some(IsolatedWorldState::Confirmed)
+        );
+    }
+
+    #[test]
+    fn destroying_a_third_class_isolated_context_clears_both_indices() {
+        let (mut manager, main_session, _) = manager_with_main();
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("main-frame", 5, "extension-context", "extension"),
+            main_session.clone(),
+        );
+        assert!(manager.context_by_unique.contains_key("extension-context"));
+        assert!(
+            manager
+                .context_to_frame
+                .contains_key(&ctx_key(&main_session, 5))
+        );
+
+        manager.on_frame_execution_context_destroyed_in_session(
+            &destroyed("extension-context"),
+            main_session.clone(),
+        );
+
+        // Historically this forward entry leaked because destroy could only
+        // resolve the numeric id for the main/utility worlds.
+        assert!(!manager.context_by_unique.contains_key("extension-context"));
+        assert!(
+            !manager
+                .context_to_frame
+                .contains_key(&ctx_key(&main_session, 5))
+        );
+    }
+
+    #[test]
+    fn numeric_context_id_reuse_across_frames_does_not_misroute() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        // Two frames each get numeric context id 3 in the same session.
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("main-frame", 3, "main-iso", "iso"),
+            main_session.clone(),
+        );
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("child", 3, "child-iso", "iso"),
+            main_session.clone(),
+        );
+
+        // The later insert owns numeric key (session, 3); the forward map must
+        // point at the frame that created it last, not the earlier one.
+        let binding = manager
+            .context_to_frame
+            .get(&ctx_key(&main_session, 3))
+            .expect("numeric key is bound");
+        assert_eq!(binding.frame_id, FrameId::new("child"));
+        assert_eq!(binding.unique_id, "child-iso");
+
+        // Destroying the earlier context must not touch the reused forward key.
+        manager.on_frame_execution_context_destroyed_in_session(
+            &destroyed("main-iso"),
+            main_session.clone(),
+        );
+        let binding = manager
+            .context_to_frame
+            .get(&ctx_key(&main_session, 3))
+            .expect("reused key survives the stale destroy");
+        assert_eq!(binding.frame_id, FrameId::new("child"));
+        assert!(!manager.context_by_unique.contains_key("main-iso"));
+    }
+
+    #[test]
+    fn late_destroy_after_same_frame_numeric_reuse_keeps_current_binding() {
+        let (mut manager, main_session, _) = manager_with_main();
+        // First context on the frame with numeric id 4.
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("main-frame", 4, "first-iso", "iso"),
+            main_session.clone(),
+        );
+        // Numeric id 4 is reused on the same frame by a newer context before the
+        // first one's destroy is processed.
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("main-frame", 4, "second-iso", "iso"),
+            main_session.clone(),
+        );
+
+        // The forward key now belongs to the newer context.
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 4))
+                .map(|binding| binding.unique_id.clone()),
+            Some("second-iso".to_owned())
+        );
+
+        // Late destroy of the first context must not evict the newer binding.
+        manager.on_frame_execution_context_destroyed_in_session(
+            &destroyed("first-iso"),
+            main_session.clone(),
+        );
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 4))
+                .map(|binding| binding.unique_id.clone()),
+            Some("second-iso".to_owned())
+        );
+        assert!(!manager.context_by_unique.contains_key("first-iso"));
+        assert!(manager.context_by_unique.contains_key("second-iso"));
+    }
+
+    #[test]
+    fn bulk_clear_of_old_frame_preserves_reused_key_binding_of_another_frame() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "childA", "main-frame", &main_session);
+        add_child(&mut manager, "childB", "main-frame", &main_session);
+        // Both frames use numeric context id 3 in the same session; childB is
+        // created last, so it owns the forward (session, 3) key. childA leaves a
+        // stale reverse entry that still points at the reused key.
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("childA", 3, "A-iso", "iso"),
+            main_session.clone(),
+        );
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("childB", 3, "B-iso", "iso"),
+            main_session.clone(),
+        );
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 3))
+                .map(|binding| binding.unique_id.clone()),
+            Some("B-iso".to_owned())
+        );
+
+        // Drive a REAL bulk path (recursive frame removal), not the helper
+        // directly: detaching childA must not delete childB's live forward
+        // binding on the reused key.
+        manager.on_frame_detached(&EventFrameDetached {
+            frame_id: FrameId::new("childA"),
+            reason: FrameDetachedReason::Remove,
+        });
+
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 3))
+                .map(|binding| binding.unique_id.clone()),
+            Some("B-iso".to_owned()),
+            "childB's forward binding must survive childA's bulk clear"
+        );
+        assert!(!manager.context_by_unique.contains_key("A-iso"));
+        assert!(manager.context_by_unique.contains_key("B-iso"));
+    }
+
+    #[test]
+    fn session_detach_leaves_another_sessions_same_numeric_key_intact() {
+        let (mut manager, main_session, _) = manager_with_main();
+        // childA lives in a child session; childB stays on the main session.
+        add_child(&mut manager, "childA", "main-frame", &main_session);
+        let child_session = session("child-session");
+        manager.on_attached_to_target_in_session(
+            &attached_event("childA", "main-frame", &child_session),
+            child_session.clone(),
+        );
+        add_child(&mut manager, "childB", "main-frame", &main_session);
+        // Reuse numeric id 5 across the two sessions. The keys differ by session
+        // (`(child_session, 5)` vs `(main_session, 5)`), so this exercises
+        // per-session scoping of the bulk clear, NOT the same-key `still_ours`
+        // guard (which the same-session tests below cover).
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("childA", 5, "A-iso", "iso"),
+            child_session.clone(),
+        );
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("childB", 5, "B-iso", "iso"),
+            main_session.clone(),
+        );
+
+        manager.on_detached_from_target(&child_session, &main_session);
+
+        // childB's main-session binding on numeric id 5 must be untouched.
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 5))
+                .map(|binding| binding.unique_id.clone()),
+            Some("B-iso".to_owned())
+        );
+        assert!(!manager.context_by_unique.contains_key("A-iso"));
+        assert_no_orphan_forward_entries(&manager);
+    }
+
+    #[test]
+    fn same_session_swap_clear_preserves_another_frames_reused_key_binding() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "childA", "main-frame", &main_session);
+        add_child(&mut manager, "childB", "main-frame", &main_session);
+        // Same session, same numeric id 7; childB is created last and owns the
+        // forward key, leaving childA with a stale reverse entry.
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("childA", 7, "A-iso", "iso"),
+            main_session.clone(),
+        );
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("childB", 7, "B-iso", "iso"),
+            main_session.clone(),
+        );
+
+        // Swap-detaching childA clears its contexts through `clear_frame_contexts`
+        // (a different bulk path than recursive removal). The `still_ours` guard
+        // must keep childB's live binding on the reused key.
+        manager.on_frame_detached(&EventFrameDetached {
+            frame_id: FrameId::new("childA"),
+            reason: FrameDetachedReason::Swap,
+        });
+
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 7))
+                .map(|binding| binding.unique_id.clone()),
+            Some("B-iso".to_owned()),
+            "childB's forward binding must survive childA's swap-clear"
+        );
+        assert!(!manager.context_by_unique.contains_key("A-iso"));
+        assert_no_orphan_forward_entries(&manager);
+    }
+
+    /// Every `context_to_frame` (forward) entry must have a matching
+    /// `context_by_unique` (reverse) entry carrying the same unique id. The
+    /// forward map is driven entirely by the reverse map, so an orphaned forward
+    /// entry would mean an insert path wrote only one map — a drift the bulk
+    /// eviction can no longer clean up. Asserting it turns the "forward always
+    /// has a reverse" invariant into a tested contract.
+    fn assert_no_orphan_forward_entries(manager: &FrameManager) {
+        for (key, binding) in &manager.context_to_frame {
+            let reverse = manager.context_by_unique.get(&binding.unique_id);
+            assert!(
+                reverse.is_some_and(|context| context.key.as_ref() == Some(key)),
+                "forward entry {key:?} -> {binding:?} has no matching reverse entry",
+            );
+        }
+    }
+
+    #[test]
+    fn recursive_removal_leaves_no_orphan_forward_entries() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        add_child(&mut manager, "grandchild", "child", &main_session);
+        manager.on_frame_execution_context_created_in_session(
+            &execution_context("child", 1, "child-default"),
+            main_session.clone(),
+        );
+        manager.on_frame_execution_context_created_in_session(
+            &isolated_execution_context("grandchild", 2, "grand-iso", "iso"),
+            main_session.clone(),
+        );
+
+        manager.on_frame_detached(&EventFrameDetached {
+            frame_id: FrameId::new("child"),
+            reason: FrameDetachedReason::Remove,
+        });
+
+        assert_no_orphan_forward_entries(&manager);
+    }
+
+    #[test]
+    fn fresh_frames_bind_to_the_event_session() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+
+        assert_eq!(
+            manager
+                .frame(&FrameId::new("child"))
+                .and_then(Frame::session_id),
+            Some(&main_session)
+        );
+    }
+
+    #[test]
+    fn swap_back_uses_the_parent_session_and_rejects_a_stale_old_attach() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        let child_session = session("child-session");
+        manager.on_attached_to_target_in_session(
+            &attached_event("child", "main-frame", &child_session),
+            child_session.clone(),
+        );
+        assert!(manager.is_child_session(&child_session));
+
+        let swapped = manager.on_frame_attached_in_session(
+            FrameId::new("child"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        assert_eq!(swapped, Some(child_session.clone()));
+        assert_eq!(
+            manager
+                .frame(&FrameId::new("child"))
+                .and_then(Frame::session_id),
+            Some(&main_session)
+        );
+
+        let stale = manager.on_frame_attached_in_session(
+            FrameId::new("child"),
+            Some(FrameId::new("main-frame")),
+            child_session,
+        );
+        assert_eq!(stale, None);
+        assert_eq!(
+            manager
+                .frame(&FrameId::new("child"))
+                .and_then(Frame::session_id),
+            Some(&main_session)
+        );
+    }
+
+    #[test]
+    fn nested_swap_back_rebinds_s2_to_parent_s1_not_to_main() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "outer", "main-frame", &main_session);
+        let session_one = session("s1");
+        manager.on_attached_to_target_in_session(
+            &attached_event("outer", "main-frame", &session_one),
+            session_one.clone(),
+        );
+        add_child(&mut manager, "inner", "outer", &session_one);
+        let session_two = session("s2");
+        manager.on_attached_to_target_in_session(
+            &attached_event("inner", "outer", &session_two),
+            session_two.clone(),
+        );
+
+        let swapped = manager.on_frame_attached_in_session(
+            FrameId::new("inner"),
+            Some(FrameId::new("outer")),
+            session_one.clone(),
+        );
+        assert_eq!(swapped, Some(session_two));
+        let inner = manager.frame(&FrameId::new("inner")).expect("inner frame");
+        assert_eq!(inner.session_id(), Some(&session_one));
+        assert!(inner.is_out_of_process(&main_session));
+    }
+
+    #[test]
+    fn execution_context_ids_are_scoped_by_session() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        let child_session = session("child-session");
+        manager.rebind_frame_session(&FrameId::new("child"), child_session.clone());
+
+        manager.on_frame_execution_context_created_in_session(
+            &execution_context("main-frame", 7, "main-unique"),
+            main_session.clone(),
+        );
+        manager.on_frame_execution_context_created_in_session(
+            &execution_context("child", 7, "child-unique"),
+            child_session.clone(),
+        );
+
+        assert_eq!(manager.context_to_frame.len(), 2);
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&main_session, 7))
+                .map(|binding| binding.frame_id.clone()),
+            Some(FrameId::new("main-frame"))
+        );
+        assert_eq!(
+            manager
+                .context_to_frame
+                .get(&ctx_key(&child_session, 7))
+                .map(|binding| binding.frame_id.clone()),
+            Some(FrameId::new("child"))
+        );
+
+        manager.on_execution_contexts_cleared_in_session(main_session.clone());
+        assert!(
+            manager
+                .frame(&FrameId::new("main-frame"))
+                .expect("main frame")
+                .main_world()
+                .execution_context()
+                .is_none()
+        );
+        assert_eq!(
+            manager
+                .frame(&FrameId::new("child"))
+                .expect("child frame")
+                .main_world()
+                .execution_context(),
+            Some(ExecutionContextId::new(7))
+        );
+        assert!(
+            !manager
+                .context_to_frame
+                .contains_key(&ctx_key(&main_session, 7))
+        );
+        assert!(
+            manager
+                .context_to_frame
+                .contains_key(&ctx_key(&child_session, 7))
+        );
+    }
+
+    #[test]
+    fn binding_change_evicts_waiters_and_submitted_navigation_lanes() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        let child_frame = FrameId::new("child");
+        let (wait_tx, wait_rx) = oneshot::channel();
+        manager.wait_for_navigation(main_session.clone(), child_frame.clone(), wait_tx);
+
+        let next_session = session("next");
+        manager.rebind_frame_session(&child_frame, next_session.clone());
+        assert_eq!(
+            block_on(wait_rx).expect("waiter resolves"),
+            Err(FrameWaitError::FrameSwappedOrDetached)
+        );
+
+        manager.navigate_frame_in_session(
+            next_session.clone(),
+            child_frame.clone(),
+            navigation_request(11),
+        );
+        assert!(matches!(
+            manager.poll(Instant::now()),
+            Some(FrameEvent::NavigationRequest(NavigationId(11), _))
+        ));
+        manager.rebind_frame_session(&child_frame, session("third"));
+        assert!(matches!(
+            manager.poll(Instant::now()),
+            Some(FrameEvent::NavigationResult(Err(
+                NavigationError::FrameNotFound {
+                    id: NavigationId(11),
+                    ..
+                }
+            )))
+        ));
+    }
+
+    #[test]
+    fn cross_session_navigation_updates_metadata_without_removing_descendants() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        let child_session = session("child-session");
+        manager.rebind_frame_session(&FrameId::new("child"), child_session.clone());
+        add_child(&mut manager, "grandchild", "child", &child_session);
+
+        let mut event = cdp_frame("child", Some("main-frame"), "foreign-loader");
+        event.url = "https://updated.example/path".to_owned();
+        event.name = Some("updated-name".to_owned());
+        manager.on_frame_navigated_in_session(&event, main_session);
+
+        let child = manager.frame(&FrameId::new("child")).expect("child frame");
+        assert_eq!(child.url(), Some("https://updated.example/path"));
+        assert_eq!(child.name(), Some("updated-name"));
+        assert_eq!(child.session_id(), Some(&child_session));
+        assert_eq!(child.loader_id, Some(LoaderId::new("child-loader")));
+        assert!(child.child_frames.contains(&FrameId::new("grandchild")));
+        assert!(manager.frames.contains_key(&FrameId::new("grandchild")));
+    }
+
+    #[test]
+    fn anticipated_goto_merge_preserves_waiter_and_old_loader_snapshot() {
+        let (mut manager, main_session, main_frame_id) = manager_with_main();
+        let (wait_tx, _wait_rx) = oneshot::channel();
+        manager.wait_for_navigation(main_session.clone(), main_frame_id.clone(), wait_tx);
+        manager.navigate_frame_in_session(
+            main_session.clone(),
+            main_frame_id.clone(),
+            navigation_request(12),
+        );
+
+        assert!(matches!(
+            manager.poll(Instant::now()),
+            Some(FrameEvent::NavigationRequest(NavigationId(12), _))
+        ));
+        let entry = manager
+            .navigation
+            .get(&(Some(main_session), main_frame_id))
+            .expect("anticipated entry was upgraded in place");
+        assert_eq!(entry.waiters.len(), 1);
+        assert_eq!(entry.pre_loader_id, Some(LoaderId::new("main-loader")));
+        assert_eq!(
+            entry
+                .watcher
+                .as_ref()
+                .and_then(|watcher| watcher.loader_id.clone()),
+            Some(LoaderId::new("main-loader"))
+        );
+    }
+
+    #[test]
+    fn none_and_session_navigation_lanes_evict_each_other() {
+        let frame_id = FrameId::new("standalone");
+        let mut manager = FrameManager::new(Duration::from_millis(100));
+        manager
+            .frames
+            .insert(frame_id.clone(), Frame::new(frame_id.clone()));
+        manager.navigate_frame(frame_id.clone(), navigation_request(1));
+        manager.rebind_frame_session(&frame_id, session("s1"));
+        assert!(matches!(
+            manager.poll(Instant::now()),
+            Some(FrameEvent::NavigationResult(Err(
+                NavigationError::FrameNotFound {
+                    id: NavigationId(1),
+                    ..
+                }
+            )))
+        ));
+
+        manager.navigate_frame_in_session(session("s1"), frame_id.clone(), navigation_request(2));
+        manager.register_pending(None, frame_id, navigation_request(3));
+        assert!(matches!(
+            manager.poll(Instant::now()),
+            Some(FrameEvent::NavigationResult(Err(
+                NavigationError::FrameNotFound {
+                    id: NavigationId(2),
+                    ..
+                }
+            )))
+        ));
+    }
+
+    #[test]
+    fn explicit_same_document_navigation_completes_the_correct_lane() {
+        let (mut manager, main_session, main_frame_id) = manager_with_main();
+        manager.navigate_frame_in_session(
+            main_session.clone(),
+            main_frame_id.clone(),
+            navigation_request(21),
+        );
+        let request = manager.poll(Instant::now()).expect("navigation request");
+        assert!(matches!(
+            request,
+            FrameEvent::NavigationRequest(NavigationId(21), _)
+        ));
+
+        manager.on_frame_navigated_within_document_in_session(
+            &EventNavigatedWithinDocument {
+                frame_id: main_frame_id,
+                url: "https://main-frame.example/#hash".to_owned(),
+                navigation_type: NavigatedWithinDocumentNavigationType::Fragment,
+            },
+            main_session,
+        );
+        assert!(matches!(
+            manager.poll(Instant::now()),
+            Some(FrameEvent::NavigationResult(Ok(
+                NavigationOk::SameDocumentNavigation(NavigationId(21))
+            )))
+        ));
+    }
+
+    #[test]
+    fn concurrent_frame_sessions_each_submit_one_navigation() {
+        let (mut manager, main_session, main_frame_id) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        let child_session = session("child-session");
+        manager.rebind_frame_session(&FrameId::new("child"), child_session.clone());
+
+        manager.navigate_frame_in_session(
+            main_session.clone(),
+            main_frame_id,
+            navigation_request(31),
+        );
+        manager.navigate_frame_in_session(
+            child_session.clone(),
+            FrameId::new("child"),
+            navigation_request(32),
+        );
+
+        let first = manager.poll(Instant::now()).expect("first request");
+        let second = manager.poll(Instant::now()).expect("second request");
+        let sessions = [first, second]
+            .into_iter()
+            .map(|event| match event {
+                FrameEvent::NavigationRequest(_, request) => request.session_id,
+                other => panic!("expected navigation request, got {other:?}"),
+            })
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            sessions,
+            HashSet::from([Some(main_session.into()), Some(child_session.into()),])
+        );
+    }
+
+    #[test]
+    fn poll_completes_all_waiter_only_entries_in_one_full_scan() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child-one", "main-frame", &main_session);
+        add_child(&mut manager, "child-two", "main-frame", &main_session);
+        let (first_tx, first_rx) = oneshot::channel();
+        let (second_tx, second_rx) = oneshot::channel();
+        manager.wait_for_navigation(main_session.clone(), FrameId::new("child-one"), first_tx);
+        manager.wait_for_navigation(main_session.clone(), FrameId::new("child-two"), second_tx);
+
+        manager.on_frame_navigated_in_session(
+            &cdp_frame("child-one", Some("main-frame"), "child-one-loader-new"),
+            main_session.clone(),
+        );
+        manager.on_frame_navigated_in_session(
+            &cdp_frame("child-two", Some("main-frame"), "child-two-loader-new"),
+            main_session,
+        );
+        for (frame_id, loader_id) in [
+            (
+                FrameId::new("child-one"),
+                LoaderId::new("child-one-loader-new"),
+            ),
+            (
+                FrameId::new("child-two"),
+                LoaderId::new("child-two-loader-new"),
+            ),
+        ] {
+            let frame = manager.frames.get_mut(&frame_id).expect("tracked frame");
+            frame.loader_id = Some(loader_id);
+            frame.on_loading_stopped();
+        }
+
+        assert!(manager.poll(Instant::now()).is_none());
+        assert_eq!(block_on(first_rx).expect("first waiter resolves"), Ok(()));
+        assert_eq!(block_on(second_rx).expect("second waiter resolves"), Ok(()));
+    }
+
+    #[test]
+    fn recursive_removal_cleans_context_and_navigation_state() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        add_child(&mut manager, "grandchild", "child", &main_session);
+        manager.insert_context(
+            Some(&main_session),
+            ExecutionContextId::new(9),
+            "grandchild-context".to_owned(),
+            FrameId::new("grandchild"),
+        );
+        let (wait_tx, wait_rx) = oneshot::channel();
+        manager.wait_for_navigation(main_session, FrameId::new("grandchild"), wait_tx);
+
+        manager.on_frame_detached(&EventFrameDetached {
+            frame_id: FrameId::new("child"),
+            reason: FrameDetachedReason::Remove,
+        });
+
+        assert!(!manager.frames.contains_key(&FrameId::new("child")));
+        assert!(!manager.frames.contains_key(&FrameId::new("grandchild")));
+        assert!(!manager.context_by_unique.contains_key("grandchild-context"));
+        assert!(
+            !manager
+                .context_to_frame
+                .values()
+                .any(|binding| binding.frame_id == FrameId::new("grandchild"))
+        );
+        assert_eq!(
+            block_on(wait_rx).expect("waiter resolves"),
+            Err(FrameWaitError::FrameNotFound {
+                frame: FrameId::new("grandchild")
+            })
+        );
+    }
+
+    #[test]
+    fn swap_detach_preserves_frame_identity_but_clears_its_contexts() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        manager.on_frame_execution_context_created_in_session(
+            &execution_context("child", 12, "child-context"),
+            main_session,
+        );
+
+        manager.on_frame_detached(&EventFrameDetached {
+            frame_id: FrameId::new("child"),
+            reason: FrameDetachedReason::Swap,
+        });
+
+        let child = manager
+            .frame(&FrameId::new("child"))
+            .expect("frame survives swap");
+        assert!(child.main_world().execution_context().is_none());
+        assert!(!manager.context_by_unique.contains_key("child-context"));
+    }
+
+    #[test]
+    fn child_session_detach_cleans_session_state_and_rebinds_descendants() {
+        let (mut manager, main_session, _) = manager_with_main();
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        let child_session = session("child-session");
+        manager.on_attached_to_target_in_session(
+            &attached_event("child", "main-frame", &child_session),
+            child_session.clone(),
+        );
+        add_child(&mut manager, "grandchild", "child", &child_session);
+        manager.on_frame_execution_context_created_in_session(
+            &execution_context("grandchild", 14, "grandchild-context"),
+            child_session.clone(),
+        );
+        let (wait_tx, wait_rx) = oneshot::channel();
+        manager.wait_for_navigation(child_session.clone(), FrameId::new("grandchild"), wait_tx);
+
+        manager.on_detached_from_target(&child_session, &main_session);
+
+        assert!(!manager.is_child_session(&child_session));
+        for frame_id in [FrameId::new("child"), FrameId::new("grandchild")] {
+            assert_eq!(
+                manager.frame(&frame_id).and_then(Frame::session_id),
+                Some(&main_session)
+            );
+        }
+        assert!(!manager.context_by_unique.contains_key("grandchild-context"));
+        assert!(
+            !manager
+                .context_to_frame
+                .keys()
+                .any(|key| key.session_id == child_session)
+        );
+        assert_eq!(
+            block_on(wait_rx).expect("waiter resolves"),
+            Err(FrameWaitError::FrameSwappedOrDetached)
+        );
+    }
+
+    #[test]
+    fn anticipated_waiter_timeouts_are_all_settled_before_poll_returns_none() {
+        let (mut manager, main_session, main_frame_id) = manager_with_main();
+        let (first_tx, first_rx) = oneshot::channel();
+        let (second_tx, second_rx) = oneshot::channel();
+        manager.wait_for_navigation(main_session.clone(), main_frame_id.clone(), first_tx);
+        manager
+            .navigation
+            .get_mut(&(Some(main_session.clone()), main_frame_id.clone()))
+            .expect("first navigation entry")
+            .deadline = Instant::now() - Duration::from_millis(1);
+
+        add_child(&mut manager, "child", "main-frame", &main_session);
+        manager.wait_for_navigation(main_session.clone(), FrameId::new("child"), second_tx);
+        manager
+            .navigation
+            .get_mut(&(Some(main_session), FrameId::new("child")))
+            .expect("second navigation entry")
+            .deadline = Instant::now() - Duration::from_millis(1);
+
+        assert!(manager.poll(Instant::now()).is_none());
+        assert_eq!(
+            block_on(first_rx).expect("first waiter resolves"),
+            Err(FrameWaitError::Timeout)
+        );
+        assert_eq!(
+            block_on(second_rx).expect("second waiter resolves"),
+            Err(FrameWaitError::Timeout)
+        );
     }
 }

--- a/src/handler/http.rs
+++ b/src/handler/http.rs
@@ -1,10 +1,12 @@
 use chromiumoxide_cdp::cdp::browser_protocol::network::{InterceptionId, RequestId, Response};
 use chromiumoxide_cdp::cdp::browser_protocol::page::FrameId;
+use chromiumoxide_cdp::cdp::browser_protocol::target::SessionId;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct HttpRequest {
     request_id: RequestId,
+    session_id: Option<SessionId>,
     pub from_memory_cache: bool,
     pub failure_text: Option<String>,
     pub interception_id: Option<InterceptionId>,
@@ -29,8 +31,45 @@ impl HttpRequest {
         allow_interception: bool,
         redirect_chain: Vec<HttpRequest>,
     ) -> Self {
+        Self::new_inner(
+            request_id,
+            frame,
+            interception_id,
+            allow_interception,
+            redirect_chain,
+            None,
+        )
+    }
+
+    pub(crate) fn new_with_session(
+        request_id: RequestId,
+        frame: Option<FrameId>,
+        interception_id: Option<InterceptionId>,
+        allow_interception: bool,
+        redirect_chain: Vec<HttpRequest>,
+        session_id: SessionId,
+    ) -> Self {
+        Self::new_inner(
+            request_id,
+            frame,
+            interception_id,
+            allow_interception,
+            redirect_chain,
+            Some(session_id),
+        )
+    }
+
+    fn new_inner(
+        request_id: RequestId,
+        frame: Option<FrameId>,
+        interception_id: Option<InterceptionId>,
+        allow_interception: bool,
+        redirect_chain: Vec<HttpRequest>,
+        session_id: Option<SessionId>,
+    ) -> Self {
         Self {
             request_id,
+            session_id,
             from_memory_cache: false,
             failure_text: None,
             interception_id,
@@ -50,6 +89,10 @@ impl HttpRequest {
 
     pub fn request_id(&self) -> &RequestId {
         &self.request_id
+    }
+
+    pub(crate) fn session_id(&self) -> Option<&SessionId> {
+        self.session_id.as_ref()
     }
 
     pub(crate) fn set_response(&mut self, response: Response) {

--- a/src/handler/httpfuture.rs
+++ b/src/handler/httpfuture.rs
@@ -1,6 +1,6 @@
 use futures::FutureExt;
 use futures::channel::mpsc;
-use futures::future::{Fuse, FusedFuture};
+use futures::future::{BoxFuture, Fuse, FusedFuture};
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
@@ -19,7 +19,7 @@ pin_project! {
         #[pin]
         command: Fuse<CommandFuture<T>>,
         #[pin]
-        navigation: TargetMessageFuture<ArcHttpRequest>,
+        navigation: BoxFuture<'static, Result<ArcHttpRequest>>,
     }
 }
 
@@ -27,7 +27,17 @@ impl<T: Command> HttpFuture<T> {
     pub fn new(sender: mpsc::Sender<TargetMessage>, command: CommandFuture<T>) -> Self {
         Self {
             command: command.fuse(),
-            navigation: TargetMessageFuture::<T>::wait_for_navigation(sender),
+            navigation: TargetMessageFuture::<T>::wait_for_navigation(sender).boxed(),
+        }
+    }
+
+    pub(crate) fn with_navigation(
+        command: CommandFuture<T>,
+        navigation: BoxFuture<'static, Result<ArcHttpRequest>>,
+    ) -> Self {
+        Self {
+            command: command.fuse(),
+            navigation,
         }
     }
 }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -10,28 +10,40 @@ use futures::task::{Context, Poll};
 
 use crate::listeners::{EventListenerRequest, EventListeners};
 use chromiumoxide_cdp::cdp::browser_protocol::browser::*;
+use chromiumoxide_cdp::cdp::browser_protocol::page::{
+    AddScriptToEvaluateOnNewDocumentParams, NavigateReturns, ScriptIdentifier,
+};
 use chromiumoxide_cdp::cdp::browser_protocol::target::*;
 use chromiumoxide_cdp::cdp::events::CdpEvent;
 use chromiumoxide_cdp::cdp::events::CdpEventMessage;
-use chromiumoxide_types::{CallId, Message, Method, Response};
+use chromiumoxide_types::{CallId, Error as ProtocolError, Message, Method, Response};
 use chromiumoxide_types::{MethodId, Request as CdpRequest};
+#[cfg(test)]
+pub(crate) use page::PageHandle;
 pub(crate) use page::PageInner;
 
 use crate::cmd::{CommandMessage, to_command_response};
 use crate::conn::Connection;
 use crate::error::{CdpError, Result};
 use crate::handler::browser::BrowserContext;
-use crate::handler::frame::FrameNavigationRequest;
-use crate::handler::frame::{NavigationError, NavigationId, NavigationOk};
+use crate::handler::frame::{FrameNavigationRequest, FrameWaitError, HTTP_RESPONSE_CODE_FAILURE};
+use crate::handler::frame::{NavigationError, NavigationId, NavigationOk, PreloadId};
 use crate::handler::job::PeriodicJob;
 use crate::handler::session::Session;
-use crate::handler::target::TargetEvent;
+use crate::handler::target::{FanOutAckBatch, TargetEvent};
 use crate::handler::target::{Target, TargetConfig};
 use crate::handler::viewport::Viewport;
 use crate::page::Page;
 
 /// Standard timeout in MS
 pub const REQUEST_TIMEOUT: u64 = 30_000;
+
+/// Chrome uses this structured protocol error for commands addressed to a
+/// child session that has already detached. Detection is shared by ACK and
+/// navigation paths even though their dispositions differ.
+pub(crate) fn is_session_gone_error(error: &ProtocolError) -> bool {
+    error.code == -32001
+}
 
 pub mod browser;
 pub mod commandfuture;
@@ -57,6 +69,9 @@ pub struct Handler {
     /// chromium instance together with the timestamp when the request
     /// started.
     pending_commands: FnvHashMap<CallId, (PendingRequest, MethodId, Instant)>,
+    /// Response-confirmed multi-session operations. A group owns the only
+    /// caller sender; individual pending calls only carry its stable id.
+    pending_ack_groups: FnvHashMap<AckGroupId, AckGroup>,
     /// Connection to the browser instance
     from_browser: Fuse<Receiver<HandlerMessage>>,
     default_browser_context: BrowserContext,
@@ -77,6 +92,8 @@ pub struct Handler {
     evict_command_timeout: PeriodicJob,
     /// The internal identifier for a specific navigation
     next_navigation_id: usize,
+    /// Monotonic id source for response-confirmed fan-out groups.
+    next_ack_group_id: u64,
     /// How this handler will configure targets etc,
     config: HandlerConfig,
     /// All registered event subscriptions
@@ -108,6 +125,7 @@ impl Handler {
 
         Self {
             pending_commands: Default::default(),
+            pending_ack_groups: Default::default(),
             from_browser: rx.fuse(),
             default_browser_context: Default::default(),
             browser_contexts,
@@ -118,6 +136,7 @@ impl Handler {
             conn,
             evict_command_timeout: PeriodicJob::new(config.request_timeout),
             next_navigation_id: 0,
+            next_ack_group_id: 0,
             config,
             event_listeners: Default::default(),
             closing: false,
@@ -144,8 +163,135 @@ impl Handler {
         self.browser_contexts.iter()
     }
 
+    fn next_ack_group_id(&mut self) -> AckGroupId {
+        let id = AckGroupId(self.next_ack_group_id);
+        self.next_ack_group_id = self.next_ack_group_id.wrapping_add(1);
+        id
+    }
+
+    fn classify_fan_out_member_outcome(
+        is_main: bool,
+        error: Option<ProtocolError>,
+    ) -> MemberOutcome {
+        match error {
+            None => MemberOutcome::Complete,
+            Some(error) if !is_main && is_session_gone_error(&error) => MemberOutcome::Complete,
+            Some(error) => MemberOutcome::Err(CdpError::Chrome(error)),
+        }
+    }
+
+    /// Consume one removed pending member. Removing the pending call before
+    /// this method makes duplicate detach/response/timeout paths idempotent.
+    fn complete_ack_member(&mut self, group_id: AckGroupId, outcome: MemberOutcome) {
+        match outcome {
+            MemberOutcome::Err(error) => self.fail_ack_group(group_id, error),
+            MemberOutcome::Complete => {
+                let complete = match self.pending_ack_groups.get_mut(&group_id) {
+                    Some(group) if group.remaining > 0 => {
+                        group.remaining -= 1;
+                        group.remaining == 0
+                    }
+                    Some(_) | None => false,
+                };
+                if complete {
+                    if let Some(group) = self.pending_ack_groups.remove(&group_id) {
+                        let _ = group.tx.send(Ok(()));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Fail a fan-out immediately and purge every still-pending member so late
+    /// responses become harmless unknown call ids.
+    fn fail_ack_group(&mut self, group_id: AckGroupId, error: CdpError) {
+        let Some(group) = self.pending_ack_groups.remove(&group_id) else {
+            return;
+        };
+        self.pending_commands.retain(|_, (pending, _, _)| {
+            !matches!(
+                pending,
+                PendingRequest::FanOutAckMember {
+                    group_id: pending_group,
+                    ..
+                } if *pending_group == group_id
+            )
+        });
+        let _ = group.tx.send(Err(error));
+    }
+
+    fn fail_ack_groups_for_target(&mut self, target_id: &TargetId) {
+        let group_ids = self
+            .pending_ack_groups
+            .iter()
+            .filter(|(_, group)| &group.target_id == target_id)
+            .map(|(group_id, _)| *group_id)
+            .collect::<Vec<_>>();
+        for group_id in group_ids {
+            self.fail_ack_group(group_id, CdpError::NoResponse);
+        }
+    }
+
+    fn fail_all_ack_groups(&mut self) {
+        let group_ids = self.pending_ack_groups.keys().copied().collect::<Vec<_>>();
+        for group_id in group_ids {
+            self.fail_ack_group(group_id, CdpError::NoResponse);
+        }
+    }
+
+    fn fail_navigation_response(
+        &mut self,
+        id: NavigationId,
+        error: CdpError,
+        watcher_error: String,
+    ) {
+        if let Some(NavigationRequest::Navigate(navigation)) = self.navigations.remove(&id) {
+            if let Some(target) = self.targets.get_mut(&navigation.target_id) {
+                target.on_navigation_failed(id, watcher_error);
+            }
+            let _ = navigation.tx.send(Err(error));
+        }
+    }
+
     /// received a response to a navigation request like `Page.navigate`
-    fn on_navigation_response(&mut self, id: NavigationId, resp: Response) {
+    fn on_navigation_response(&mut self, id: NavigationId, mut resp: Response) {
+        if let Some(error) = resp.error.take() {
+            if is_session_gone_error(&error) {
+                tracing::debug!(navigation_id = ?id, "navigation session disappeared before response");
+            }
+            let watcher_error = error.message.clone();
+            self.fail_navigation_response(id, CdpError::Chrome(error), watcher_error);
+            return;
+        }
+
+        let navigate_result = match resp.result.as_ref() {
+            Some(result) => {
+                serde_json::from_value::<NavigateReturns>(result.clone()).map_err(CdpError::from)
+            }
+            None => Err(CdpError::NoResponse),
+        };
+        let navigate_result = match navigate_result {
+            Ok(result) => result,
+            Err(error) => {
+                let watcher_error = error.to_string();
+                self.fail_navigation_response(id, error, watcher_error);
+                return;
+            }
+        };
+        if let Some(error_text) = navigate_result
+            .error_text
+            .filter(|error_text| !error_text.is_empty())
+        {
+            if error_text != HTTP_RESPONSE_CODE_FAILURE {
+                self.fail_navigation_response(
+                    id,
+                    CdpError::ChromeMessage(error_text.clone()),
+                    error_text,
+                );
+                return;
+            }
+        }
+
         if let Some(nav) = self.navigations.remove(&id) {
             match nav {
                 NavigationRequest::Navigate(mut nav) => {
@@ -181,6 +327,7 @@ impl Handler {
                 }
             }
             Err(err) => {
+                self.remove_pending_navigation_call(*err.navigation_id());
                 if let Some(nav) = self.navigations.remove(err.navigation_id()) {
                     match nav {
                         NavigationRequest::Navigate(nav) => {
@@ -189,6 +336,20 @@ impl Handler {
                     }
                 }
             }
+        }
+    }
+
+    fn remove_pending_navigation_call(&mut self, navigation_id: NavigationId) {
+        let call_ids = self
+            .pending_commands
+            .iter()
+            .filter_map(|(call_id, (pending, _, _))| {
+                matches!(pending, PendingRequest::Navigate(id) if *id == navigation_id)
+                    .then_some(*call_id)
+            })
+            .collect::<Vec<_>>();
+        for call_id in call_ids {
+            self.pending_commands.remove(&call_id);
         }
     }
 
@@ -238,15 +399,109 @@ impl Handler {
                     }
                 }
                 PendingRequest::Navigate(id) => {
-                    self.on_navigation_response(id, resp);
-                }
-                PendingRequest::ExternalCommand(tx) => {
-                    let _ = tx.send(Ok(resp)).ok();
-                }
-                PendingRequest::InternalCommand(target_id) => {
-                    if let Some(target) = self.targets.get_mut(&target_id) {
-                        target.on_response(resp, method.as_ref());
+                    let detached = self
+                        .navigations
+                        .get(&id)
+                        .map(|navigation| match navigation {
+                            NavigationRequest::Navigate(navigation) => {
+                                navigation.session_id.clone()
+                            }
+                        })
+                        .is_some_and(|session_id| self.session_is_unavailable(&session_id));
+                    if detached {
+                        if let Some(NavigationRequest::Navigate(navigation)) =
+                            self.navigations.remove(&id)
+                        {
+                            let _ = navigation.tx.send(Err(CdpError::FrameNotReady));
+                        }
+                    } else {
+                        self.on_navigation_response(id, resp);
                     }
+                }
+                PendingRequest::ExternalCommand { session_id, tx } => {
+                    if session_id
+                        .as_ref()
+                        .is_some_and(|session_id| self.session_is_unavailable(session_id))
+                    {
+                        let _ = tx.send(Err(CdpError::FrameNotReady));
+                    } else {
+                        let _ = tx.send(Ok(resp));
+                    }
+                }
+                PendingRequest::InternalCommand(target_id, session_id) => {
+                    let detached = session_id
+                        .as_ref()
+                        .is_some_and(|session_id| self.session_is_unavailable(session_id));
+                    if !detached {
+                        if let Some(target) = self.targets.get_mut(&target_id) {
+                            target.on_response_in_session(resp, method.as_ref(), session_id);
+                        }
+                    }
+                }
+                PendingRequest::PreloadAddScript {
+                    target_id,
+                    session_id,
+                    preload_key,
+                } => {
+                    match to_command_response::<AddScriptToEvaluateOnNewDocumentParams>(
+                        resp, method,
+                    ) {
+                        Ok(response) => {
+                            if !self.session_is_unavailable(&session_id) {
+                                if let Some(target) = self.targets.get_mut(&target_id) {
+                                    target.frame_manager_mut().set_preload_id(
+                                        preload_key,
+                                        session_id,
+                                        response.result.identifier,
+                                    );
+                                }
+                            }
+                        }
+                        Err(error) => {
+                            tracing::debug!(
+                                target_id = %target_id.as_ref(),
+                                session_id = %session_id.as_ref(),
+                                %error,
+                                "child preload script registration failed"
+                            );
+                        }
+                    }
+                }
+                PendingRequest::AddPreloadScriptMain {
+                    target_id,
+                    params,
+                    tx,
+                } => {
+                    match to_command_response::<AddScriptToEvaluateOnNewDocumentParams>(
+                        resp, method,
+                    ) {
+                        Ok(response) => {
+                            let main_id = response.result.identifier;
+                            if let Some(target) = self.targets.get_mut(&target_id) {
+                                let preload_key = target
+                                    .frame_manager_mut()
+                                    .add_preload_script(params, main_id.clone());
+                                target.enqueue_preload_fan_out(preload_key);
+                                let _ = tx.send(Ok(main_id));
+                            } else {
+                                let _ = tx.send(Err(CdpError::NoResponse));
+                            }
+                        }
+                        Err(error) => {
+                            let _ = tx.send(Err(error));
+                        }
+                    }
+                }
+                PendingRequest::FanOutAckMember {
+                    group_id,
+                    session_id,
+                } => {
+                    let is_main = self
+                        .pending_ack_groups
+                        .get(&group_id)
+                        .is_some_and(|group| group.main_session_id == session_id);
+                    let outcome = Self::classify_fan_out_member_outcome(is_main, resp.error);
+                    self.complete_ack_member(group_id, outcome);
                 }
                 PendingRequest::CloseBrowser(tx) => {
                     self.closing = true;
@@ -256,18 +511,35 @@ impl Handler {
         }
     }
 
+    fn session_is_unavailable(&self, session_id: &SessionId) -> bool {
+        let Some(session) = self.sessions.get(session_id) else {
+            return true;
+        };
+        self.targets
+            .get(session.target_id())
+            .is_none_or(|target| target.is_session_draining(session_id))
+    }
+
     /// Submit a command initiated via channel
     pub(crate) fn submit_external_command(
         &mut self,
         msg: CommandMessage,
         now: Instant,
     ) -> Result<()> {
+        let session_id = msg.session_id.clone();
         let call_id = self
             .conn
             .submit_command(msg.method.clone(), msg.session_id, msg.params)?;
         self.pending_commands.insert(
             call_id,
-            (PendingRequest::ExternalCommand(msg.sender), msg.method, now),
+            (
+                PendingRequest::ExternalCommand {
+                    session_id,
+                    tx: msg.sender,
+                },
+                msg.method,
+                now,
+            ),
         );
         Ok(())
     }
@@ -278,6 +550,10 @@ impl Handler {
         req: CdpRequest,
         now: Instant,
     ) -> Result<()> {
+        let session_id = req
+            .session_id
+            .as_ref()
+            .map(|session_id| SessionId::new(session_id.clone()));
         let call_id = self.conn.submit_command(
             req.method.clone(),
             req.session_id.map(Into::into),
@@ -285,9 +561,98 @@ impl Handler {
         )?;
         self.pending_commands.insert(
             call_id,
-            (PendingRequest::InternalCommand(target_id), req.method, now),
+            (
+                PendingRequest::InternalCommand(target_id, session_id),
+                req.method,
+                now,
+            ),
         );
         Ok(())
+    }
+
+    /// Submit an already-serialized request and attach its lifecycle owner.
+    /// `Connection::submit_command` only allocates an id and queues a value, so
+    /// after serialization this operation has no recoverable failure branch.
+    fn submit_command_with_pending(
+        &mut self,
+        req: CdpRequest,
+        pending: PendingRequest,
+        now: Instant,
+    ) -> CallId {
+        let CdpRequest {
+            method,
+            session_id,
+            params,
+        } = req;
+        let call_id = self
+            .conn
+            .submit_command(method.clone(), session_id.map(SessionId::new), params)
+            .expect("queuing an already-serialized CDP request is infallible");
+        self.pending_commands
+            .insert(call_id, (pending, method, now));
+        call_id
+    }
+
+    /// Submit both disjoint halves of one queued fan-out item exactly once.
+    /// The target queue position establishes ordering; this method only turns
+    /// the already-ordered batch into call ids and an acknowledgement group.
+    fn submit_fan_out_ack_batch(
+        &mut self,
+        target_id: &TargetId,
+        batch: FanOutAckBatch,
+        now: Instant,
+    ) {
+        let FanOutAckBatch {
+            ack_reqs,
+            send_only_reqs,
+            ack_tx,
+            main_session_id,
+        } = batch;
+
+        for request in send_only_reqs {
+            let session_id = request
+                .session_id
+                .as_ref()
+                .map(|session_id| SessionId::new(session_id.clone()));
+            self.submit_command_with_pending(
+                request,
+                PendingRequest::InternalCommand(target_id.clone(), session_id),
+                now,
+            );
+        }
+
+        if ack_reqs.is_empty() {
+            let _ = ack_tx.send(Ok(()));
+            return;
+        }
+
+        let group_id = self.next_ack_group_id();
+        self.pending_ack_groups.insert(
+            group_id,
+            AckGroup {
+                target_id: target_id.clone(),
+                main_session_id,
+                remaining: ack_reqs.len(),
+                tx: ack_tx,
+            },
+        );
+        for request in ack_reqs {
+            let session_id = SessionId::new(
+                request
+                    .session_id
+                    .as_ref()
+                    .expect("fan-out request carries a session")
+                    .clone(),
+            );
+            self.submit_command_with_pending(
+                request,
+                PendingRequest::FanOutAckMember {
+                    group_id,
+                    session_id,
+                },
+                now,
+            );
+        }
     }
 
     fn submit_fetch_targets(&mut self, tx: OneshotSender<Result<Vec<TargetInfo>>>, now: Instant) {
@@ -318,6 +683,31 @@ impl Handler {
             .insert(call_id, (PendingRequest::Navigate(id), req.method, now));
     }
 
+    fn submit_navigation_for_target(
+        &mut self,
+        target: &Target,
+        id: NavigationId,
+        req: CdpRequest,
+        now: Instant,
+    ) {
+        let draining_session = req
+            .session_id
+            .as_ref()
+            .map(|session_id| SessionId::new(session_id.clone()))
+            .filter(|session_id| target.is_session_draining(session_id));
+        if draining_session.is_some() {
+            // The target is temporarily outside the registry while it is
+            // polled, so this gate must use the local target. A missing sender
+            // means earlier draining cleanup already settled the navigation.
+            if let Some(NavigationRequest::Navigate(navigation)) = self.navigations.remove(&id) {
+                let _ = navigation.tx.send(Err(CdpError::FrameNotReady));
+            }
+            return;
+        }
+
+        self.submit_navigation(id, req, now);
+    }
+
     fn submit_close(&mut self, tx: OneshotSender<Result<CloseReturns>>, now: Instant) {
         let close_msg = CloseParams::default();
         let method = close_msg.identifier();
@@ -337,14 +727,31 @@ impl Handler {
 
     /// Process a message received by the target's page via channel
     fn on_target_message(&mut self, target: &mut Target, msg: CommandMessage, now: Instant) {
-        // if let some
+        if let Some(session_id) = msg.session_id.as_ref() {
+            if !target.frame_session_ready(session_id) {
+                let _ = msg.sender.send(Err(CdpError::FrameNotReady));
+                return;
+            }
+        }
         if msg.is_navigation() {
+            let Some(session_id) = msg
+                .session_id
+                .clone()
+                .or_else(|| target.session_id().cloned())
+            else {
+                let _ = msg.sender.send(Err(CdpError::FrameNotReady));
+                return;
+            };
             let (req, tx) = msg.split();
             let id = self.next_navigation_id();
-            target.goto(FrameNavigationRequest::new(id, req));
+            target.goto_in_session(session_id.clone(), FrameNavigationRequest::new(id, req));
             self.navigations.insert(
                 id,
-                NavigationRequest::Navigate(NavigationInProgress::new(tx)),
+                NavigationRequest::Navigate(NavigationInProgress::new(
+                    target.target_id().clone(),
+                    session_id,
+                    tx,
+                )),
             );
         } else {
             let _ = self.submit_external_command(msg, now);
@@ -356,6 +763,254 @@ impl Handler {
         let id = NavigationId(self.next_navigation_id);
         self.next_navigation_id = self.next_navigation_id.wrapping_add(1);
         id
+    }
+
+    /// Settle every submitted operation owned by one child session. Main
+    /// session teardown is target-wide and deliberately takes a different path.
+    fn fail_pending_for_session(&mut self, target: &mut Target, session_id: &SessionId) {
+        if target.session_id() == Some(session_id) {
+            return;
+        }
+
+        let call_ids = self
+            .pending_commands
+            .iter()
+            .filter_map(|(call_id, (pending, _, _))| {
+                let matches = match pending {
+                    PendingRequest::ExternalCommand {
+                        session_id: Some(pending_session),
+                        ..
+                    } => pending_session == session_id,
+                    PendingRequest::ExternalCommand {
+                        session_id: None, ..
+                    } => false,
+                    PendingRequest::InternalCommand(_, Some(pending_session)) => {
+                        pending_session == session_id
+                    }
+                    PendingRequest::InternalCommand(_, None) => false,
+                    PendingRequest::FanOutAckMember {
+                        session_id: pending_session,
+                        ..
+                    } => pending_session == session_id,
+                    PendingRequest::PreloadAddScript {
+                        session_id: pending_session,
+                        ..
+                    } => pending_session == session_id,
+                    PendingRequest::AddPreloadScriptMain { .. } => false,
+                    PendingRequest::Navigate(navigation_id) => self
+                        .navigations
+                        .get(navigation_id)
+                        .is_some_and(|navigation| match navigation {
+                            NavigationRequest::Navigate(navigation) => {
+                                &navigation.session_id == session_id
+                            }
+                        }),
+                    PendingRequest::CreateTarget(_)
+                    | PendingRequest::GetTargets(_)
+                    | PendingRequest::CloseBrowser(_) => false,
+                };
+                matches.then_some(*call_id)
+            })
+            .collect::<Vec<_>>();
+
+        for call_id in call_ids {
+            let Some((pending, _, _)) = self.pending_commands.remove(&call_id) else {
+                continue;
+            };
+            match pending {
+                PendingRequest::ExternalCommand { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::FrameNotReady));
+                }
+                PendingRequest::InternalCommand(_, _) => {}
+                PendingRequest::PreloadAddScript { .. } => {}
+                PendingRequest::AddPreloadScriptMain { .. } => {}
+                PendingRequest::FanOutAckMember { group_id, .. } => {
+                    self.complete_ack_member(group_id, MemberOutcome::Complete);
+                }
+                PendingRequest::Navigate(navigation_id) => {
+                    if let Some(NavigationRequest::Navigate(navigation)) =
+                        self.navigations.remove(&navigation_id)
+                    {
+                        let _ = navigation.tx.send(Err(CdpError::FrameNotReady));
+                    }
+                }
+                PendingRequest::CreateTarget(_)
+                | PendingRequest::GetTargets(_)
+                | PendingRequest::CloseBrowser(_) => {}
+            }
+        }
+
+        let navigation_ids = self
+            .navigations
+            .iter()
+            .filter_map(|(navigation_id, navigation)| match navigation {
+                NavigationRequest::Navigate(navigation) if &navigation.session_id == session_id => {
+                    Some(*navigation_id)
+                }
+                NavigationRequest::Navigate(_) => None,
+            })
+            .collect::<Vec<_>>();
+        for navigation_id in navigation_ids {
+            if let Some(NavigationRequest::Navigate(navigation)) =
+                self.navigations.remove(&navigation_id)
+            {
+                let _ = navigation.tx.send(Err(CdpError::FrameNotReady));
+            }
+        }
+
+        target.fail_queued_events(session_id);
+    }
+
+    /// Settle all state owned by a target, including child sessions and
+    /// navigation entries whose command response already arrived.
+    fn fail_pending_for_target(&mut self, target_id: &TargetId, main_session: Option<&SessionId>) {
+        let mut owned_sessions = self
+            .sessions
+            .values()
+            .filter(|session| session.target_id() == target_id)
+            .map(|session| session.session_id().clone())
+            .collect::<HashSet<_>>();
+        if let Some(main_session) = main_session {
+            owned_sessions.insert(main_session.clone());
+        }
+
+        let navigation_ids = self
+            .navigations
+            .iter()
+            .filter_map(|(navigation_id, navigation)| match navigation {
+                NavigationRequest::Navigate(navigation) if &navigation.target_id == target_id => {
+                    Some(*navigation_id)
+                }
+                NavigationRequest::Navigate(_) => None,
+            })
+            .collect::<HashSet<_>>();
+
+        let call_ids = self
+            .pending_commands
+            .iter()
+            .filter_map(|(call_id, (pending, _, _))| {
+                let matches = match pending {
+                    PendingRequest::InternalCommand(pending_target, _) => {
+                        pending_target == target_id
+                    }
+                    PendingRequest::ExternalCommand {
+                        session_id: Some(session_id),
+                        ..
+                    } => owned_sessions.contains(session_id),
+                    PendingRequest::ExternalCommand {
+                        session_id: None, ..
+                    } => false,
+                    PendingRequest::FanOutAckMember { group_id, .. } => self
+                        .pending_ack_groups
+                        .get(group_id)
+                        .is_some_and(|group| &group.target_id == target_id),
+                    PendingRequest::PreloadAddScript {
+                        target_id: pending_target,
+                        ..
+                    }
+                    | PendingRequest::AddPreloadScriptMain {
+                        target_id: pending_target,
+                        ..
+                    } => pending_target == target_id,
+                    PendingRequest::Navigate(navigation_id) => {
+                        navigation_ids.contains(navigation_id)
+                    }
+                    PendingRequest::CreateTarget(_)
+                    | PendingRequest::GetTargets(_)
+                    | PendingRequest::CloseBrowser(_) => false,
+                };
+                matches.then_some(*call_id)
+            })
+            .collect::<Vec<_>>();
+
+        for navigation_id in &navigation_ids {
+            if let Some(NavigationRequest::Navigate(navigation)) =
+                self.navigations.remove(navigation_id)
+            {
+                let _ = navigation.tx.send(Err(CdpError::NoResponse));
+            }
+        }
+
+        for call_id in call_ids {
+            let Some((pending, _, _)) = self.pending_commands.remove(&call_id) else {
+                continue;
+            };
+            match pending {
+                PendingRequest::ExternalCommand { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                PendingRequest::Navigate(_) | PendingRequest::InternalCommand(_, _) => {}
+                PendingRequest::PreloadAddScript { .. } => {}
+                PendingRequest::AddPreloadScriptMain { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                PendingRequest::FanOutAckMember { group_id, .. } => {
+                    self.fail_ack_group(group_id, CdpError::NoResponse);
+                }
+                PendingRequest::CreateTarget(_)
+                | PendingRequest::GetTargets(_)
+                | PendingRequest::CloseBrowser(_) => {}
+            }
+        }
+
+        self.sessions
+            .retain(|_, session| session.target_id() != target_id);
+    }
+
+    /// Explicitly settle owned senders before the handler stream terminates.
+    /// This avoids exposing channel cancellation when the transport already
+    /// knows no response can arrive.
+    fn fail_all_pending_on_connection_close(&mut self) {
+        for target in self.targets.values_mut() {
+            target.fail_all_queued_events();
+            target.settle_whole_target_teardown();
+            // On connection close the Handler stops polling, so FrameManager
+            // waiters would otherwise hang until their own deadline (which is
+            // never advanced again). Settle them with a typed error now. The
+            // Handler-owned goto senders are settled by the pending drain below.
+            target
+                .frame_manager_mut()
+                .fail_all_navigation_state(FrameWaitError::FrameSwappedOrDetached);
+        }
+        self.fail_all_ack_groups();
+
+        for (_, (pending, _, _)) in std::mem::take(&mut self.pending_commands) {
+            match pending {
+                PendingRequest::CreateTarget(tx) => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                PendingRequest::GetTargets(tx) => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                PendingRequest::Navigate(navigation_id) => {
+                    if let Some(NavigationRequest::Navigate(navigation)) =
+                        self.navigations.remove(&navigation_id)
+                    {
+                        let _ = navigation.tx.send(Err(CdpError::NoResponse));
+                    }
+                }
+                PendingRequest::ExternalCommand { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                PendingRequest::InternalCommand(_, _)
+                | PendingRequest::FanOutAckMember { .. }
+                | PendingRequest::PreloadAddScript { .. } => {}
+                PendingRequest::AddPreloadScriptMain { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                PendingRequest::CloseBrowser(tx) => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+            }
+        }
+
+        for (_, navigation) in std::mem::take(&mut self.navigations) {
+            match navigation {
+                NavigationRequest::Navigate(navigation) => {
+                    let _ = navigation.tx.send(Err(CdpError::NoResponse));
+                }
+            }
+        }
     }
 
     /// Create a new page and send it to the receiver when ready
@@ -457,22 +1112,65 @@ impl Handler {
     /// Can be issued multiple times per target if multiple session have been
     /// attached to it.
     fn on_detached_from_target(&mut self, event: EventDetachedFromTarget) {
-        // remove the session
-        if let Some(session) = self.sessions.remove(&event.session_id) {
-            if let Some(target) = self.targets.get_mut(session.target_id()) {
+        let Some(session) = self.sessions.get(&event.session_id).cloned() else {
+            return;
+        };
+        let target_id = session.target_id().clone();
+        let is_main = self
+            .targets
+            .get(&target_id)
+            .is_some_and(|target| target.session_id() == Some(&event.session_id));
+
+        if is_main {
+            if let Some(mut target) = self.targets.remove(&target_id) {
+                let main_session = target.session_id().cloned();
+                target.fail_all_queued_events();
+                target.settle_whole_target_teardown();
+                // Main-session detach drops the whole target; settle FrameManager
+                // waiters before it (and its FrameManager) is gone. Handler-owned
+                // goto senders are settled by fail_pending_for_target below.
+                target
+                    .frame_manager_mut()
+                    .fail_all_navigation_state(FrameWaitError::FrameSwappedOrDetached);
+                self.fail_ack_groups_for_target(&target_id);
+                self.fail_pending_for_target(&target_id, main_session.as_ref());
                 target.session_id_mut().take();
+            }
+            self.target_ids.retain(|candidate| candidate != &target_id);
+        } else {
+            tracing::warn!(
+                target_id = ?target_id,
+                session_id = ?event.session_id,
+                "child-session detach reached the handler path; the auto-attach envelope invariant did not hold and cleanup here is incomplete"
+            );
+            self.sessions.remove(&event.session_id);
+            if let Some(mut target) = self.targets.remove(&target_id) {
+                self.fail_pending_for_session(&mut target, &event.session_id);
+                target.clear_draining(&event.session_id);
+                self.targets.insert(target_id, target);
             }
         }
     }
 
     /// Fired when the target was destroyed in the browser
     fn on_target_destroyed(&mut self, event: EventTargetDestroyed) {
-        if let Some(target) = self.targets.remove(&event.target_id) {
-            // TODO shutdown?
-            if let Some(session) = target.session_id() {
-                self.sessions.remove(session);
-            }
+        if let Some(mut target) = self.targets.remove(&event.target_id) {
+            let main_session = target.session_id().cloned();
+            target.fail_all_queued_events();
+            target.settle_whole_target_teardown();
+            // Settle FrameManager-registered wait_for_navigation waiters before
+            // the target (and its FrameManager) is dropped, so callers observe a
+            // typed error rather than a channel cancellation. The Handler-owned
+            // goto senders are settled by fail_pending_for_target below.
+            target
+                .frame_manager_mut()
+                .fail_all_navigation_state(FrameWaitError::FrameSwappedOrDetached);
+            self.fail_ack_groups_for_target(&event.target_id);
+            self.fail_pending_for_target(&event.target_id, main_session.as_ref());
+            target.session_id_mut().take();
         }
+        self.target_ids
+            .retain(|target_id| target_id != &event.target_id);
     }
 
     /// House keeping of commands
@@ -504,10 +1202,17 @@ impl Handler {
                             }
                         }
                     }
-                    PendingRequest::ExternalCommand(tx) => {
+                    PendingRequest::ExternalCommand { tx, .. } => {
                         let _ = tx.send(Err(CdpError::Timeout));
                     }
-                    PendingRequest::InternalCommand(_) => {}
+                    PendingRequest::InternalCommand(_, _) => {}
+                    PendingRequest::PreloadAddScript { .. } => {}
+                    PendingRequest::AddPreloadScriptMain { tx, .. } => {
+                        let _ = tx.send(Err(CdpError::Timeout));
+                    }
+                    PendingRequest::FanOutAckMember { group_id, .. } => {
+                        self.fail_ack_group(group_id, CdpError::Timeout);
+                    }
                     PendingRequest::CloseBrowser(tx) => {
                         let _ = tx.send(Err(CdpError::Timeout));
                     }
@@ -547,14 +1252,24 @@ impl Stream for Handler {
                         pin.create_page(params, tx);
                     }
                     HandlerMessage::GetPages(tx) => {
-                        let pages: Vec<_> = pin
-                            .targets
-                            .values_mut()
-                            .filter(|p| p.is_page())
-                            .filter_map(|target| target.get_or_create_page())
-                            .map(|page| Page::from(page.clone()))
-                            .collect();
-                        let _ = tx.send(pages);
+                        let mut pages = Vec::new();
+                        let mut exposed_target_ids = Vec::new();
+                        for (target_id, target) in &mut pin.targets {
+                            if !target.is_page() {
+                                continue;
+                            }
+                            if let Some(page) = target.get_or_create_page() {
+                                pages.push(Page::from(page.clone()));
+                                exposed_target_ids.push(target_id.clone());
+                            }
+                        }
+                        if tx.send(pages).is_ok() {
+                            for target_id in exposed_target_ids {
+                                if let Some(target) = pin.targets.get_mut(&target_id) {
+                                    target.mark_page_exposed_after_successful_send(true);
+                                }
+                            }
+                        }
                     }
                     HandlerMessage::InsertContext(ctx) => {
                         pin.browser_contexts.insert(ctx);
@@ -563,12 +1278,16 @@ impl Stream for Handler {
                         pin.browser_contexts.remove(&ctx);
                     }
                     HandlerMessage::GetPage(target_id, tx) => {
-                        let page = pin
-                            .targets
-                            .get_mut(&target_id)
-                            .and_then(|target| target.get_or_create_page())
-                            .map(|page| Page::from(page.clone()));
-                        let _ = tx.send(page);
+                        if let Some(target) = pin.targets.get_mut(&target_id) {
+                            let page = target
+                                .get_or_create_page()
+                                .map(|page| Page::from(page.clone()));
+                            let has_page = page.is_some();
+                            let delivered = tx.send(page).is_ok();
+                            target.mark_page_exposed_after_successful_send(has_page && delivered);
+                        } else {
+                            let _ = tx.send(None);
+                        }
                     }
                     HandlerMessage::AddEventListener(req) => {
                         pin.event_listeners.add_listener(req);
@@ -592,10 +1311,110 @@ impl Stream for Handler {
                                 pin.on_target_message(&mut target, msg, now);
                             }
                             TargetEvent::NavigationRequest(id, req) => {
-                                pin.submit_navigation(id, req, now);
+                                pin.submit_navigation_for_target(&target, id, req, now);
                             }
                             TargetEvent::NavigationResult(res) => {
                                 pin.on_navigation_lifecycle_completed(res)
+                            }
+                            TargetEvent::RegisterChildSession(session_id) => {
+                                let session =
+                                    Session::new(session_id.clone(), target.target_id().clone());
+                                pin.sessions.insert(session_id, session);
+                            }
+                            TargetEvent::UnregisterChildSession(session_id) => {
+                                pin.sessions.remove(&session_id);
+                                pin.fail_pending_for_session(&mut target, &session_id);
+                                target.fail_queued_events(&session_id);
+                                target.clear_draining(&session_id);
+                            }
+                            TargetEvent::SessionDraining(session_id) => {
+                                pin.fail_pending_for_session(&mut target, &session_id);
+                                target.fail_queued_events(&session_id);
+                            }
+                            TargetEvent::FrameNavigate {
+                                session_id,
+                                frame_id,
+                                req,
+                                tx,
+                            } => {
+                                if !target.frame_ready(&frame_id, &session_id) {
+                                    let _ = tx.send(Err(CdpError::FrameNotReady));
+                                } else {
+                                    let navigation_id = pin.next_navigation_id();
+                                    target.goto_frame(
+                                        session_id.clone(),
+                                        frame_id,
+                                        FrameNavigationRequest::new(navigation_id, req),
+                                    );
+                                    pin.navigations.insert(
+                                        navigation_id,
+                                        NavigationRequest::Navigate(NavigationInProgress::new(
+                                            target.target_id().clone(),
+                                            session_id,
+                                            tx,
+                                        )),
+                                    );
+                                }
+                            }
+                            TargetEvent::FrameWaitForNavigation {
+                                session_id,
+                                frame_id,
+                                tx,
+                            } => {
+                                if !target.frame_ready(&frame_id, &session_id) {
+                                    let _ = tx.send(Err(
+                                        crate::handler::frame::FrameWaitError::FrameSwappedOrDetached,
+                                    ));
+                                } else {
+                                    target
+                                        .frame_manager_mut()
+                                        .wait_for_navigation(session_id, frame_id, tx);
+                                }
+                            }
+                            TargetEvent::QueuePreloadScript {
+                                request,
+                                preload_key,
+                            } => {
+                                let session_id = SessionId::new(
+                                    request
+                                        .session_id
+                                        .as_ref()
+                                        .expect("preload request carries a child session")
+                                        .clone(),
+                                );
+                                pin.submit_command_with_pending(
+                                    request,
+                                    PendingRequest::PreloadAddScript {
+                                        target_id: target.target_id().clone(),
+                                        session_id,
+                                        preload_key,
+                                    },
+                                    now,
+                                );
+                            }
+                            TargetEvent::AddPreloadScript { params, tx } => {
+                                if let Some(main_session_id) = target.session_id().cloned() {
+                                    let request = CdpRequest {
+                                        method: params.identifier(),
+                                        session_id: Some(main_session_id.into()),
+                                        params: serde_json::to_value(params.clone())
+                                            .expect("preload command should serialize"),
+                                    };
+                                    pin.submit_command_with_pending(
+                                        request,
+                                        PendingRequest::AddPreloadScriptMain {
+                                            target_id: target.target_id().clone(),
+                                            params,
+                                            tx,
+                                        },
+                                        now,
+                                    );
+                                } else {
+                                    let _ = tx.send(Err(CdpError::FrameNotReady));
+                                }
+                            }
+                            TargetEvent::FanOutAckBatch(batch) => {
+                                pin.submit_fan_out_ack_batch(target.target_id(), batch, now);
                             }
                         }
                     }
@@ -612,31 +1431,41 @@ impl Stream for Handler {
 
             let mut done = true;
 
-            while let Poll::Ready(Some(ev)) = Pin::new(&mut pin.conn).poll_next(cx) {
-                match ev {
-                    Ok(Message::Response(resp)) => {
-                        pin.on_response(resp);
-                        if pin.closing {
-                            // handler should stop processing
-                            return Poll::Ready(None);
+            loop {
+                match Pin::new(&mut pin.conn).poll_next(cx) {
+                    Poll::Pending => break,
+                    Poll::Ready(None) => {
+                        pin.fail_all_pending_on_connection_close();
+                        return Poll::Ready(None);
+                    }
+                    Poll::Ready(Some(ev)) => {
+                        done = false;
+                        match ev {
+                            Ok(Message::Response(resp)) => {
+                                pin.on_response(resp);
+                                if pin.closing {
+                                    pin.fail_all_pending_on_connection_close();
+                                    return Poll::Ready(None);
+                                }
+                            }
+                            Ok(Message::Event(ev)) => {
+                                pin.on_event(ev);
+                            }
+                            Err(err @ CdpError::InvalidMessage(_, _)) => {
+                                if pin.config.ignore_invalid_messages {
+                                    tracing::warn!("WS Invalid message: {}", err);
+                                } else {
+                                    return Poll::Ready(Some(Err(err)));
+                                }
+                            }
+                            Err(err) => {
+                                tracing::error!("WS Connection error: {:?}", err);
+                                pin.fail_all_pending_on_connection_close();
+                                return Poll::Ready(Some(Err(err)));
+                            }
                         }
-                    }
-                    Ok(Message::Event(ev)) => {
-                        pin.on_event(ev);
-                    }
-                    Err(err @ CdpError::InvalidMessage(_, _)) => {
-                        if pin.config.ignore_invalid_messages {
-                            tracing::warn!("WS Invalid message: {}", err);
-                        } else {
-                            return Poll::Ready(Some(Err(err)));
-                        }
-                    }
-                    Err(err) => {
-                        tracing::error!("WS Connection error: {:?}", err);
-                        return Poll::Ready(Some(Err(err)));
                     }
                 }
-                done = false;
             }
 
             if pin.evict_command_timeout.poll_ready(cx) {
@@ -688,6 +1517,11 @@ impl Default for HandlerConfig {
 /// Wraps the sender half of the channel who requested a navigation
 #[derive(Debug)]
 pub struct NavigationInProgress<T> {
+    /// Target that owns this navigation. Needed to settle lifecycle-only state
+    /// when the whole target disappears.
+    target_id: TargetId,
+    /// Session selected once at registration and used for detach cleanup.
+    session_id: SessionId,
     /// Marker to indicate whether a navigation lifecycle has completed
     navigated: bool,
     /// The response of the issued navigation request
@@ -697,8 +1531,10 @@ pub struct NavigationInProgress<T> {
 }
 
 impl<T> NavigationInProgress<T> {
-    fn new(tx: OneshotSender<T>) -> Self {
+    fn new(target_id: TargetId, session_id: SessionId, tx: OneshotSender<T>) -> Self {
         Self {
+            target_id,
+            session_id,
             navigated: false,
             response: None,
             tx,
@@ -741,12 +1577,57 @@ enum PendingRequest {
     /// loading, which comes after the response.
     Navigate(NavigationId),
     /// A common request received via a channel (`Page`).
-    ExternalCommand(OneshotSender<Result<Response>>),
+    ExternalCommand {
+        /// `None` is the browser/root transport path; page and frame commands
+        /// always retain their real session identity here.
+        session_id: Option<SessionId>,
+        tx: OneshotSender<Result<Response>>,
+    },
     /// Requests that are initiated directly from a `Target` (all the
     /// initialization commands).
-    InternalCommand(TargetId),
+    InternalCommand(TargetId, Option<SessionId>),
+    /// One response-confirmed command in a multi-session fan-out operation.
+    FanOutAckMember {
+        group_id: AckGroupId,
+        session_id: SessionId,
+    },
+    /// Add one tracked preload to a child session, whether sourced from its
+    /// initialization snapshot or a later existing-session fan-out.
+    PreloadAddScript {
+        target_id: TargetId,
+        session_id: SessionId,
+        preload_key: PreloadId,
+    },
+    /// Add a public preload to the main session while retaining its complete
+    /// parameters until the returned identifier can be tracked.
+    AddPreloadScriptMain {
+        target_id: TargetId,
+        params: AddScriptToEvaluateOnNewDocumentParams,
+        tx: OneshotSender<Result<ScriptIdentifier>>,
+    },
     // A Request to close the browser.
     CloseBrowser(OneshotSender<Result<CloseReturns>>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct AckGroupId(u64);
+
+#[derive(Debug)]
+struct AckGroup {
+    target_id: TargetId,
+    /// Stored at creation so a detached child remains distinguishable from
+    /// the main session when a racing response is classified.
+    main_session_id: SessionId,
+    /// Counts CDP command responses, not sessions. A session may contribute
+    /// more than one member while preserving one caller acknowledgement.
+    remaining: usize,
+    tx: OneshotSender<Result<()>>,
+}
+
+#[derive(Debug)]
+enum MemberOutcome {
+    Complete,
+    Err(CdpError),
 }
 
 /// Events used internally to communicate with the handler, which are executed
@@ -763,4 +1644,1766 @@ pub(crate) enum HandlerMessage {
     GetPage(TargetId, OneshotSender<Option<Page>>),
     AddEventListener(EventListenerRequest),
     CloseBrowser(OneshotSender<Result<CloseReturns>>),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use async_tungstenite::tungstenite::Message as WsMessage;
+    use futures::channel::{mpsc, oneshot};
+    use futures::future::BoxFuture;
+    use futures::task::noop_waker_ref;
+    use futures::{SinkExt, StreamExt};
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    use chromiumoxide_cdp::cdp::browser_protocol::page::FrameId;
+    use chromiumoxide_cdp::cdp::js_protocol::runtime::RunIfWaitingForDebuggerParams;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct SharedLogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedLogWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("test log buffer lock")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn session(id: &str) -> SessionId {
+        SessionId::new(id)
+    }
+
+    fn target_id(id: &str) -> TargetId {
+        TargetId::new(id)
+    }
+
+    fn target_info(id: &str) -> TargetInfo {
+        TargetInfo::builder()
+            .target_id(target_id(id))
+            .r#type("page")
+            .title(id)
+            .url("about:blank")
+            .attached(true)
+            .can_access_opener(false)
+            .build()
+            .expect("target fixture has all mandatory fields")
+    }
+
+    fn frame_navigated_event(
+        session_id: &SessionId,
+        frame_id: &str,
+        parent_id: Option<&str>,
+        url: &str,
+    ) -> CdpEventMessage {
+        let mut frame = json!({
+            "id": frame_id,
+            "loaderId": format!("loader-{frame_id}"),
+            "url": url,
+            "domainAndRegistry": "example",
+            "securityOrigin": "https://example.test",
+            "mimeType": "text/html",
+            "secureContextType": "Secure",
+            "crossOriginIsolatedContextType": "NotIsolated",
+            "gatedAPIFeatures": []
+        });
+        if let Some(parent_id) = parent_id {
+            frame["parentId"] = json!(parent_id);
+        }
+        let event = serde_json::from_value(json!({
+            "frame": frame,
+            "type": "Navigation"
+        }))
+        .expect("frameNavigated fixture is valid");
+        CdpEventMessage {
+            method: "Page.frameNavigated".into(),
+            session_id: Some(session_id.as_ref().to_owned()),
+            params: CdpEvent::PageFrameNavigated(Box::new(event)),
+        }
+    }
+
+    async fn test_handler() -> (Handler, oneshot::Sender<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local websocket listener");
+        let address = listener.local_addr().expect("listener address");
+        let (close_tx, close_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept websocket client");
+            let mut websocket = async_tungstenite::tokio::accept_async(stream)
+                .await
+                .expect("complete websocket handshake");
+            let _ = close_rx.await;
+            let _ = websocket.close(None).await;
+        });
+
+        let connection = Connection::connect(format!("ws://{address}"))
+            .await
+            .expect("connect test handler");
+        let (_tx, rx) = mpsc::channel(1);
+        (
+            Handler::new(connection, rx, HandlerConfig::default()),
+            close_tx,
+        )
+    }
+
+    async fn test_handler_with_sender()
+    -> (Handler, mpsc::Sender<HandlerMessage>, oneshot::Sender<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local websocket listener");
+        let address = listener.local_addr().expect("listener address");
+        let (close_tx, close_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept websocket client");
+            let mut websocket = async_tungstenite::tokio::accept_async(stream)
+                .await
+                .expect("complete websocket handshake");
+            let _ = close_rx.await;
+            let _ = websocket.close(None).await;
+        });
+
+        let connection = Connection::connect(format!("ws://{address}"))
+            .await
+            .expect("connect test handler");
+        let (tx, rx) = mpsc::channel(4);
+        (
+            Handler::new(connection, rx, HandlerConfig::default()),
+            tx,
+            close_tx,
+        )
+    }
+
+    fn poll_handler_once(handler: &mut Handler) {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        let _ = Pin::new(handler).poll_next(&mut cx);
+    }
+
+    fn poll_future_once<F: std::future::Future + ?Sized>(future: Pin<&mut F>) -> Poll<F::Output> {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        future.poll(&mut cx)
+    }
+
+    async fn test_handler_with_message(message: WsMessage) -> (Handler, oneshot::Sender<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local websocket listener");
+        let address = listener.local_addr().expect("listener address");
+        let (release_tx, release_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept websocket client");
+            let mut websocket = async_tungstenite::tokio::accept_async(stream)
+                .await
+                .expect("complete websocket handshake");
+            websocket.send(message).await.expect("send test message");
+            let _ = release_rx.await;
+        });
+
+        let connection = Connection::connect(format!("ws://{address}"))
+            .await
+            .expect("connect test handler");
+        let (_tx, rx) = mpsc::channel(1);
+        (
+            Handler::new(connection, rx, HandlerConfig::default()),
+            release_tx,
+        )
+    }
+
+    #[tokio::test]
+    async fn child_session_event_route_reaches_parent_target_and_rejects_draining_work() {
+        let (mut handler, close_tx) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "target");
+        handler.on_event(frame_navigated_event(
+            &main_session,
+            "main-frame",
+            None,
+            "https://main.example/",
+        ));
+
+        let child_session = session("child");
+        handler.sessions.insert(
+            child_session.clone(),
+            Session::new(child_session.clone(), target_id.clone()),
+        );
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("parent target remains registered")
+            .frame_manager_mut()
+            .on_frame_attached_in_session(
+                chromiumoxide_cdp::cdp::browser_protocol::page::FrameId::new("child-frame"),
+                Some(chromiumoxide_cdp::cdp::browser_protocol::page::FrameId::new("main-frame")),
+                child_session.clone(),
+            );
+        handler.on_event(frame_navigated_event(
+            &child_session,
+            "child-frame",
+            Some("main-frame"),
+            "https://child.example/first",
+        ));
+
+        let child_frame_id =
+            chromiumoxide_cdp::cdp::browser_protocol::page::FrameId::new("child-frame");
+        let target = handler
+            .targets
+            .get(&target_id)
+            .expect("parent target remains registered");
+        let child_frame = target
+            .frame_manager()
+            .frame(&child_frame_id)
+            .expect("child event reached the parent target");
+        assert_eq!(child_frame.session_id(), Some(&child_session));
+        assert_eq!(child_frame.url(), Some("https://child.example/first"));
+
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("parent target remains registered")
+            .enter_draining_session(child_session.clone());
+        handler.on_event(frame_navigated_event(
+            &child_session,
+            "child-frame",
+            Some("main-frame"),
+            "https://child.example/late",
+        ));
+        assert_eq!(
+            handler
+                .targets
+                .get(&target_id)
+                .and_then(|target| target.frame_manager().frame(&child_frame_id))
+                .and_then(|frame| frame.url()),
+            Some("https://child.example/first")
+        );
+
+        let _ = close_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn captured_session_command_rejects_a_stale_session_before_wire_submit() {
+        let (mut handler, close_tx) = test_handler().await;
+        let (target_id, _) = install_target(&mut handler, "target");
+        let mut target = handler
+            .targets
+            .remove(&target_id)
+            .expect("target remains registered");
+        let (tx, rx) = oneshot::channel();
+        let command = CommandMessage::with_session(
+            RunIfWaitingForDebuggerParams::default(),
+            tx,
+            Some(session("detached-child")),
+        )
+        .expect("command serializes");
+
+        handler.on_target_message(&mut target, command, Instant::now());
+
+        assert!(matches!(
+            rx.await.expect("stale command sender resolves"),
+            Err(CdpError::FrameNotReady)
+        ));
+        assert!(handler.pending_commands.is_empty());
+        handler.targets.insert(target_id, target);
+        let _ = close_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn get_pages_marks_only_successfully_delivered_pages_as_exposed() {
+        let (mut handler, mut sender, close_tx) = test_handler_with_sender().await;
+        let (target_id, _) = install_target(&mut handler, "target");
+        let (tx, rx) = oneshot::channel();
+        sender
+            .send(HandlerMessage::GetPages(tx))
+            .await
+            .expect("handler channel remains live");
+        poll_handler_once(&mut handler);
+
+        assert_eq!(rx.await.expect("page list is delivered").len(), 1);
+        assert!(
+            handler
+                .targets
+                .get(&target_id)
+                .expect("target remains registered")
+                .page_exposed()
+        );
+        let _ = close_tx.send(());
+
+        let (mut handler, mut sender, close_tx) = test_handler_with_sender().await;
+        let (target_id, _) = install_target(&mut handler, "canceled");
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        sender
+            .send(HandlerMessage::GetPages(tx))
+            .await
+            .expect("handler channel remains live");
+        poll_handler_once(&mut handler);
+        assert!(
+            !handler
+                .targets
+                .get(&target_id)
+                .expect("target remains registered")
+                .page_exposed()
+        );
+        let _ = close_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn get_page_marks_exposure_after_successful_delivery() {
+        let (mut handler, mut sender, close_tx) = test_handler_with_sender().await;
+        let (target_id, _) = install_target(&mut handler, "target");
+        let (tx, rx) = oneshot::channel();
+        sender
+            .send(HandlerMessage::GetPage(target_id.clone(), tx))
+            .await
+            .expect("handler channel remains live");
+        poll_handler_once(&mut handler);
+
+        assert!(rx.await.expect("page response is delivered").is_some());
+        assert!(
+            handler
+                .targets
+                .get(&target_id)
+                .expect("target remains registered")
+                .page_exposed()
+        );
+        let _ = close_tx.send(());
+    }
+
+    fn add_ack_group(
+        handler: &mut Handler,
+        target_id: TargetId,
+        main_session_id: SessionId,
+        remaining: usize,
+    ) -> (AckGroupId, oneshot::Receiver<Result<()>>) {
+        let (tx, rx) = oneshot::channel();
+        let group_id = handler.next_ack_group_id();
+        handler.pending_ack_groups.insert(
+            group_id,
+            AckGroup {
+                target_id,
+                main_session_id,
+                remaining,
+                tx,
+            },
+        );
+        (group_id, rx)
+    }
+
+    fn add_ack_member(
+        handler: &mut Handler,
+        call_id: usize,
+        group_id: AckGroupId,
+        session_id: SessionId,
+    ) {
+        handler.pending_commands.insert(
+            CallId::new(call_id),
+            (
+                PendingRequest::FanOutAckMember {
+                    group_id,
+                    session_id,
+                },
+                "Fetch.enable".into(),
+                Instant::now(),
+            ),
+        );
+    }
+
+    fn response(call_id: usize, error: Option<ProtocolError>) -> Response {
+        Response {
+            id: CallId::new(call_id),
+            result: error.is_none().then(|| json!({})),
+            error,
+        }
+    }
+
+    fn preload_response(call_id: usize, identifier: &str) -> Response {
+        Response {
+            id: CallId::new(call_id),
+            result: Some(json!({ "identifier": identifier })),
+            error: None,
+        }
+    }
+
+    fn navigation_response(call_id: usize, error_text: Option<&str>) -> Response {
+        let mut result = json!({ "frameId": "main-frame" });
+        if let Some(error_text) = error_text {
+            result["errorText"] = json!(error_text);
+        }
+        Response {
+            id: CallId::new(call_id),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn protocol_error(code: i64) -> ProtocolError {
+        ProtocolError {
+            code,
+            message: format!("protocol error {code}"),
+        }
+    }
+
+    fn session_request(method: &str, session_id: &SessionId) -> CdpRequest {
+        CdpRequest::with_session(method.to_owned().into(), json!({}), session_id.as_ref())
+    }
+
+    fn install_target(handler: &mut Handler, id: &str) -> (TargetId, SessionId) {
+        let target_id = target_id(id);
+        let main_session = session(&format!("{id}-main"));
+        let mut target = Target::new(
+            target_info(id),
+            TargetConfig::default(),
+            BrowserContext::default(),
+        );
+        target.set_session_id(main_session.clone());
+        handler.sessions.insert(
+            main_session.clone(),
+            Session::new(main_session.clone(), target_id.clone()),
+        );
+        handler.target_ids.push(target_id.clone());
+        handler.targets.insert(target_id.clone(), target);
+        (target_id, main_session)
+    }
+
+    fn install_page_teardown_waiters(
+        handler: &mut Handler,
+        target_id: &TargetId,
+    ) -> (
+        BoxFuture<'static, Result<crate::ArcHttpRequest>>,
+        oneshot::Receiver<Result<Page>>,
+    ) {
+        let target = handler
+            .targets
+            .get_mut(target_id)
+            .expect("target remains registered");
+        let page = target
+            .get_or_create_page()
+            .expect("attached target creates a page handle")
+            .clone();
+        let mut wait = page.wait_for_navigation();
+        assert!(poll_future_once(wait.as_mut()).is_pending());
+
+        let (initiator_tx, initiator_rx) = oneshot::channel();
+        target.set_initiator(initiator_tx);
+        (wait, initiator_rx)
+    }
+
+    #[tokio::test]
+    async fn preload_main_failures_do_not_allocate_and_success_fans_out_before_completion() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "preload-target");
+        handler.on_event(frame_navigated_event(
+            &main_session,
+            "main-frame",
+            None,
+            "https://main.example/",
+        ));
+
+        let child_session = session("preload-child");
+        handler.sessions.insert(
+            child_session.clone(),
+            Session::new(child_session.clone(), target_id.clone()),
+        );
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered")
+            .frame_manager_mut()
+            .on_frame_attached_in_session(
+                FrameId::new("child-frame"),
+                Some(FrameId::new("main-frame")),
+                child_session.clone(),
+            );
+
+        let failed_params = AddScriptToEvaluateOnNewDocumentParams::new("globalThis.failed = true");
+        let (failed_tx, failed_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(200),
+            (
+                PendingRequest::AddPreloadScriptMain {
+                    target_id: target_id.clone(),
+                    params: failed_params,
+                    tx: failed_tx,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.on_response(response(200, Some(protocol_error(-32000))));
+        assert!(matches!(
+            failed_rx.await.expect("failed preload sender resolves"),
+            Err(CdpError::Chrome(error)) if error.code == -32000
+        ));
+        assert!(
+            handler.targets[&target_id]
+                .frame_manager()
+                .preload_snapshot()
+                .is_empty()
+        );
+
+        let timed_out_params =
+            AddScriptToEvaluateOnNewDocumentParams::new("globalThis.timedOut = true");
+        let (timed_out_tx, timed_out_rx) = oneshot::channel();
+        let now = Instant::now();
+        handler.pending_commands.insert(
+            CallId::new(201),
+            (
+                PendingRequest::AddPreloadScriptMain {
+                    target_id: target_id.clone(),
+                    params: timed_out_params,
+                    tx: timed_out_tx,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                now - handler.config.request_timeout - Duration::from_millis(1),
+            ),
+        );
+        handler.evict_timed_out_commands(now);
+        assert!(matches!(
+            timed_out_rx
+                .await
+                .expect("timed-out preload sender resolves"),
+            Err(CdpError::Timeout)
+        ));
+        assert!(
+            handler.targets[&target_id]
+                .frame_manager()
+                .preload_snapshot()
+                .is_empty()
+        );
+
+        let first_params = AddScriptToEvaluateOnNewDocumentParams::new("globalThis.first = true");
+        let (first_tx, first_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(202),
+            (
+                PendingRequest::AddPreloadScriptMain {
+                    target_id: target_id.clone(),
+                    params: first_params.clone(),
+                    tx: first_tx,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.on_response(preload_response(202, "main-script-0"));
+
+        let target = &handler.targets[&target_id];
+        let tracked = target
+            .frame_manager()
+            .preload_script(0)
+            .expect("first successful preload uses the first stable key");
+        assert_eq!(tracked.id, 0);
+        assert_eq!(tracked.params, first_params);
+        assert_eq!(tracked.main_id.as_ref(), "main-script-0");
+        assert!(matches!(
+            target.queued_events().front(),
+            Some(TargetEvent::QueuePreloadScript {
+                request,
+                preload_key: 0,
+            }) if request.session_id.as_deref() == Some(child_session.as_ref())
+        ));
+        assert_eq!(
+            first_rx
+                .await
+                .expect("successful preload sender resolves")
+                .expect("main preload succeeds")
+                .as_ref(),
+            "main-script-0"
+        );
+
+        let second_params = AddScriptToEvaluateOnNewDocumentParams::new("globalThis.second = true");
+        let (second_tx, second_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(203),
+            (
+                PendingRequest::AddPreloadScriptMain {
+                    target_id: target_id.clone(),
+                    params: second_params,
+                    tx: second_tx,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.on_response(preload_response(203, "main-script-1"));
+        assert_eq!(
+            second_rx
+                .await
+                .expect("second preload sender resolves")
+                .expect("second main preload succeeds")
+                .as_ref(),
+            "main-script-1"
+        );
+        assert_eq!(
+            handler.targets[&target_id]
+                .frame_manager()
+                .preload_snapshot()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+
+    #[tokio::test]
+    async fn preload_child_response_tracks_only_a_live_registered_session() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "preload-target");
+        handler.on_event(frame_navigated_event(
+            &main_session,
+            "main-frame",
+            None,
+            "https://main.example/",
+        ));
+        let preload_key = handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered")
+            .frame_manager_mut()
+            .add_preload_script(
+                AddScriptToEvaluateOnNewDocumentParams::new("globalThis.preloaded = true"),
+                ScriptIdentifier::new("main-script"),
+            );
+
+        let live_child = session("live-child");
+        handler.sessions.insert(
+            live_child.clone(),
+            Session::new(live_child.clone(), target_id.clone()),
+        );
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered")
+            .frame_manager_mut()
+            .on_frame_attached_in_session(
+                FrameId::new("live-frame"),
+                Some(FrameId::new("main-frame")),
+                live_child.clone(),
+            );
+        handler.pending_commands.insert(
+            CallId::new(210),
+            (
+                PendingRequest::PreloadAddScript {
+                    target_id: target_id.clone(),
+                    session_id: live_child.clone(),
+                    preload_key,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.on_response(preload_response(210, "live-child-script"));
+        assert_eq!(
+            handler.targets[&target_id]
+                .frame_manager()
+                .preload_script(preload_key)
+                .and_then(|preload| preload.per_session_ids.get(&live_child))
+                .map(|id| id.as_ref()),
+            Some("live-child-script")
+        );
+
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered")
+            .frame_manager_mut()
+            .on_detached_from_target(&live_child, &main_session);
+        handler.sessions.remove(&live_child);
+        assert!(
+            !handler.targets[&target_id]
+                .frame_manager()
+                .preload_script(preload_key)
+                .expect("tracked preload remains live")
+                .per_session_ids
+                .contains_key(&live_child)
+        );
+
+        let detached_child = session("detached-child");
+        handler.sessions.insert(
+            detached_child.clone(),
+            Session::new(detached_child.clone(), target_id.clone()),
+        );
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered")
+            .frame_manager_mut()
+            .on_frame_attached_in_session(
+                FrameId::new("detached-frame"),
+                Some(FrameId::new("main-frame")),
+                detached_child.clone(),
+            );
+        handler.pending_commands.insert(
+            CallId::new(211),
+            (
+                PendingRequest::PreloadAddScript {
+                    target_id: target_id.clone(),
+                    session_id: detached_child.clone(),
+                    preload_key,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        let mut target = handler
+            .targets
+            .remove(&target_id)
+            .expect("target remains registered");
+        handler.fail_pending_for_session(&mut target, &detached_child);
+        target
+            .frame_manager_mut()
+            .on_detached_from_target(&detached_child, &main_session);
+        handler.targets.insert(target_id.clone(), target);
+        handler.sessions.remove(&detached_child);
+        assert!(!handler.pending_commands.contains_key(&CallId::new(211)));
+        handler.on_response(preload_response(211, "late-child-script"));
+        assert!(
+            !handler.targets[&target_id]
+                .frame_manager()
+                .preload_script(preload_key)
+                .expect("tracked preload remains live")
+                .per_session_ids
+                .contains_key(&detached_child)
+        );
+
+        let draining_child = session("draining-child");
+        handler.sessions.insert(
+            draining_child.clone(),
+            Session::new(draining_child.clone(), target_id.clone()),
+        );
+        let target = handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered");
+        target.frame_manager_mut().on_frame_attached_in_session(
+            FrameId::new("draining-frame"),
+            Some(FrameId::new("main-frame")),
+            draining_child.clone(),
+        );
+        target.enter_draining_session(draining_child.clone());
+        handler.pending_commands.insert(
+            CallId::new(212),
+            (
+                PendingRequest::PreloadAddScript {
+                    target_id: target_id.clone(),
+                    session_id: draining_child.clone(),
+                    preload_key,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.on_response(preload_response(212, "draining-child-script"));
+        assert!(
+            !handler.targets[&target_id]
+                .frame_manager()
+                .preload_script(preload_key)
+                .expect("tracked preload remains live")
+                .per_session_ids
+                .contains_key(&draining_child)
+        );
+    }
+
+    #[tokio::test]
+    async fn preload_isolated_world_response_does_not_create_a_tracked_script() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "preload-target");
+        handler.pending_commands.insert(
+            CallId::new(220),
+            (
+                PendingRequest::InternalCommand(target_id.clone(), Some(main_session)),
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+
+        handler.on_response(preload_response(220, "utility-world-script"));
+
+        assert!(
+            handler.targets[&target_id]
+                .frame_manager()
+                .preload_snapshot()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn preload_main_lifecycle_failures_settle_the_user_sender() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "preload-target");
+        let params = AddScriptToEvaluateOnNewDocumentParams::new("globalThis.preloaded = true");
+
+        let (target_tx, target_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(230),
+            (
+                PendingRequest::AddPreloadScriptMain {
+                    target_id: target_id.clone(),
+                    params: params.clone(),
+                    tx: target_tx,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.fail_pending_for_target(&target_id, Some(&main_session));
+        assert!(matches!(
+            target_rx.await.expect("target teardown sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+
+        let (connection_tx, connection_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(231),
+            (
+                PendingRequest::AddPreloadScriptMain {
+                    target_id,
+                    params,
+                    tx: connection_tx,
+                },
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER.into(),
+                Instant::now(),
+            ),
+        );
+        handler.fail_all_pending_on_connection_close();
+        assert!(matches!(
+            connection_rx
+                .await
+                .expect("connection teardown sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    fn install_frame_navigation_watcher(
+        handler: &mut Handler,
+        target_id: &TargetId,
+        session_id: &SessionId,
+        navigation_id: NavigationId,
+    ) -> oneshot::Receiver<std::result::Result<(), crate::handler::frame::FrameWaitError>> {
+        handler.on_event(frame_navigated_event(
+            session_id,
+            "main-frame",
+            None,
+            "https://main.example/",
+        ));
+        let frame_id = FrameId::new("main-frame");
+        let (wait_tx, wait_rx) = oneshot::channel();
+        let target = handler
+            .targets
+            .get_mut(target_id)
+            .expect("target remains registered");
+        target.frame_manager_mut().wait_for_navigation(
+            session_id.clone(),
+            frame_id.clone(),
+            wait_tx,
+        );
+        target.frame_manager_mut().navigate_frame_in_session(
+            session_id.clone(),
+            frame_id,
+            FrameNavigationRequest::new(
+                navigation_id,
+                CdpRequest::with_session(
+                    "Page.navigate".into(),
+                    json!({ "url": "https://next.example/" }),
+                    session_id.as_ref(),
+                ),
+            ),
+        );
+        assert!(matches!(
+            target.frame_manager_mut().poll(Instant::now()),
+            Some(crate::handler::frame::FrameEvent::NavigationRequest(id, _))
+                if id == navigation_id
+        ));
+        wait_rx
+    }
+
+    #[tokio::test]
+    async fn navigation_response_without_error_text_waits_for_lifecycle() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, session_id) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(100);
+        let (tx, mut rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(target_id, session_id, tx)),
+        );
+
+        handler.on_navigation_response(navigation_id, navigation_response(100, None));
+        assert!(matches!(rx.try_recv(), Ok(None)));
+        handler.on_navigation_lifecycle_completed(Ok(NavigationOk::NewDocumentNavigation(
+            navigation_id,
+        )));
+
+        let response = rx
+            .await
+            .expect("navigation sender remains live")
+            .expect("normal navigation succeeds");
+        assert!(response.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn navigation_http_response_failure_waits_for_lifecycle_and_succeeds() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, session_id) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(101);
+        let (tx, mut rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(target_id, session_id, tx)),
+        );
+
+        handler.on_navigation_response(
+            navigation_id,
+            navigation_response(101, Some(HTTP_RESPONSE_CODE_FAILURE)),
+        );
+        assert!(matches!(rx.try_recv(), Ok(None)));
+        handler.on_navigation_lifecycle_completed(Ok(NavigationOk::NewDocumentNavigation(
+            navigation_id,
+        )));
+
+        let response = rx
+            .await
+            .expect("navigation sender remains live")
+            .expect("HTTP error page navigation succeeds");
+        let result = serde_json::from_value::<NavigateReturns>(
+            response.result.expect("navigate response has a result"),
+        )
+        .expect("navigate result is valid");
+        assert_eq!(
+            result.error_text.as_deref(),
+            Some(HTTP_RESPONSE_CODE_FAILURE)
+        );
+    }
+
+    #[tokio::test]
+    async fn navigation_non_http_error_text_fails_immediately_and_cancels_waiter() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, session_id) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(102);
+        let wait_rx =
+            install_frame_navigation_watcher(&mut handler, &target_id, &session_id, navigation_id);
+        let (tx, rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(
+                target_id.clone(),
+                session_id,
+                tx,
+            )),
+        );
+
+        handler.on_navigation_response(
+            navigation_id,
+            navigation_response(102, Some("net::ERR_ABORTED")),
+        );
+
+        assert!(matches!(
+            rx.await.expect("navigation sender remains live"),
+            Err(CdpError::ChromeMessage(message)) if message == "net::ERR_ABORTED"
+        ));
+        assert_eq!(
+            wait_rx.await.expect("waiter sender remains live"),
+            Err(crate::handler::frame::FrameWaitError::NavigationFailed(
+                "net::ERR_ABORTED".to_owned()
+            ))
+        );
+        assert!(
+            handler
+                .targets
+                .get_mut(&target_id)
+                .expect("target remains registered")
+                .frame_manager_mut()
+                .poll(Instant::now() + Duration::from_secs(60))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn navigation_protocol_error_fails_immediately_and_cancels_waiter() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, session_id) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(103);
+        let wait_rx =
+            install_frame_navigation_watcher(&mut handler, &target_id, &session_id, navigation_id);
+        let (tx, rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(target_id, session_id, tx)),
+        );
+
+        handler.on_navigation_response(
+            navigation_id,
+            Response {
+                id: CallId::new(103),
+                result: None,
+                error: Some(protocol_error(-32001)),
+            },
+        );
+
+        assert!(matches!(
+            rx.await.expect("navigation sender remains live"),
+            Err(CdpError::Chrome(error)) if error.code == -32001
+        ));
+        assert_eq!(
+            wait_rx.await.expect("waiter sender remains live"),
+            Err(crate::handler::frame::FrameWaitError::NavigationFailed(
+                "protocol error -32001".to_owned()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn navigation_lifecycle_failure_removes_pending_call_before_late_response() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, session_id) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(104);
+        let (tx, rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(target_id, session_id, tx)),
+        );
+        handler.pending_commands.insert(
+            CallId::new(104),
+            (
+                PendingRequest::Navigate(navigation_id),
+                "Page.navigate".into(),
+                Instant::now(),
+            ),
+        );
+
+        handler.on_navigation_lifecycle_completed(Err(NavigationError::FrameNotFound {
+            id: navigation_id,
+            frame: FrameId::new("main-frame"),
+        }));
+
+        assert!(matches!(
+            rx.await.expect("navigation sender remains live"),
+            Err(CdpError::FrameNotFound(frame)) if frame == FrameId::new("main-frame")
+        ));
+        assert!(!handler.pending_commands.contains_key(&CallId::new(104)));
+        handler.on_response(navigation_response(104, None));
+        assert!(!handler.navigations.contains_key(&navigation_id));
+    }
+
+    #[tokio::test]
+    async fn ack_fan_out_batch_submits_each_disjoint_request_once() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let warming_child = session("warming-child");
+        let (ack_tx, ack_rx) = oneshot::channel();
+        handler.submit_fan_out_ack_batch(
+            &target_id("target"),
+            FanOutAckBatch {
+                ack_reqs: vec![
+                    session_request("Network.setCacheDisabled", &main),
+                    session_request("Fetch.enable", &main),
+                    session_request("Network.setCacheDisabled", &child),
+                    session_request("Fetch.enable", &child),
+                ],
+                send_only_reqs: vec![
+                    session_request("Network.setCacheDisabled", &warming_child),
+                    session_request("Fetch.enable", &warming_child),
+                ],
+                ack_tx,
+                main_session_id: main,
+            },
+            Instant::now(),
+        );
+
+        assert_eq!(handler.pending_commands.len(), 6);
+        let group_id = *handler
+            .pending_ack_groups
+            .keys()
+            .next()
+            .expect("one ack group was registered");
+        assert_eq!(handler.pending_ack_groups[&group_id].remaining, 4);
+        assert_eq!(
+            handler
+                .pending_commands
+                .values()
+                .filter(|(pending, _, _)| matches!(pending, PendingRequest::FanOutAckMember { .. }))
+                .count(),
+            4
+        );
+        assert_eq!(
+            handler
+                .pending_commands
+                .values()
+                .filter(|(pending, _, _)| matches!(pending, PendingRequest::InternalCommand(_, _)))
+                .count(),
+            2
+        );
+
+        let member_calls = handler
+            .pending_commands
+            .iter()
+            .filter_map(|(call_id, (pending, _, _))| {
+                matches!(pending, PendingRequest::FanOutAckMember { .. }).then_some(*call_id)
+            })
+            .collect::<Vec<_>>();
+        for call_id in member_calls {
+            handler.on_response(Response {
+                id: call_id,
+                result: Some(json!({})),
+                error: None,
+            });
+        }
+        assert!(ack_rx.await.expect("ack sender remains live").is_ok());
+    }
+
+    #[tokio::test]
+    async fn ack_empty_fan_out_batch_resolves_without_registering_a_group() {
+        let (mut handler, _close) = test_handler().await;
+        let (ack_tx, ack_rx) = oneshot::channel();
+        handler.submit_fan_out_ack_batch(
+            &target_id("target"),
+            FanOutAckBatch {
+                ack_reqs: Vec::new(),
+                send_only_reqs: Vec::new(),
+                ack_tx,
+                main_session_id: session("main"),
+            },
+            Instant::now(),
+        );
+
+        assert!(handler.pending_commands.is_empty());
+        assert!(handler.pending_ack_groups.is_empty());
+        assert!(ack_rx.await.expect("empty batch ack remains live").is_ok());
+    }
+
+    #[tokio::test]
+    async fn ack_two_commands_per_session_complete_only_after_all_responses() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let (group_id, rx) = add_ack_group(&mut handler, target_id("target"), main.clone(), 4);
+        add_ack_member(&mut handler, 10, group_id, main.clone());
+        add_ack_member(&mut handler, 11, group_id, main);
+        add_ack_member(&mut handler, 12, group_id, child.clone());
+        add_ack_member(&mut handler, 13, group_id, child);
+
+        for call_id in [10, 11, 12] {
+            handler.on_response(response(call_id, None));
+        }
+        assert_eq!(
+            handler
+                .pending_ack_groups
+                .get(&group_id)
+                .map(|group| group.remaining),
+            Some(1)
+        );
+        handler.on_response(response(13, None));
+
+        assert!(!handler.pending_ack_groups.contains_key(&group_id));
+        assert!(rx.await.expect("ack sender remains live").is_ok());
+    }
+
+    #[tokio::test]
+    async fn ack_child_session_gone_is_benign_after_registry_removal() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let (group_id, rx) = add_ack_group(&mut handler, target_id("target"), main, 1);
+        add_ack_member(&mut handler, 20, group_id, child);
+
+        handler.on_response(response(20, Some(protocol_error(-32001))));
+
+        assert!(rx.await.expect("ack sender remains live").is_ok());
+    }
+
+    #[tokio::test]
+    async fn ack_real_child_error_fails_fast_and_purges_stragglers() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let (group_id, rx) = add_ack_group(&mut handler, target_id("target"), main, 2);
+        add_ack_member(&mut handler, 30, group_id, child.clone());
+        add_ack_member(&mut handler, 31, group_id, child);
+
+        handler.on_response(response(30, Some(protocol_error(-32000))));
+
+        assert!(!handler.pending_ack_groups.contains_key(&group_id));
+        assert!(!handler.pending_commands.contains_key(&CallId::new(31)));
+        assert!(matches!(
+            rx.await.expect("ack sender remains live"),
+            Err(CdpError::Chrome(error)) if error.code == -32000
+        ));
+        handler.on_response(response(31, None));
+    }
+
+    #[tokio::test]
+    async fn ack_main_session_gone_error_is_not_ignorable() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let (group_id, rx) = add_ack_group(&mut handler, target_id("target"), main.clone(), 1);
+        add_ack_member(&mut handler, 40, group_id, main);
+
+        handler.on_response(response(40, Some(protocol_error(-32001))));
+
+        assert!(matches!(
+            rx.await.expect("ack sender remains live"),
+            Err(CdpError::Chrome(error)) if error.code == -32001
+        ));
+    }
+
+    #[tokio::test]
+    async fn ack_timeout_fails_group_and_removes_other_members() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let (group_id, rx) = add_ack_group(&mut handler, target_id("target"), main.clone(), 2);
+        add_ack_member(&mut handler, 50, group_id, main.clone());
+        add_ack_member(&mut handler, 51, group_id, main);
+        for (_, _, submitted_at) in handler.pending_commands.values_mut() {
+            *submitted_at = Instant::now() - Duration::from_secs(60);
+        }
+
+        handler.evict_timed_out_commands(Instant::now());
+
+        assert!(!handler.pending_commands.contains_key(&CallId::new(51)));
+        assert!(matches!(
+            rx.await.expect("ack sender remains live"),
+            Err(CdpError::Timeout)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ack_child_detach_completes_each_member_without_failing_main() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let mut target = Target::new(
+            target_info("target"),
+            TargetConfig::default(),
+            BrowserContext::default(),
+        );
+        target.set_session_id(main.clone());
+        let (group_id, rx) = add_ack_group(&mut handler, target_id("target"), main.clone(), 3);
+        add_ack_member(&mut handler, 60, group_id, child.clone());
+        add_ack_member(&mut handler, 61, group_id, child.clone());
+        add_ack_member(&mut handler, 62, group_id, main);
+
+        handler.fail_pending_for_session(&mut target, &child);
+
+        assert_eq!(
+            handler
+                .pending_ack_groups
+                .get(&group_id)
+                .map(|group| group.remaining),
+            Some(1)
+        );
+        handler.on_response(response(62, None));
+        assert!(rx.await.expect("ack sender remains live").is_ok());
+    }
+
+    #[tokio::test]
+    async fn ack_target_scoped_failure_keeps_concurrent_group_isolated() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let target_a = target_id("a");
+        let target_b = target_id("b");
+        let (group_a, rx_a) = add_ack_group(&mut handler, target_a.clone(), main.clone(), 1);
+        let (group_b, rx_b) = add_ack_group(&mut handler, target_b, main.clone(), 1);
+        add_ack_member(&mut handler, 70, group_a, main.clone());
+        add_ack_member(&mut handler, 71, group_b, main);
+
+        handler.fail_ack_groups_for_target(&target_a);
+
+        assert!(!handler.pending_ack_groups.contains_key(&group_a));
+        assert!(handler.pending_ack_groups.contains_key(&group_b));
+        assert!(matches!(
+            rx_a.await.expect("ack sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+        handler.on_response(response(71, None));
+        assert!(rx_b.await.expect("ack sender remains live").is_ok());
+    }
+
+    #[tokio::test]
+    async fn draining_child_settles_pending_command_and_navigation() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let mut target = Target::new(
+            target_info("target"),
+            TargetConfig::default(),
+            BrowserContext::default(),
+        );
+        target.set_session_id(main);
+        let (command_tx, command_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(80),
+            (
+                PendingRequest::ExternalCommand {
+                    session_id: Some(child.clone()),
+                    tx: command_tx,
+                },
+                "Runtime.evaluate".into(),
+                Instant::now(),
+            ),
+        );
+        let navigation_id = NavigationId(80);
+        let (navigation_tx, navigation_rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(
+                target_id("target"),
+                child.clone(),
+                navigation_tx,
+            )),
+        );
+        handler.pending_commands.insert(
+            CallId::new(81),
+            (
+                PendingRequest::Navigate(navigation_id),
+                "Page.navigate".into(),
+                Instant::now(),
+            ),
+        );
+
+        handler.fail_pending_for_session(&mut target, &child);
+
+        assert!(matches!(
+            command_rx.await.expect("command sender remains live"),
+            Err(CdpError::FrameNotReady)
+        ));
+        assert!(matches!(
+            navigation_rx.await.expect("navigation sender remains live"),
+            Err(CdpError::FrameNotReady)
+        ));
+        assert!(handler.pending_commands.is_empty());
+        assert!(handler.navigations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn draining_navigation_gate_blocks_only_session_scoped_requests() {
+        let (mut handler, _close) = test_handler().await;
+        let main = session("main");
+        let child = session("child");
+        let target_id = target_id("target");
+        let mut target = Target::new(
+            target_info("target"),
+            TargetConfig::default(),
+            BrowserContext::default(),
+        );
+        target.set_session_id(main.clone());
+        target.enter_draining_session(child.clone());
+
+        let blocked_id = NavigationId(82);
+        let (blocked_tx, blocked_rx) = oneshot::channel();
+        handler.navigations.insert(
+            blocked_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(
+                target_id.clone(),
+                child.clone(),
+                blocked_tx,
+            )),
+        );
+        handler.submit_navigation_for_target(
+            &target,
+            blocked_id,
+            CdpRequest::with_session(
+                "Page.navigate".into(),
+                json!({ "url": "https://blocked.example/" }),
+                child.as_ref(),
+            ),
+            Instant::now(),
+        );
+
+        assert!(matches!(
+            blocked_rx
+                .await
+                .expect("blocked navigation sender resolves"),
+            Err(CdpError::FrameNotReady)
+        ));
+        assert!(!handler.navigations.contains_key(&blocked_id));
+        assert!(handler.pending_commands.is_empty());
+
+        let sessionless_id = NavigationId(83);
+        let (sessionless_tx, mut sessionless_rx) = oneshot::channel();
+        handler.navigations.insert(
+            sessionless_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(target_id, main, sessionless_tx)),
+        );
+        handler.submit_navigation_for_target(
+            &target,
+            sessionless_id,
+            CdpRequest::new(
+                "Page.navigate".into(),
+                json!({ "url": "https://main.example/" }),
+            ),
+            Instant::now(),
+        );
+
+        assert_eq!(handler.pending_commands.len(), 1);
+        assert!(matches!(sessionless_rx.try_recv(), Ok(None)));
+        handler.fail_all_pending_on_connection_close();
+        assert!(matches!(
+            sessionless_rx
+                .await
+                .expect("submitted navigation sender resolves during cleanup"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn target_teardown_settles_navigation_before_response() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(90);
+        let (tx, rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(
+                target_id.clone(),
+                main_session,
+                tx,
+            )),
+        );
+        handler.pending_commands.insert(
+            CallId::new(90),
+            (
+                PendingRequest::Navigate(navigation_id),
+                "Page.navigate".into(),
+                Instant::now(),
+            ),
+        );
+
+        handler.on_target_destroyed(EventTargetDestroyed {
+            target_id: target_id.clone(),
+        });
+
+        assert!(matches!(
+            rx.await.expect("navigation sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(!handler.targets.contains_key(&target_id));
+        assert!(handler.pending_commands.is_empty());
+        assert!(handler.navigations.is_empty());
+        assert!(handler.sessions.is_empty());
+        handler.on_response(response(90, None));
+    }
+
+    #[tokio::test]
+    async fn target_teardown_settles_navigation_after_response_before_lifecycle() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(91);
+        let (tx, rx) = oneshot::channel();
+        handler.navigations.insert(
+            navigation_id,
+            NavigationRequest::Navigate(NavigationInProgress::new(
+                target_id.clone(),
+                main_session,
+                tx,
+            )),
+        );
+        handler.pending_commands.insert(
+            CallId::new(91),
+            (
+                PendingRequest::Navigate(navigation_id),
+                "Page.navigate".into(),
+                Instant::now(),
+            ),
+        );
+        handler.on_response(navigation_response(91, None));
+        assert!(handler.navigations.contains_key(&navigation_id));
+
+        handler.on_target_destroyed(EventTargetDestroyed {
+            target_id: target_id.clone(),
+        });
+
+        assert!(matches!(
+            rx.await.expect("navigation sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(handler.navigations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn target_destroy_settles_registered_wait_for_navigation() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(120);
+        let wait_rx = install_frame_navigation_watcher(
+            &mut handler,
+            &target_id,
+            &main_session,
+            navigation_id,
+        );
+        let (page_wait, initiator_rx) = install_page_teardown_waiters(&mut handler, &target_id);
+
+        handler.on_target_destroyed(EventTargetDestroyed {
+            target_id: target_id.clone(),
+        });
+
+        // The FrameManager-registered waiter must observe a typed error rather
+        // than an opaque channel cancellation (which is what dropping the
+        // FrameManager alone would produce).
+        assert!(matches!(
+            wait_rx
+                .await
+                .expect("wait sender is settled, not cancelled"),
+            Err(crate::handler::frame::FrameWaitError::FrameSwappedOrDetached)
+        ));
+        assert!(matches!(page_wait.await, Err(CdpError::FrameNotReady)));
+        assert!(matches!(
+            initiator_rx.await.expect("initiator sender is settled"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(!handler.targets.contains_key(&target_id));
+    }
+
+    #[tokio::test]
+    async fn main_session_detach_settles_registered_wait_for_navigation() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(121);
+        let wait_rx = install_frame_navigation_watcher(
+            &mut handler,
+            &target_id,
+            &main_session,
+            navigation_id,
+        );
+        let (page_wait, initiator_rx) = install_page_teardown_waiters(&mut handler, &target_id);
+
+        handler.on_detached_from_target(EventDetachedFromTarget {
+            session_id: main_session,
+        });
+
+        assert!(matches!(
+            wait_rx
+                .await
+                .expect("wait sender is settled, not cancelled"),
+            Err(crate::handler::frame::FrameWaitError::FrameSwappedOrDetached)
+        ));
+        assert!(matches!(page_wait.await, Err(CdpError::FrameNotReady)));
+        assert!(matches!(
+            initiator_rx.await.expect("initiator sender is settled"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(!handler.targets.contains_key(&target_id));
+    }
+
+    #[tokio::test]
+    async fn connection_close_settles_registered_wait_for_navigation() {
+        let (mut handler, close) = test_handler().await;
+        let (target_id, main_session) = install_target(&mut handler, "target");
+        let navigation_id = NavigationId(122);
+        let wait_rx = install_frame_navigation_watcher(
+            &mut handler,
+            &target_id,
+            &main_session,
+            navigation_id,
+        );
+        let (page_wait, initiator_rx) = install_page_teardown_waiters(&mut handler, &target_id);
+
+        close.send(()).expect("close test websocket");
+        let next = tokio::time::timeout(Duration::from_secs(2), handler.next())
+            .await
+            .expect("handler observes websocket EOF");
+        assert!(next.is_none());
+
+        // On connection close the Handler stops polling, so without explicit
+        // settlement this waiter would hang forever. It must resolve to a typed
+        // error instead.
+        assert!(matches!(
+            wait_rx
+                .await
+                .expect("wait sender is settled, not cancelled"),
+            Err(crate::handler::frame::FrameWaitError::FrameSwappedOrDetached)
+        ));
+        assert!(matches!(page_wait.await, Err(CdpError::FrameNotReady)));
+        assert!(matches!(
+            initiator_rx.await.expect("initiator sender is settled"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn child_session_detach_keeps_the_target_initiator_alive() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, _) = install_target(&mut handler, "target");
+        let child_session = session("target-child");
+        handler.sessions.insert(
+            child_session.clone(),
+            Session::new(child_session.clone(), target_id.clone()),
+        );
+        let (initiator_tx, mut initiator_rx) = oneshot::channel();
+        handler
+            .targets
+            .get_mut(&target_id)
+            .expect("target remains registered")
+            .set_initiator(initiator_tx);
+
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let writer_logs = logs.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(move || SharedLogWriter(writer_logs.clone()))
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            handler.on_detached_from_target(EventDetachedFromTarget {
+                session_id: child_session,
+            });
+        });
+
+        assert!(matches!(initiator_rx.try_recv(), Ok(None)));
+        assert!(handler.targets.contains_key(&target_id));
+        let logs = String::from_utf8(logs.lock().expect("test log buffer lock").clone())
+            .expect("warning output is utf-8");
+        assert!(logs.contains("auto-attach envelope invariant did not hold"));
+
+        handler.on_target_destroyed(EventTargetDestroyed { target_id });
+        assert!(matches!(
+            initiator_rx
+                .await
+                .expect("whole-target teardown settles initiator"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn target_teardown_covers_live_child_session_commands() {
+        let (mut handler, _close) = test_handler().await;
+        let (target_id, _) = install_target(&mut handler, "target");
+        let child = session("target-child");
+        handler.sessions.insert(
+            child.clone(),
+            Session::new(child.clone(), target_id.clone()),
+        );
+        let (tx, rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(92),
+            (
+                PendingRequest::ExternalCommand {
+                    session_id: Some(child),
+                    tx,
+                },
+                "Runtime.evaluate".into(),
+                Instant::now(),
+            ),
+        );
+
+        handler.on_target_destroyed(EventTargetDestroyed { target_id });
+
+        assert!(matches!(
+            rx.await.expect("command sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(handler.sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ack_connection_eof_drains_group_and_browser_root_command() {
+        let (mut handler, close) = test_handler().await;
+        let (group_id, ack_rx) =
+            add_ack_group(&mut handler, target_id("target"), session("main"), 1);
+        add_ack_member(&mut handler, 100, group_id, session("main"));
+        let (command_tx, command_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(101),
+            (
+                PendingRequest::ExternalCommand {
+                    session_id: None,
+                    tx: command_tx,
+                },
+                "Browser.getVersion".into(),
+                Instant::now(),
+            ),
+        );
+
+        close.send(()).expect("close test websocket");
+        let next = tokio::time::timeout(Duration::from_secs(2), handler.next())
+            .await
+            .expect("handler observes websocket EOF");
+        assert!(next.is_none());
+        assert!(matches!(
+            ack_rx.await.expect("ack sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(matches!(
+            command_rx.await.expect("command sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ack_connection_error_drains_groups_before_returning_error() {
+        let (mut handler, _release) =
+            test_handler_with_message(WsMessage::Binary(vec![1, 2, 3].into())).await;
+        let (_group_id, ack_rx) =
+            add_ack_group(&mut handler, target_id("target"), session("main"), 1);
+
+        let next = tokio::time::timeout(Duration::from_secs(2), handler.next())
+            .await
+            .expect("handler observes websocket error");
+        assert!(matches!(next, Some(Err(CdpError::UnexpectedWsMessage(_)))));
+        assert!(matches!(
+            ack_rx.await.expect("ack sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ack_closing_completion_drains_other_groups() {
+        let close_call_id = 120;
+        let response = format!(r#"{{"id":{close_call_id},"result":{{}}}}"#);
+        let (mut handler, _release) =
+            test_handler_with_message(WsMessage::Text(response.into())).await;
+        let (_group_id, ack_rx) =
+            add_ack_group(&mut handler, target_id("target"), session("main"), 1);
+        let (close_tx, close_rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(close_call_id),
+            (
+                PendingRequest::CloseBrowser(close_tx),
+                "Browser.close".into(),
+                Instant::now(),
+            ),
+        );
+
+        let next = tokio::time::timeout(Duration::from_secs(2), handler.next())
+            .await
+            .expect("handler observes closing response");
+        assert!(next.is_none());
+        assert!(close_rx.await.expect("close sender remains live").is_ok());
+        assert!(matches!(
+            ack_rx.await.expect("ack sender remains live"),
+            Err(CdpError::NoResponse)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ack_browser_root_response_remains_targetless_and_successful() {
+        let (mut handler, _close) = test_handler().await;
+        let (tx, rx) = oneshot::channel();
+        handler.pending_commands.insert(
+            CallId::new(110),
+            (
+                PendingRequest::ExternalCommand {
+                    session_id: None,
+                    tx,
+                },
+                "Browser.getVersion".into(),
+                Instant::now(),
+            ),
+        );
+
+        handler.on_response(response(110, None));
+
+        assert!(rx.await.expect("root sender remains live").is_ok());
+    }
 }

--- a/src/handler/network.rs
+++ b/src/handler/network.rs
@@ -8,10 +8,11 @@ use chromiumoxide_cdp::cdp::browser_protocol::network::{
     EventRequestServedFromCache, EventRequestWillBeSent, EventResponseReceived, Headers,
     InterceptionId, RequestId, Response, SetCacheDisabledParams, SetExtraHttpHeadersParams,
 };
+use chromiumoxide_cdp::cdp::browser_protocol::target::SessionId;
 use chromiumoxide_cdp::cdp::browser_protocol::{
     network::EnableParams, security::SetIgnoreCertificateErrorsParams,
 };
-use chromiumoxide_types::{Command, Method, MethodId};
+use chromiumoxide_types::{Command, Method, MethodId, Request};
 
 use crate::auth::Credentials;
 use crate::cmd::CommandChain;
@@ -19,13 +20,16 @@ use crate::handler::http::HttpRequest;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Duration;
 
+pub(crate) type NetworkCommand = (MethodId, serde_json::Value);
+
 #[derive(Debug)]
 pub struct NetworkManager {
-    queued_events: VecDeque<NetworkEvent>,
+    queued_events: VecDeque<QueuedNetworkEvent>,
+    session_requests: VecDeque<SessionCdpRequest>,
     ignore_httpserrors: bool,
     requests: HashMap<RequestId, HttpRequest>,
     // TODO put event in an Arc?
-    requests_will_be_sent: HashMap<RequestId, EventRequestWillBeSent>,
+    requests_will_be_sent: HashMap<RequestId, RequestWillBeSent>,
     extra_headers: HashMap<String, String>,
     request_id_to_interception_id: HashMap<RequestId, InterceptionId>,
     user_cache_disabled: bool,
@@ -41,6 +45,7 @@ impl NetworkManager {
     pub fn new(ignore_httpserrors: bool, request_timeout: Duration) -> Self {
         Self {
             queued_events: Default::default(),
+            session_requests: Default::default(),
             ignore_httpserrors,
             requests: Default::default(),
             requests_will_be_sent: Default::default(),
@@ -71,76 +76,191 @@ impl NetworkManager {
     }
 
     fn push_cdp_request<T: Command>(&mut self, cmd: T) {
-        let method = cmd.identifier();
-        let params = serde_json::to_value(cmd).expect("Command should not panic");
+        let (method, params) = Self::serialize_command(cmd);
+        self.push_event(NetworkEvent::SendCdpRequest((method, params)), None);
+    }
+
+    fn push_cdp_requests(&mut self, commands: Vec<NetworkCommand>) {
+        for command in commands {
+            self.push_event(NetworkEvent::SendCdpRequest(command), None);
+        }
+    }
+
+    fn serialize_command<T: Command>(cmd: T) -> NetworkCommand {
+        (
+            cmd.identifier(),
+            serde_json::to_value(cmd).expect("Command should not panic"),
+        )
+    }
+
+    pub(crate) fn push_cdp_request_session<T: Command>(&mut self, cmd: T, session_id: SessionId) {
+        self.session_requests.push_back(SessionCdpRequest {
+            method: cmd.identifier(),
+            params: serde_json::to_value(cmd).expect("Command should not panic"),
+            session_id,
+        });
+    }
+
+    fn push_event(&mut self, event: NetworkEvent, session_id: Option<SessionId>) {
         self.queued_events
-            .push_back(NetworkEvent::SendCdpRequest((method, params)));
+            .push_back(QueuedNetworkEvent { event, session_id });
     }
 
     /// The next event to handle
     pub fn poll(&mut self) -> Option<NetworkEvent> {
-        self.queued_events.pop_front()
+        self.queued_events.pop_front().map(|queued| queued.event)
+    }
+
+    pub(crate) fn poll_session_request(&mut self) -> Option<Request> {
+        self.session_requests.pop_front().map(|request| Request {
+            method: request.method,
+            session_id: Some(request.session_id.into()),
+            params: request.params,
+        })
     }
 
     pub fn extra_headers(&self) -> &HashMap<String, String> {
         &self.extra_headers
     }
 
+    pub(crate) fn ignore_https_errors(&self) -> bool {
+        self.ignore_httpserrors
+    }
+
+    pub(crate) fn is_cache_disabled(&self) -> bool {
+        self.user_cache_disabled || self.protocol_request_interception_enabled
+    }
+
+    pub(crate) fn is_request_interception_enabled(&self) -> bool {
+        self.protocol_request_interception_enabled
+    }
+
+    pub(crate) fn credentials(&self) -> Option<&Credentials> {
+        self.credentials.as_ref()
+    }
+
+    pub(crate) fn is_offline(&self) -> bool {
+        self.offline
+    }
+
     pub fn set_extra_headers(&mut self, headers: HashMap<String, String>) {
+        let commands = self.set_extra_headers_core(headers);
+        self.push_cdp_requests(commands);
+    }
+
+    fn set_extra_headers_core(&mut self, headers: HashMap<String, String>) -> Vec<NetworkCommand> {
         self.extra_headers = headers;
         let headers = serde_json::to_value(self.extra_headers.clone()).unwrap();
-        self.push_cdp_request(SetExtraHttpHeadersParams::new(Headers::new(headers)));
+        vec![Self::serialize_command(SetExtraHttpHeadersParams::new(
+            Headers::new(headers),
+        ))]
     }
 
     pub fn set_request_interception(&mut self, enabled: bool) {
+        let commands = self.set_request_interception_core(enabled);
+        self.push_cdp_requests(commands);
+    }
+
+    pub(crate) fn set_request_interception_core(&mut self, enabled: bool) -> Vec<NetworkCommand> {
         self.user_request_interception_enabled = enabled;
-        self.update_protocol_request_interception();
+        self.update_protocol_request_interception_core()
     }
 
     pub fn set_cache_enabled(&mut self, enabled: bool) {
+        let commands = self.set_cache_enabled_core(enabled);
+        self.push_cdp_requests(commands);
+    }
+
+    fn set_cache_enabled_core(&mut self, enabled: bool) -> Vec<NetworkCommand> {
         self.user_cache_disabled = !enabled;
-        self.update_protocol_cache_disabled();
+        self.update_protocol_cache_disabled_core()
     }
 
     pub fn update_protocol_cache_disabled(&mut self) {
-        self.push_cdp_request(SetCacheDisabledParams::new(
+        let commands = self.update_protocol_cache_disabled_core();
+        self.push_cdp_requests(commands);
+    }
+
+    fn update_protocol_cache_disabled_core(&self) -> Vec<NetworkCommand> {
+        vec![Self::serialize_command(SetCacheDisabledParams::new(
             self.user_cache_disabled || self.protocol_request_interception_enabled,
-        ));
+        ))]
     }
 
     pub fn authenticate(&mut self, credentials: Credentials) {
-        self.credentials = Some(credentials);
-        self.update_protocol_request_interception()
+        let commands = self.authenticate_core(credentials);
+        self.push_cdp_requests(commands);
     }
 
-    fn update_protocol_request_interception(&mut self) {
+    pub(crate) fn authenticate_core(&mut self, credentials: Credentials) -> Vec<NetworkCommand> {
+        self.credentials = Some(credentials);
+        self.update_protocol_request_interception_core()
+    }
+
+    fn update_protocol_request_interception_core(&mut self) -> Vec<NetworkCommand> {
         let enabled = self.user_request_interception_enabled || self.credentials.is_some();
-        if enabled == self.protocol_request_interception_enabled {
-            return;
-        }
-        self.update_protocol_cache_disabled();
+        // Always re-emit the idempotent batch, even when the desired state
+        // equals our current belief. The belief is set optimistically here
+        // before Chrome ACKs and is never rolled back on ACK failure, so a
+        // short-circuit on equality would make a same-value retry after a failed
+        // enable produce an empty batch and resolve `Ok(())` without Chrome ever
+        // applying it (a silent false success on the response-confirmed
+        // `set_request_interception`/`authenticate` contract). `Fetch.enable`,
+        // `Fetch.disable`, and `Network.setCacheDisabled` are all idempotent, so
+        // re-sending is safe and guarantees every awaited call waits for a real
+        // ACK. (I-020.)
         self.protocol_request_interception_enabled = enabled;
+        let mut commands = self.update_protocol_cache_disabled_core();
         if enabled {
-            self.push_cdp_request(
+            commands.push(Self::serialize_command(
                 fetch::EnableParams::builder()
                     .handle_auth_requests(true)
                     .pattern(RequestPattern::builder().url_pattern("*").build())
                     .build(),
-            )
+            ));
         } else {
-            self.push_cdp_request(DisableParams::default())
+            commands.push(Self::serialize_command(DisableParams::default()));
         }
+        commands
     }
 
     pub fn on_fetch_request_paused(&mut self, event: &EventRequestPaused) {
         if !self.user_request_interception_enabled && self.protocol_request_interception_enabled {
             self.push_cdp_request(ContinueRequestParams::new(event.request_id.clone()))
         }
+        self.correlate_request_paused(event);
+    }
+
+    pub(crate) fn on_fetch_request_paused_in_session(
+        &mut self,
+        event: &EventRequestPaused,
+        session_id: &SessionId,
+    ) -> PauseDisposition {
+        let disposition = if !self.user_request_interception_enabled
+            && self.protocol_request_interception_enabled
+        {
+            self.push_cdp_request_session(
+                ContinueRequestParams::new(event.request_id.clone()),
+                session_id.clone(),
+            );
+            PauseDisposition::AutoResponded
+        } else {
+            PauseDisposition::UserIntercept
+        };
+        self.correlate_request_paused(event);
+        disposition
+    }
+
+    fn correlate_request_paused(&mut self, event: &EventRequestPaused) {
         if let Some(network_id) = event.network_id.as_ref() {
             if let Some(request_will_be_sent) =
                 self.requests_will_be_sent.remove(network_id.as_ref())
             {
-                self.on_request(&request_will_be_sent, Some(event.request_id.clone().into()));
+                self.on_request(
+                    &request_will_be_sent.event,
+                    Some(event.request_id.clone().into()),
+                    request_will_be_sent.session_id,
+                );
             } else {
                 self.request_id_to_interception_id
                     .insert(network_id.clone(), event.request_id.clone().into());
@@ -149,6 +269,23 @@ impl NetworkManager {
     }
 
     pub fn on_fetch_auth_required(&mut self, event: &EventAuthRequired) {
+        let auth = self.auth_challenge_response(event);
+        self.push_cdp_request(ContinueWithAuthParams::new(event.request_id.clone(), auth));
+    }
+
+    pub(crate) fn on_fetch_auth_required_in_session(
+        &mut self,
+        event: &EventAuthRequired,
+        session_id: &SessionId,
+    ) {
+        let auth = self.auth_challenge_response(event);
+        self.push_cdp_request_session(
+            ContinueWithAuthParams::new(event.request_id.clone(), auth),
+            session_id.clone(),
+        );
+    }
+
+    fn auth_challenge_response(&mut self, event: &EventAuthRequired) -> AuthChallengeResponse {
         let response = if self
             .attempted_authentications
             .contains(event.request_id.as_ref())
@@ -167,15 +304,25 @@ impl NetworkManager {
             auth.username = Some(creds.username);
             auth.password = Some(creds.password);
         }
-        self.push_cdp_request(ContinueWithAuthParams::new(event.request_id.clone(), auth));
+        auth
     }
 
     pub fn set_offline_mode(&mut self, value: bool) {
+        let commands = self.set_offline_mode_core(value);
+        self.push_cdp_requests(commands);
+    }
+
+    fn set_offline_mode_core(&mut self, value: bool) -> Vec<NetworkCommand> {
+        // Safe today: this mutator is legacy fire-and-forget (no fan-out ACK), so
+        // an equality short-circuit cannot cause a false-confirmed await. If
+        // Phase 2 gives `set_offline_mode` dynamic fan-out + ACK (design §5.5),
+        // this short-circuit MUST be removed like I-020 did for interception, or
+        // a same-value retry after a failed ACK will silently report success.
         if self.offline == value {
-            return;
+            return Vec::new();
         }
         self.offline = value;
-        self.push_cdp_request(
+        vec![Self::serialize_command(
             // This event was recently deprecated, so we continue to use it for now
             // if some users are on older versions of chromium.
             #[allow(deprecated)]
@@ -186,24 +333,45 @@ impl NetworkManager {
                 .upload_throughput(-1.)
                 .build()
                 .unwrap(),
-        );
+        )]
     }
 
     /// Request interception doesn't happen for data URLs with Network Service.
     pub fn on_request_will_be_sent(&mut self, event: &EventRequestWillBeSent) {
+        self.on_request_will_be_sent_core(event, None);
+    }
+
+    pub(crate) fn on_request_will_be_sent_in_session(
+        &mut self,
+        event: &EventRequestWillBeSent,
+        session_id: &SessionId,
+    ) {
+        self.on_request_will_be_sent_core(event, Some(session_id.clone()));
+    }
+
+    fn on_request_will_be_sent_core(
+        &mut self,
+        event: &EventRequestWillBeSent,
+        session_id: Option<SessionId>,
+    ) {
         if self.protocol_request_interception_enabled && !event.request.url.starts_with("data:") {
             if let Some(interception_id) = self
                 .request_id_to_interception_id
                 .remove(event.request_id.as_ref())
             {
-                self.on_request(event, Some(interception_id));
+                self.on_request(event, Some(interception_id), session_id);
             } else {
                 // TODO remove the clone for event
-                self.requests_will_be_sent
-                    .insert(event.request_id.clone(), event.clone());
+                self.requests_will_be_sent.insert(
+                    event.request_id.clone(),
+                    RequestWillBeSent {
+                        event: event.clone(),
+                        session_id,
+                    },
+                );
             }
         } else {
-            self.on_request(event, None);
+            self.on_request(event, None, session_id);
         }
     }
 
@@ -216,8 +384,8 @@ impl NetworkManager {
     pub fn on_response_received(&mut self, event: &EventResponseReceived) {
         if let Some(mut request) = self.requests.remove(event.request_id.as_ref()) {
             request.set_response(event.response.clone());
-            self.queued_events
-                .push_back(NetworkEvent::RequestFinished(request))
+            let session_id = request.session_id().cloned();
+            self.push_event(NetworkEvent::RequestFinished(request), session_id)
         }
     }
 
@@ -227,8 +395,8 @@ impl NetworkManager {
                 self.attempted_authentications
                     .remove(interception_id.as_ref());
             }
-            self.queued_events
-                .push_back(NetworkEvent::RequestFinished(request));
+            let session_id = request.session_id().cloned();
+            self.push_event(NetworkEvent::RequestFinished(request), session_id);
         }
     }
 
@@ -239,15 +407,31 @@ impl NetworkManager {
                 self.attempted_authentications
                     .remove(interception_id.as_ref());
             }
-            self.queued_events
-                .push_back(NetworkEvent::RequestFailed(request));
+            let session_id = request.session_id().cloned();
+            self.push_event(NetworkEvent::RequestFailed(request), session_id);
         }
+    }
+
+    pub(crate) fn on_session_draining(&mut self, session_id: &SessionId) {
+        self.requests
+            .retain(|_, request| request.session_id() != Some(session_id));
+        self.requests_will_be_sent
+            .retain(|_, request| request.session_id.as_ref() != Some(session_id));
+        self.queued_events
+            .retain(|event| event.session_id.as_ref() != Some(session_id));
+        self.session_requests
+            .retain(|request| &request.session_id != session_id);
+    }
+
+    pub(crate) fn on_session_detached(&mut self, session_id: &SessionId) {
+        self.on_session_draining(session_id);
     }
 
     fn on_request(
         &mut self,
         event: &EventRequestWillBeSent,
         interception_id: Option<InterceptionId>,
+        session_id: Option<SessionId>,
     ) {
         let mut redirect_chain = Vec::new();
         if let Some(redirect_resp) = event.redirect_response.as_ref() {
@@ -257,17 +441,26 @@ impl NetworkManager {
                 redirect_chain.push(request);
             }
         }
-        let request = HttpRequest::new(
-            event.request_id.clone(),
-            event.frame_id.clone(),
-            interception_id,
-            self.user_request_interception_enabled,
-            redirect_chain,
-        );
+        let request = match session_id.clone() {
+            Some(session_id) => HttpRequest::new_with_session(
+                event.request_id.clone(),
+                event.frame_id.clone(),
+                interception_id,
+                self.user_request_interception_enabled,
+                redirect_chain,
+                session_id,
+            ),
+            None => HttpRequest::new(
+                event.request_id.clone(),
+                event.frame_id.clone(),
+                interception_id,
+                self.user_request_interception_enabled,
+                redirect_chain,
+            ),
+        };
 
         self.requests.insert(event.request_id.clone(), request);
-        self.queued_events
-            .push_back(NetworkEvent::Request(event.request_id.clone()));
+        self.push_event(NetworkEvent::Request(event.request_id.clone()), session_id);
     }
 
     fn handle_request_redirect(&mut self, request: &mut HttpRequest, response: Response) {
@@ -280,10 +473,325 @@ impl NetworkManager {
 }
 
 #[derive(Debug)]
+struct SessionCdpRequest {
+    method: MethodId,
+    params: serde_json::Value,
+    session_id: SessionId,
+}
+
+#[derive(Debug)]
+struct QueuedNetworkEvent {
+    event: NetworkEvent,
+    session_id: Option<SessionId>,
+}
+
+#[derive(Debug, Clone)]
+struct RequestWillBeSent {
+    event: EventRequestWillBeSent,
+    session_id: Option<SessionId>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum PauseDisposition {
+    AutoResponded,
+    UserIntercept,
+}
+
+#[derive(Debug)]
 pub enum NetworkEvent {
     SendCdpRequest((MethodId, serde_json::Value)),
     Request(RequestId),
     Response(RequestId),
     RequestFailed(HttpRequest),
     RequestFinished(HttpRequest),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn session(id: &str) -> SessionId {
+        SessionId::new(id)
+    }
+
+    fn network_request(url: &str) -> serde_json::Value {
+        json!({
+            "url": url,
+            "method": "GET",
+            "headers": {},
+            "initialPriority": "High",
+            "referrerPolicy": "no-referrer"
+        })
+    }
+
+    fn request_will_be_sent(id: &str) -> EventRequestWillBeSent {
+        serde_json::from_value(json!({
+            "requestId": id,
+            "loaderId": format!("loader-{id}"),
+            "documentURL": format!("https://{id}.example/"),
+            "request": network_request(&format!("https://{id}.example/")),
+            "timestamp": 1.0,
+            "wallTime": 1.0,
+            "initiator": { "type": "other" },
+            "redirectHasExtraInfo": false
+        }))
+        .expect("requestWillBeSent fixture is valid")
+    }
+
+    fn paused_request(fetch_id: &str, network_id: Option<&str>) -> EventRequestPaused {
+        serde_json::from_value(json!({
+            "requestId": fetch_id,
+            "request": network_request("https://paused.example/"),
+            "frameId": "frame",
+            "resourceType": "Document",
+            "networkId": network_id
+        }))
+        .expect("requestPaused fixture is valid")
+    }
+
+    fn queued_methods(manager: &mut NetworkManager) -> Vec<String> {
+        let mut methods = Vec::new();
+        while let Some(event) = manager.poll() {
+            if let NetworkEvent::SendCdpRequest((method, _)) = event {
+                methods.push(method.as_ref().to_owned());
+            }
+        }
+        methods
+    }
+
+    #[test]
+    fn interception_core_returns_exact_batch_without_legacy_queue_side_effects() {
+        let mut manager = NetworkManager::new(false, Duration::from_secs(1));
+
+        let commands = manager.set_request_interception_core(true);
+        assert_eq!(
+            commands
+                .iter()
+                .map(|(method, _)| method.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["Network.setCacheDisabled", "Fetch.enable"]
+        );
+        assert_eq!(commands[0].1["cacheDisabled"], true);
+        assert!(manager.poll().is_none());
+        // A same-value repeat must re-emit the idempotent batch rather than
+        // short-circuit to empty: the empty path resolves the awaited call
+        // `Ok(())` without Chrome re-applying it, which after a failed enable is
+        // a silent false success (I-020).
+        assert_eq!(
+            manager
+                .set_request_interception_core(true)
+                .iter()
+                .map(|(method, _)| method.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["Network.setCacheDisabled", "Fetch.enable"]
+        );
+
+        let commands = manager.set_request_interception_core(false);
+        assert_eq!(
+            commands
+                .iter()
+                .map(|(method, _)| method.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["Network.setCacheDisabled", "Fetch.disable"]
+        );
+        assert_eq!(commands[0].1["cacheDisabled"], false);
+        assert!(manager.poll().is_none());
+    }
+
+    #[test]
+    fn legacy_mutator_wrappers_queue_each_core_command_once() {
+        let mut manager = NetworkManager::new(false, Duration::from_secs(1));
+        manager.set_request_interception(true);
+        assert_eq!(
+            queued_methods(&mut manager),
+            vec!["Network.setCacheDisabled", "Fetch.enable"]
+        );
+
+        manager.authenticate(Credentials {
+            username: "user".to_owned(),
+            password: "pass".to_owned(),
+        });
+        // Interception is already on, but authenticate still re-emits the
+        // idempotent batch (I-020: no equality short-circuit), so the awaited
+        // call always waits for a real ACK instead of a false success.
+        assert_eq!(
+            queued_methods(&mut manager),
+            vec!["Network.setCacheDisabled", "Fetch.enable"]
+        );
+
+        let mut auth_manager = NetworkManager::new(false, Duration::from_secs(1));
+        let commands = auth_manager.authenticate_core(Credentials {
+            username: "user".to_owned(),
+            password: "pass".to_owned(),
+        });
+        assert_eq!(
+            commands
+                .iter()
+                .map(|(method, _)| method.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["Network.setCacheDisabled", "Fetch.enable"]
+        );
+        assert!(auth_manager.poll().is_none());
+    }
+
+    #[test]
+    fn session_cleanup_removes_only_matching_private_state() {
+        let mut manager = NetworkManager::new(false, Duration::from_secs(1));
+        let dead = session("dead");
+        let live = session("live");
+        let dead_request_id = RequestId::new("dead-request");
+        let live_request_id = RequestId::new("live-request");
+
+        manager.requests.insert(
+            dead_request_id.clone(),
+            HttpRequest::new_with_session(
+                dead_request_id.clone(),
+                None,
+                None,
+                false,
+                Vec::new(),
+                dead.clone(),
+            ),
+        );
+        manager.requests.insert(
+            live_request_id.clone(),
+            HttpRequest::new_with_session(
+                live_request_id.clone(),
+                None,
+                None,
+                false,
+                Vec::new(),
+                live.clone(),
+            ),
+        );
+        manager.requests_will_be_sent.insert(
+            dead_request_id.clone(),
+            RequestWillBeSent {
+                event: request_will_be_sent("dead-request"),
+                session_id: Some(dead.clone()),
+            },
+        );
+        manager.requests_will_be_sent.insert(
+            live_request_id.clone(),
+            RequestWillBeSent {
+                event: request_will_be_sent("live-request"),
+                session_id: Some(live.clone()),
+            },
+        );
+        manager.push_event(
+            NetworkEvent::Request(dead_request_id.clone()),
+            Some(dead.clone()),
+        );
+        manager.push_event(
+            NetworkEvent::Request(live_request_id.clone()),
+            Some(live.clone()),
+        );
+        manager.push_cdp_request_session(
+            ContinueRequestParams::new(
+                chromiumoxide_cdp::cdp::browser_protocol::fetch::RequestId::new("dead-fetch"),
+            ),
+            dead.clone(),
+        );
+        manager.push_cdp_request_session(
+            ContinueRequestParams::new(
+                chromiumoxide_cdp::cdp::browser_protocol::fetch::RequestId::new("live-fetch"),
+            ),
+            live.clone(),
+        );
+
+        manager.on_session_draining(&dead);
+        manager.on_session_detached(&dead);
+
+        assert!(!manager.requests.contains_key(&dead_request_id));
+        assert!(manager.requests.contains_key(&live_request_id));
+        assert!(!manager.requests_will_be_sent.contains_key(&dead_request_id));
+        assert!(manager.requests_will_be_sent.contains_key(&live_request_id));
+        let session_request = manager
+            .poll_session_request()
+            .expect("the live session request survives");
+        assert_eq!(session_request.session_id.as_deref(), Some(live.as_ref()));
+        assert!(manager.poll_session_request().is_none());
+        assert!(matches!(
+            manager.poll(),
+            Some(NetworkEvent::Request(request_id)) if request_id == live_request_id
+        ));
+        assert!(manager.poll().is_none());
+    }
+
+    #[test]
+    fn session_cleanup_preserves_request_will_be_sent_creation_stamp() {
+        let mut manager = NetworkManager::new(false, Duration::from_secs(1));
+        manager.set_request_interception(true);
+        while manager.poll().is_some() {}
+        let parent = session("parent");
+        let child = session("child");
+        let request = request_will_be_sent("network-request");
+        let paused = paused_request("fetch-request", Some("network-request"));
+
+        manager.on_request_will_be_sent_in_session(&request, &parent);
+        assert_eq!(
+            manager.on_fetch_request_paused_in_session(&paused, &child),
+            PauseDisposition::UserIntercept
+        );
+
+        let stored = manager
+            .requests
+            .get(&RequestId::new("network-request"))
+            .expect("correlated request is stored");
+        assert_eq!(stored.session_id(), Some(&parent));
+        assert!(matches!(
+            manager.queued_events.front(),
+            Some(QueuedNetworkEvent {
+                event: NetworkEvent::Request(request_id),
+                session_id: Some(session_id),
+            }) if request_id.as_ref() == "network-request" && session_id == &parent
+        ));
+
+        manager.on_session_draining(&child);
+        assert!(
+            manager
+                .requests
+                .contains_key(&RequestId::new("network-request"))
+        );
+        manager.on_session_draining(&parent);
+        assert!(
+            !manager
+                .requests
+                .contains_key(&RequestId::new("network-request"))
+        );
+        assert!(manager.queued_events.is_empty());
+    }
+
+    #[test]
+    fn session_cleanup_auto_response_keeps_exact_pause_session() {
+        let mut manager = NetworkManager::new(false, Duration::from_secs(1));
+        manager.authenticate(Credentials {
+            username: "user".to_owned(),
+            password: "pass".to_owned(),
+        });
+        while manager.poll().is_some() {}
+        let child = session("child");
+        let paused = paused_request("fetch-request", None);
+
+        assert_eq!(
+            manager.on_fetch_request_paused_in_session(&paused, &child),
+            PauseDisposition::AutoResponded
+        );
+        let request = manager
+            .poll_session_request()
+            .expect("auto response is queued");
+        assert_eq!(request.method.as_ref(), "Fetch.continueRequest");
+        assert_eq!(request.session_id.as_deref(), Some(child.as_ref()));
+
+        manager.push_cdp_request_session(
+            ContinueRequestParams::new(
+                chromiumoxide_cdp::cdp::browser_protocol::fetch::RequestId::new("late"),
+            ),
+            child.clone(),
+        );
+        manager.on_session_detached(&child);
+        assert!(manager.poll_session_request().is_none());
+    }
 }

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use futures::channel::mpsc::{Receiver, Sender, channel};
 use futures::channel::oneshot::channel as oneshot_channel;
+use futures::future::BoxFuture;
 use futures::stream::Fuse;
-use futures::{SinkExt, StreamExt};
+use futures::{FutureExt, SinkExt, StreamExt};
 
 use chromiumoxide_cdp::cdp::browser_protocol::browser::{GetVersionParams, GetVersionReturns};
 use chromiumoxide_cdp::cdp::browser_protocol::dom::{
@@ -23,17 +24,19 @@ use chromiumoxide_cdp::cdp::browser_protocol::page::{
 };
 use chromiumoxide_cdp::cdp::browser_protocol::target::{ActivateTargetParams, SessionId, TargetId};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{
-    CallFunctionOnParams, CallFunctionOnReturns, EvaluateParams, ExecutionContextId, RemoteObjectId,
+    CallFunctionOnParams, EvaluateParams, ExecutionContextId,
 };
 use chromiumoxide_types::{Command, CommandResponse};
 
 use crate::cmd::{CommandMessage, to_command_response};
 use crate::error::{CdpError, Result};
+use crate::frame::Frame;
 use crate::handler::commandfuture::CommandFuture;
 use crate::handler::domworld::DOMWorldKind;
 use crate::handler::httpfuture::HttpFuture;
-use crate::handler::target::{GetExecutionContext, TargetMessage};
-use crate::handler::target_message_future::TargetMessageFuture;
+use crate::handler::target::{
+    FrameBoundary, FrameInfo, GetExecutionContext, InternalTargetMessage, TargetMessage,
+};
 use crate::js::EvaluationResult;
 use crate::layout::Point;
 use crate::page::ScreenshotParams;
@@ -42,20 +45,24 @@ use crate::{ArcHttpRequest, keys, utils};
 #[derive(Debug)]
 pub struct PageHandle {
     pub(crate) rx: Fuse<Receiver<TargetMessage>>,
+    pub(crate) internal_rx: Fuse<Receiver<InternalTargetMessage>>,
     page: Arc<PageInner>,
 }
 
 impl PageHandle {
     pub fn new(target_id: TargetId, session_id: SessionId, opener_id: Option<TargetId>) -> Self {
         let (commands, rx) = channel(1);
+        let (internal_commands, internal_rx) = channel(1);
         let page = PageInner {
             target_id,
             session_id,
             opener_id,
             sender: commands,
+            internal_sender: internal_commands,
         };
         Self {
             rx: rx.fuse(),
+            internal_rx: internal_rx.fuse(),
             page: Arc::new(page),
         }
     }
@@ -71,6 +78,7 @@ pub(crate) struct PageInner {
     session_id: SessionId,
     opener_id: Option<TargetId>,
     sender: Sender<TargetMessage>,
+    internal_sender: Sender<InternalTargetMessage>,
 }
 
 impl PageInner {
@@ -79,22 +87,53 @@ impl PageInner {
         execute(cmd, self.sender.clone(), Some(self.session_id.clone())).await
     }
 
+    /// Execute a command on an explicitly captured CDP session.
+    ///
+    /// Element handles use this path so their DOM and Runtime object ids never
+    /// silently fall back to the page's main session after an OOP frame swap.
+    pub(crate) async fn execute_with_session<T: Command>(
+        &self,
+        cmd: T,
+        session_id: &SessionId,
+    ) -> Result<CommandResponse<T::Response>> {
+        let (tx, rx) = oneshot_channel();
+        let method = cmd.identifier();
+        let command = CommandMessage::with_session(cmd, tx, Some(session_id.clone()))?;
+        self.internal_sender
+            .clone()
+            .send(InternalTargetMessage::SessionCommand {
+                session_id: session_id.clone(),
+                command,
+            })
+            .await?;
+        let response = rx.await??;
+        to_command_response::<T>(response, method)
+    }
+
     /// Create a PDL command future
     pub(crate) fn command_future<T: Command>(&self, cmd: T) -> Result<CommandFuture<T>> {
         CommandFuture::new(cmd, self.sender.clone(), Some(self.session_id.clone()))
     }
 
     /// This creates navigation future with the final http response when the page is loaded
-    pub(crate) fn wait_for_navigation(&self) -> TargetMessageFuture<ArcHttpRequest> {
-        TargetMessageFuture::<ArcHttpRequest>::wait_for_navigation(self.sender.clone())
+    pub(crate) fn wait_for_navigation(&self) -> BoxFuture<'static, Result<ArcHttpRequest>> {
+        let mut sender = self.internal_sender.clone();
+        async move {
+            let (tx, rx) = oneshot_channel();
+            sender
+                .send(InternalTargetMessage::WaitForNavigationResult { tx })
+                .await?;
+            rx.await?
+        }
+        .boxed()
     }
 
     /// This creates HTTP future with navigation and responds with the final
     /// http response when the page is loaded
     pub(crate) fn http_future<T: Command>(&self, cmd: T) -> Result<HttpFuture<T>> {
-        Ok(HttpFuture::new(
-            self.sender.clone(),
+        Ok(HttpFuture::with_navigation(
             self.command_future(cmd)?,
+            self.wait_for_navigation(),
         ))
     }
 
@@ -117,13 +156,87 @@ impl PageInner {
         &self.sender
     }
 
+    /// Sender for operations whose correctness depends on a captured frame or
+    /// child-session identity. It is intentionally separate from the legacy
+    /// public message channel.
+    pub(crate) fn internal_sender(&self) -> &Sender<InternalTargetMessage> {
+        &self.internal_sender
+    }
+
+    pub(crate) async fn frame_info(&self, frame_id: FrameId) -> Result<Option<FrameInfo>> {
+        let (tx, rx) = oneshot_channel();
+        self.internal_sender
+            .clone()
+            .send(InternalTargetMessage::GetFrameInfo { frame_id, tx })
+            .await?;
+        rx.await?
+    }
+
+    /// Snapshot the cross-session edges between a frame and the page root.
+    pub(crate) async fn frame_boundary_chain(
+        &self,
+        frame_id: FrameId,
+        expected_session_id: SessionId,
+    ) -> Result<Vec<FrameBoundary>> {
+        let (tx, rx) = oneshot_channel();
+        self.internal_sender
+            .clone()
+            .send(InternalTargetMessage::GetFrameBoundaryChain {
+                frame_id,
+                expected_session_id,
+                tx,
+            })
+            .await?;
+        rx.await?
+    }
+
+    pub(crate) fn frame_from_info(self: &Arc<Self>, info: FrameInfo) -> Frame {
+        Frame::from_info(Arc::clone(self), info)
+    }
+
+    pub(crate) async fn frame_by_id(self: &Arc<Self>, frame_id: FrameId) -> Result<Option<Frame>> {
+        Ok(self
+            .frame_info(frame_id)
+            .await?
+            .map(|info| self.frame_from_info(info)))
+    }
+
+    pub(crate) async fn all_frames(self: &Arc<Self>) -> Result<Vec<Frame>> {
+        let (tx, rx) = oneshot_channel();
+        self.internal_sender
+            .clone()
+            .send(InternalTargetMessage::GetAllFrames { tx })
+            .await?;
+        Ok(rx
+            .await?
+            .into_iter()
+            .map(|info| self.frame_from_info(info))
+            .collect())
+    }
+
+    pub(crate) async fn main_frame(self: &Arc<Self>) -> Result<Option<Frame>> {
+        let (tx, rx) = oneshot_channel();
+        self.sender
+            .clone()
+            .send(TargetMessage::MainFrame(tx))
+            .await?;
+        let Some(frame_id) = rx.await? else {
+            return Ok(None);
+        };
+        self.frame_by_id(frame_id).await
+    }
+
     /// Returns the first element in the node which matches the given CSS
     /// selector.
     pub async fn find_element(&self, selector: impl Into<String>, node: NodeId) -> Result<NodeId> {
-        Ok(self
+        let node_id = self
             .execute(QuerySelectorParams::new(node, selector))
             .await?
-            .node_id)
+            .node_id;
+        if *node_id.inner() == 0 {
+            return Err(CdpError::NotFound);
+        }
+        Ok(node_id)
     }
 
     /// Activates (focuses) the target.
@@ -273,28 +386,6 @@ impl PageInner {
         self.execute(cmd.r#type(DispatchKeyEventType::KeyUp).build().unwrap())
             .await?;
         Ok(self)
-    }
-
-    /// Calls function with given declaration on the remote object with the
-    /// matching id
-    pub async fn call_js_fn(
-        &self,
-        function_declaration: impl Into<String>,
-        await_promise: bool,
-        remote_object_id: RemoteObjectId,
-    ) -> Result<CallFunctionOnReturns> {
-        let resp = self
-            .execute(
-                CallFunctionOnParams::builder()
-                    .object_id(remote_object_id)
-                    .function_declaration(function_declaration)
-                    .generate_preview(true)
-                    .await_promise(await_promise)
-                    .build()
-                    .unwrap(),
-            )
-            .await?;
-        Ok(resp.result)
     }
 
     pub async fn evaluate_expression(

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -1,22 +1,37 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 
 use chromiumoxide_cdp::cdp::browser_protocol::target::DetachFromTargetParams;
+use futures::channel::mpsc::{Receiver, TryRecvError, UnboundedSender};
 use futures::channel::oneshot::Sender;
 use futures::stream::Stream;
 use futures::task::{Context, Poll};
 
 use chromiumoxide_cdp::cdp::CdpEventMessage;
-use chromiumoxide_cdp::cdp::browser_protocol::page::{FrameId, GetFrameTreeParams};
+use chromiumoxide_cdp::cdp::browser_protocol::fetch::{
+    self, ContinueRequestParams, RequestPattern,
+};
+#[allow(deprecated)]
+use chromiumoxide_cdp::cdp::browser_protocol::network::{
+    EmulateNetworkConditionsParams, Headers, SetCacheDisabledParams, SetExtraHttpHeadersParams,
+};
+use chromiumoxide_cdp::cdp::browser_protocol::page::{
+    AddScriptToEvaluateOnNewDocumentParams, FrameId, GetFrameTreeParams, ScriptIdentifier,
+};
 use chromiumoxide_cdp::cdp::browser_protocol::{
     browser::BrowserContextId,
-    log as cdplog, performance,
-    target::{AttachToTargetParams, SessionId, SetAutoAttachParams, TargetId, TargetInfo},
+    log as cdplog, network as cdp_network, performance,
+    security::SetIgnoreCertificateErrorsParams,
+    target::{
+        AttachToTargetParams, EventDetachedFromTarget, SessionId, SetAutoAttachParams, TargetId,
+        TargetInfo,
+    },
 };
 use chromiumoxide_cdp::cdp::events::CdpEvent;
-use chromiumoxide_types::{Command, Method, Request, Response};
+use chromiumoxide_types::{Command, Method, MethodId, Request, Response};
 
 use crate::auth::Credentials;
 use crate::cdp::browser_protocol::target::CloseTargetParams;
@@ -27,19 +42,67 @@ use crate::handler::browser::BrowserContext;
 use crate::handler::domworld::DOMWorldKind;
 use crate::handler::emulation::EmulationManager;
 use crate::handler::frame::{
-    FrameEvent, FrameManager, NavigationError, NavigationId, NavigationOk,
+    FrameEvent, FrameManager, FrameWaitError, NavigationError, NavigationId, NavigationOk,
+    PreloadId,
 };
 use crate::handler::frame::{FrameNavigationRequest, UTILITY_WORLD_NAME};
-use crate::handler::network::{NetworkEvent, NetworkManager};
+use crate::handler::network::{NetworkCommand, NetworkEvent, NetworkManager, PauseDisposition};
 use crate::handler::page::PageHandle;
 use crate::handler::viewport::Viewport;
 use crate::handler::{PageInner, REQUEST_TIMEOUT};
 use crate::listeners::{EventListenerRequest, EventListeners};
-use crate::{ArcHttpRequest, page::Page};
+use crate::{
+    ArcHttpRequest,
+    page::{Page, PausedRequest},
+};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{
     ExecutionContextId, RunIfWaitingForDebuggerParams,
 };
 use std::time::Duration;
+
+const PAGE_MESSAGE_POLL_BUDGET: usize = 32;
+
+fn drain_closed_receiver<T>(receiver: &mut Receiver<T>, mut settle: impl FnMut(T)) {
+    loop {
+        match receiver.try_recv() {
+            Ok(message) => settle(message),
+            Err(TryRecvError::Empty) => {
+                // SinkExt::send performs the state increment and queue push in
+                // one synchronous poll, so a single-thread executor cannot
+                // interleave teardown here. A producer on another OS thread can
+                // be preempted inside that short critical section, with no hard
+                // wall-clock bound before it resumes. Receiver::drop relies on
+                // the same yield-and-drain behavior; teardown accepts that
+                // dependency-level risk so every message accepted before close
+                // is drained and settled. Sends starting after close fail at
+                // the channel boundary instead of entering this receiver.
+                std::thread::yield_now();
+            }
+            Err(TryRecvError::Closed) => break,
+        }
+    }
+}
+
+fn poll_receiver_batch<T, S>(receiver: &mut S, cx: &mut Context<'_>) -> (Vec<T>, bool)
+where
+    S: Stream<Item = T> + Unpin,
+{
+    let mut messages = Vec::new();
+    for _ in 0..PAGE_MESSAGE_POLL_BUDGET {
+        match Pin::new(&mut *receiver).poll_next(cx) {
+            Poll::Ready(Some(message)) => messages.push(message),
+            Poll::Ready(None) | Poll::Pending => break,
+        }
+    }
+
+    let budget_exhausted = messages.len() == PAGE_MESSAGE_POLL_BUDGET;
+    if budget_exhausted {
+        // The receiver may still be ready. Schedule another poll instead of
+        // letting a hot page monopolize the handler task.
+        cx.waker().wake_by_ref();
+    }
+    (messages, budget_exhausted)
+}
 
 macro_rules! advance_state {
     ($s:ident, $cx:ident, $now:ident, $cmds: ident, $next_state:expr ) => {{
@@ -84,12 +147,32 @@ pub struct Target {
     page: Option<PageHandle>,
     /// Drives this target towards initialization
     init_state: TargetInit,
+    /// Initialization state for every paused OOP child session.
+    iframe_init_states: HashMap<SessionId, IframeInitState>,
+    /// Main-target initialization reuses `InitializingFrame` for the utility
+    /// script command, so this prevents an explicit failure from turning the
+    /// next state poll into an accidental retry loop.
+    main_isolated_world_attempted: bool,
     /// Currently queued events to report to the `Handler`
     queued_events: VecDeque<TargetEvent>,
+    /// Sessions that are no longer allowed to produce ordinary work. The
+    /// tombstone remains until the handler removes the session route, closing
+    /// the window where late events could otherwise re-enter this target.
+    draining_sessions: HashSet<SessionId>,
     /// All registered event subscriptions
     event_listeners: EventListeners,
+    /// At most one live consumer owns managed paused-request responses. A
+    /// closed consumer is replaceable on the next registration attempt.
+    paused_request_sink: Option<PausedRequestSink>,
+    /// Whether a Page clone has been successfully handed to user code. Before
+    /// that point a main-session pause must not wait for an unavailable
+    /// responder during target bootstrap.
+    page_exposed: bool,
     /// Senders that need to be notified once the main frame has loaded
     wait_for_frame_navigation: Vec<Sender<ArcHttpRequest>>,
+    /// Page-facing navigation waiters retain their typed error channel after
+    /// they have been promoted out of the page message receiver.
+    wait_for_navigation_results: Vec<Sender<Result<ArcHttpRequest>>>,
     /// The sender who requested the page.
     initiator: Option<Sender<Result<Page>>>,
 }
@@ -115,15 +198,22 @@ impl Target {
             session_id: None,
             page: None,
             init_state: TargetInit::AttachToTarget,
+            iframe_init_states: Default::default(),
+            main_isolated_world_attempted: false,
             wait_for_frame_navigation: Default::default(),
+            wait_for_navigation_results: Default::default(),
             queued_events: Default::default(),
+            draining_sessions: Default::default(),
             event_listeners: Default::default(),
+            paused_request_sink: None,
+            page_exposed: false,
             initiator: None,
             browser_context,
         }
     }
 
     pub fn set_session_id(&mut self, id: SessionId) {
+        self.frame_manager.set_main_session_id(id.clone());
         self.session_id = Some(id)
     }
 
@@ -159,6 +249,524 @@ impl Target {
         self.frame_manager.goto(req)
     }
 
+    pub(crate) fn goto_in_session(&mut self, session_id: SessionId, req: FrameNavigationRequest) {
+        let Some(frame_id) = self
+            .frame_manager
+            .main_frame()
+            .map(|frame| frame.id().clone())
+        else {
+            return;
+        };
+        self.frame_manager
+            .navigate_frame_in_session(session_id, frame_id, req);
+    }
+
+    pub(crate) fn goto_frame(
+        &mut self,
+        session_id: SessionId,
+        frame_id: FrameId,
+        req: FrameNavigationRequest,
+    ) {
+        self.frame_manager
+            .navigate_frame_in_session(session_id, frame_id, req);
+    }
+
+    pub(crate) fn on_navigation_failed(&mut self, navigation_id: NavigationId, error_text: String) {
+        self.frame_manager
+            .fail_navigation_by_nav_id(navigation_id, error_text);
+    }
+
+    /// Whether commands may still be submitted to this session. A child must
+    /// be registered, fully initialized, and outside the draining window.
+    pub(crate) fn frame_session_ready(&self, session_id: &SessionId) -> bool {
+        if self.is_session_draining(session_id) {
+            return false;
+        }
+        if self.session_id() == Some(session_id) {
+            return true;
+        }
+        if !self.frame_manager.is_child_session(session_id) {
+            return false;
+        }
+        self.iframe_init_states
+            .get(session_id)
+            .is_none_or(|state| matches!(state, IframeInitState::Done))
+    }
+
+    /// Pin a frame operation to both frame identity and the session captured by
+    /// its caller. A live main session alone is insufficient after a swap.
+    pub(crate) fn frame_ready(&self, frame_id: &FrameId, session_id: &SessionId) -> bool {
+        self.frame_session_ready(session_id)
+            && self
+                .frame_manager
+                .frame(frame_id)
+                .is_some_and(|frame| frame.session_id() == Some(session_id))
+    }
+
+    fn build_frame_info(&self, frame: &crate::handler::frame::Frame) -> Result<FrameInfo> {
+        Ok(FrameInfo {
+            frame_id: frame.id().clone(),
+            session_id: frame.require_session_id()?.clone(),
+            main_session_id: self
+                .frame_manager
+                .main_session_id()
+                .ok_or(CdpError::FrameNotReady)?
+                .clone(),
+            parent_id: frame.parent_id().cloned(),
+            url: frame.url().map(str::to_owned),
+            security_origin: frame.security_origin().to_owned(),
+        })
+    }
+
+    /// Build the immutable cross-session topology snapshot used by Element
+    /// geometry. Same-session ancestors are intentionally omitted because CDP
+    /// DOM quads are already relative to that session's root frame.
+    fn build_boundary_chain(
+        &self,
+        leaf: &FrameId,
+        expected_session_id: &SessionId,
+    ) -> Result<Vec<FrameBoundary>> {
+        let leaf_frame = self
+            .frame_manager
+            .frame(leaf)
+            .ok_or_else(|| CdpError::FrameNotFound(leaf.clone()))?;
+        if leaf_frame.session_id() != Some(expected_session_id)
+            || !self.frame_session_ready(expected_session_id)
+        {
+            return Err(CdpError::FrameNotReady);
+        }
+
+        let main_frame_id = self
+            .frame_manager
+            .main_frame()
+            .map(|frame| frame.id().clone())
+            .ok_or(CdpError::FrameNotReady)?;
+        let mut chain = Vec::new();
+        let mut visited = HashSet::new();
+        let mut current_id = leaf.clone();
+
+        loop {
+            let current = self
+                .frame_manager
+                .frame(&current_id)
+                .ok_or(CdpError::FrameNotReady)?;
+            let Some(parent_id) = current.parent_id().cloned() else {
+                if current_id == main_frame_id {
+                    break;
+                }
+                return Err(CdpError::FrameNotReady);
+            };
+            let current_session_id = current.require_session_id()?.clone();
+            if !visited.insert(current_id.clone()) {
+                return Err(CdpError::FrameNotReady);
+            }
+
+            let parent = self
+                .frame_manager
+                .frame(&parent_id)
+                .ok_or(CdpError::FrameNotReady)?;
+            let parent_session_id = parent.require_session_id()?;
+            if !self.frame_session_ready(parent_session_id) {
+                return Err(CdpError::FrameNotReady);
+            }
+            if parent_session_id != &current_session_id {
+                chain.push(FrameBoundary {
+                    child_frame_id: current_id.clone(),
+                    child_session_id: current_session_id,
+                    parent_frame_id: parent_id.clone(),
+                    parent_session_id: parent_session_id.clone(),
+                });
+            }
+            current_id = parent_id;
+        }
+
+        Ok(chain)
+    }
+
+    fn request_for_session<T: Command>(command: T, session_id: &SessionId) -> Request {
+        Request {
+            method: command.identifier(),
+            session_id: Some(session_id.as_ref().to_owned()),
+            params: serde_json::to_value(command).expect("Command should not panic"),
+        }
+    }
+
+    fn network_requests_for_session(
+        commands: &[NetworkCommand],
+        session_id: &SessionId,
+    ) -> Vec<Request> {
+        commands
+            .iter()
+            .map(|(method, params)| Request {
+                method: method.clone(),
+                session_id: Some(session_id.as_ref().to_owned()),
+                params: params.clone(),
+            })
+            .collect()
+    }
+
+    fn preload_request_for_session(
+        params: AddScriptToEvaluateOnNewDocumentParams,
+        preload_key: PreloadId,
+        session_id: &SessionId,
+    ) -> TargetEvent {
+        TargetEvent::QueuePreloadScript {
+            request: Self::request_for_session(params, session_id),
+            preload_key,
+        }
+    }
+
+    fn already_snapshotted_child_sessions(&self) -> Vec<SessionId> {
+        let mut sessions = self
+            .frame_manager
+            .child_sessions()
+            .filter(|session_id| !self.is_session_draining(session_id))
+            .filter(|session_id| {
+                matches!(
+                    self.iframe_init_states.get(*session_id),
+                    None | Some(IframeInitState::PostChainPreload)
+                        | Some(IframeInitState::PostChainNetwork)
+                        | Some(IframeInitState::PostChainUnpause)
+                        | Some(IframeInitState::Done)
+                )
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        sessions.sort_by(|left, right| left.as_ref().cmp(right.as_ref()));
+        sessions
+    }
+
+    /// Enqueue an already-tracked script for every child that has crossed its
+    /// init snapshot boundary. Chaining children will see it in their later
+    /// snapshot instead, which keeps each script single-sourced per session.
+    pub(crate) fn enqueue_preload_fan_out(&mut self, preload_key: PreloadId) {
+        let Some((_, params)) = self
+            .frame_manager
+            .preload_snapshot()
+            .into_iter()
+            .find(|(id, _)| *id == preload_key)
+        else {
+            return;
+        };
+        for session_id in self.already_snapshotted_child_sessions() {
+            self.queued_events
+                .push_back(Self::preload_request_for_session(
+                    params.clone(),
+                    preload_key,
+                    &session_id,
+                ));
+        }
+    }
+
+    /// Queues one ordered dynamic-state update. Fully initialized sessions
+    /// participate in the response acknowledgement; sessions already past
+    /// their network replay receive a best-effort latest-state update without
+    /// delaying the caller.
+    fn enqueue_network_fan_out(
+        &mut self,
+        commands: Vec<NetworkCommand>,
+        ack_tx: Sender<Result<()>>,
+    ) {
+        let Some(main_session_id) = self.frame_manager.main_session_id().cloned() else {
+            let _ = ack_tx.send(Err(CdpError::FrameNotReady));
+            return;
+        };
+
+        let mut child_sessions = self
+            .frame_manager
+            .child_sessions()
+            .filter(|session_id| !self.is_session_draining(session_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        child_sessions.sort_by(|left, right| left.as_ref().cmp(right.as_ref()));
+
+        let mut ack_reqs = Self::network_requests_for_session(&commands, &main_session_id);
+        let mut send_only_reqs = Vec::new();
+        for session_id in child_sessions {
+            match self.iframe_init_states.get(&session_id) {
+                None | Some(IframeInitState::Done) => {
+                    ack_reqs.extend(Self::network_requests_for_session(&commands, &session_id))
+                }
+                Some(IframeInitState::PostChainNetwork)
+                | Some(IframeInitState::PostChainUnpause) => send_only_reqs
+                    .extend(Self::network_requests_for_session(&commands, &session_id)),
+                Some(IframeInitState::Chaining { .. })
+                | Some(IframeInitState::PostChainPreload)
+                | Some(IframeInitState::Failed) => {}
+            }
+        }
+
+        self.queued_events
+            .push_back(TargetEvent::FanOutAckBatch(FanOutAckBatch {
+                ack_reqs,
+                send_only_reqs,
+                ack_tx,
+                main_session_id,
+            }));
+    }
+
+    fn start_iframe_init(&mut self, session_id: SessionId) {
+        if self.is_session_draining(&session_id)
+            || self.iframe_init_states.contains_key(&session_id)
+        {
+            return;
+        }
+        let chain = self.build_iframe_phase_chain(&session_id, InitPhase::Frame);
+        self.iframe_init_states.insert(
+            session_id,
+            IframeInitState::Chaining {
+                chain,
+                phase: InitPhase::Frame,
+            },
+        );
+    }
+
+    fn build_iframe_phase_chain(
+        &mut self,
+        session_id: &SessionId,
+        phase: InitPhase,
+    ) -> CommandChain {
+        match phase {
+            InitPhase::Frame => FrameManager::init_commands(self.config.request_timeout),
+            InitPhase::IsolatedWorld => self
+                .frame_manager
+                .ensure_isolated_world_on_next_document_in_session(
+                    UTILITY_WORLD_NAME,
+                    session_id.clone(),
+                )
+                // `None` means the utility world is already registered for this
+                // session (I-007: a paused OOP child gets the named-world script
+                // before unpause and no explicit createIsolatedWorld). Nothing to
+                // submit, so advance the init chain with an empty command chain.
+                .unwrap_or_else(|| {
+                    CommandChain::new(
+                        Vec::<(MethodId, serde_json::Value)>::new(),
+                        self.config.request_timeout,
+                    )
+                }),
+            InitPhase::AutoAttach => {
+                let attach = SetAutoAttachParams::builder()
+                    .flatten(true)
+                    .auto_attach(true)
+                    .wait_for_debugger_on_start(true)
+                    .build()
+                    .expect("auto-attach parameters are complete");
+                CommandChain::new(
+                    vec![(
+                        attach.identifier(),
+                        serde_json::to_value(attach).expect("Command should not panic"),
+                    )],
+                    self.config.request_timeout,
+                )
+            }
+            InitPhase::Bindings => CommandChain::new(
+                Vec::<(MethodId, serde_json::Value)>::new(),
+                self.config.request_timeout,
+            ),
+        }
+    }
+
+    fn advance_to_next_iframe_phase(&mut self, session_id: SessionId, phase: InitPhase) {
+        if self.is_session_draining(&session_id)
+            || !matches!(
+                self.iframe_init_states.get(&session_id),
+                Some(IframeInitState::Chaining {
+                    phase: current_phase,
+                    ..
+                }) if *current_phase == phase
+            )
+        {
+            return;
+        }
+
+        if let Some(next_phase) = phase.next() {
+            let chain = self.build_iframe_phase_chain(&session_id, next_phase);
+            self.iframe_init_states.insert(
+                session_id,
+                IframeInitState::Chaining {
+                    chain,
+                    phase: next_phase,
+                },
+            );
+        } else {
+            self.finish_iframe_init_phases(session_id);
+        }
+    }
+
+    fn finish_iframe_init_phases(&mut self, session_id: SessionId) {
+        if matches!(
+            self.iframe_init_states.get(&session_id),
+            Some(IframeInitState::Chaining { .. })
+        ) {
+            for (preload_key, params) in self.frame_manager.preload_snapshot() {
+                self.queued_events
+                    .push_back(Self::preload_request_for_session(
+                        params,
+                        preload_key,
+                        &session_id,
+                    ));
+            }
+            self.iframe_init_states
+                .insert(session_id, IframeInitState::PostChainPreload);
+        }
+    }
+
+    fn transition_iframe_to_failed_and_unpause(&mut self, session_id: SessionId) {
+        if !matches!(
+            self.iframe_init_states.get(&session_id),
+            Some(IframeInitState::Chaining { .. })
+        ) {
+            return;
+        }
+        self.iframe_init_states
+            .insert(session_id.clone(), IframeInitState::Failed);
+        self.queued_events
+            .push_back(TargetEvent::Request(Self::request_for_session(
+                RunIfWaitingForDebuggerParams::default(),
+                &session_id,
+            )));
+    }
+
+    fn iframe_network_sync_requests(&self, session_id: &SessionId) -> Vec<Request> {
+        let mut requests = Vec::new();
+        let mut push = |method: MethodId, params: serde_json::Value| {
+            requests.push(Request {
+                method,
+                session_id: Some(session_id.as_ref().to_owned()),
+                params,
+            });
+        };
+
+        let enable = cdp_network::EnableParams::default();
+        push(
+            enable.identifier(),
+            serde_json::to_value(enable).expect("Command should not panic"),
+        );
+
+        if self.network_manager.ignore_https_errors() {
+            let ignore = SetIgnoreCertificateErrorsParams::new(true);
+            push(
+                ignore.identifier(),
+                serde_json::to_value(ignore).expect("Command should not panic"),
+            );
+        }
+
+        let cache = SetCacheDisabledParams::new(self.network_manager.is_cache_disabled());
+        push(
+            cache.identifier(),
+            serde_json::to_value(cache).expect("Command should not panic"),
+        );
+
+        let headers = serde_json::to_value(self.network_manager.extra_headers().clone())
+            .expect("headers should serialize");
+        let headers = SetExtraHttpHeadersParams::new(Headers::new(headers));
+        push(
+            headers.identifier(),
+            serde_json::to_value(headers).expect("Command should not panic"),
+        );
+
+        if self.network_manager.is_offline() {
+            #[allow(deprecated)]
+            let offline = EmulateNetworkConditionsParams::builder()
+                .offline(true)
+                .latency(0)
+                .download_throughput(-1.)
+                .upload_throughput(-1.)
+                .build()
+                .expect("offline parameters are complete");
+            push(
+                offline.identifier(),
+                serde_json::to_value(offline).expect("Command should not panic"),
+            );
+        }
+
+        if self.network_manager.is_request_interception_enabled()
+            || self.network_manager.credentials().is_some()
+        {
+            let fetch = fetch::EnableParams::builder()
+                .handle_auth_requests(true)
+                .pattern(RequestPattern::builder().url_pattern("*").build())
+                .build();
+            push(
+                fetch.identifier(),
+                serde_json::to_value(fetch).expect("Command should not panic"),
+            );
+        }
+
+        if let Some(viewport) = self.config.viewport.as_ref() {
+            for (method, params) in EmulationManager::viewport_commands(viewport) {
+                push(method, params);
+            }
+        }
+
+        requests
+    }
+
+    fn poll_iframe_init(&mut self, now: Instant) -> bool {
+        let session_ids = self.iframe_init_states.keys().cloned().collect::<Vec<_>>();
+        for session_id in session_ids {
+            let action = match self.iframe_init_states.get_mut(&session_id) {
+                Some(IframeInitState::Chaining { chain, phase }) => match chain.poll(now) {
+                    Poll::Pending => None,
+                    Poll::Ready(Some(Ok((method, params)))) => {
+                        Some(IframeInitAction::Send { method, params })
+                    }
+                    Poll::Ready(Some(Err(_))) => Some(IframeInitAction::Timeout),
+                    Poll::Ready(None) => Some(IframeInitAction::PhaseComplete(*phase)),
+                },
+                Some(IframeInitState::PostChainPreload) => Some(IframeInitAction::EnqueueNetwork),
+                Some(IframeInitState::PostChainNetwork) => Some(IframeInitAction::EnqueueUnpause),
+                Some(IframeInitState::PostChainUnpause) => Some(IframeInitAction::MarkDone),
+                Some(IframeInitState::Done) => Some(IframeInitAction::RemoveDone),
+                Some(IframeInitState::Failed) | None => None,
+            };
+
+            let Some(action) = action else {
+                continue;
+            };
+            match action {
+                IframeInitAction::Send { method, params } => {
+                    self.queued_events.push_back(TargetEvent::Request(Request {
+                        method,
+                        session_id: Some(session_id.as_ref().to_owned()),
+                        params,
+                    }));
+                }
+                IframeInitAction::Timeout => {
+                    self.transition_iframe_to_failed_and_unpause(session_id);
+                }
+                IframeInitAction::PhaseComplete(phase) => {
+                    self.advance_to_next_iframe_phase(session_id, phase);
+                }
+                IframeInitAction::EnqueueNetwork => {
+                    let requests = self.iframe_network_sync_requests(&session_id);
+                    self.iframe_init_states
+                        .insert(session_id, IframeInitState::PostChainNetwork);
+                    self.queued_events
+                        .extend(requests.into_iter().map(TargetEvent::Request));
+                }
+                IframeInitAction::EnqueueUnpause => {
+                    self.iframe_init_states
+                        .insert(session_id.clone(), IframeInitState::PostChainUnpause);
+                    self.queued_events
+                        .push_back(TargetEvent::Request(Self::request_for_session(
+                            RunIfWaitingForDebuggerParams::default(),
+                            &session_id,
+                        )));
+                }
+                IframeInitAction::MarkDone => {
+                    self.iframe_init_states
+                        .insert(session_id, IframeInitState::Done);
+                }
+                IframeInitAction::RemoveDone => {
+                    self.iframe_init_states.remove(&session_id);
+                }
+            }
+            return true;
+        }
+        false
+    }
+
     fn create_page(&mut self) {
         if self.page.is_none() {
             if let Some(session) = self.session_id.clone() {
@@ -173,6 +781,19 @@ impl Target {
     pub(crate) fn get_or_create_page(&mut self) -> Option<&Arc<PageInner>> {
         self.create_page();
         self.page.as_ref().map(|p| p.inner())
+    }
+
+    /// Records Page exposure only after the receiving user-visible channel
+    /// accepted the clone. Creating an internal PageHandle is not exposure.
+    pub(crate) fn mark_page_exposed_after_successful_send(&mut self, delivered: bool) {
+        if delivered {
+            self.page_exposed = true;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn page_exposed(&self) -> bool {
+        self.page_exposed
     }
 
     pub fn is_page(&self) -> bool {
@@ -200,64 +821,530 @@ impl Target {
         &mut self.frame_manager
     }
 
+    #[cfg(test)]
+    pub(crate) fn queued_events(&self) -> &VecDeque<TargetEvent> {
+        &self.queued_events
+    }
+
+    /// Mark a child session as draining and remove work that has not reached
+    /// the connection yet.
+    ///
+    /// Inserting the tombstone first makes repeated swap/detach notifications
+    /// idempotent and ensures queue cleanup runs at most once.
+    pub(crate) fn enter_draining_session(&mut self, session_id: SessionId) {
+        if !self.draining_sessions.insert(session_id.clone()) {
+            return;
+        }
+
+        self.iframe_init_states.remove(&session_id);
+        self.network_manager.on_session_draining(&session_id);
+        self.frame_manager
+            .fail_navigation_state_for_session(&session_id, FrameWaitError::FrameSwappedOrDetached);
+        self.rebuild_queued_events_for_session(&session_id);
+        self.queued_events
+            .push_back(TargetEvent::SessionDraining(session_id));
+    }
+
+    pub(crate) fn is_session_draining(&self, session_id: &SessionId) -> bool {
+        self.draining_sessions.contains(session_id)
+    }
+
+    /// Clear a draining tombstone only after the handler has removed the
+    /// session-to-target route.
+    pub(crate) fn clear_draining(&mut self, session_id: &SessionId) {
+        self.draining_sessions.remove(session_id);
+    }
+
+    /// Fail queued work for one dead child session while preserving every
+    /// other event's relative position.
+    pub(crate) fn fail_queued_events(&mut self, session_id: &SessionId) {
+        self.rebuild_queued_events_for_session(session_id);
+    }
+
+    /// Remove one session from a queued fan-out operation without changing
+    /// the batch's position in the surrounding target queue.
+    fn filter_fan_out_batch(
+        &mut self,
+        mut batch: FanOutAckBatch,
+        session_id: &SessionId,
+    ) -> Option<FanOutAckBatch> {
+        // The main-session check is identity-based. Inferring it from an empty
+        // request bag could incorrectly report success while the page itself
+        // is being torn down.
+        if session_id == &batch.main_session_id {
+            let _ = batch.ack_tx.send(Err(CdpError::FrameNotReady));
+            return None;
+        }
+
+        batch
+            .ack_reqs
+            .retain(|request| request.session_id.as_deref() != Some(session_id.as_ref()));
+        batch
+            .send_only_reqs
+            .retain(|request| request.session_id.as_deref() != Some(session_id.as_ref()));
+        Some(batch)
+    }
+
+    /// Rebuild the queue in two ownership phases so sender resolution cannot
+    /// conflict with a borrow of `self.queued_events`.
+    fn rebuild_queued_events_for_session(&mut self, session_id: &SessionId) {
+        let queued_events = mem::take(&mut self.queued_events);
+        let mut surviving_events = VecDeque::with_capacity(queued_events.len());
+
+        for event in queued_events {
+            match event {
+                TargetEvent::Request(request) => {
+                    if request.session_id.as_deref() != Some(session_id.as_ref()) {
+                        surviving_events.push_back(TargetEvent::Request(request));
+                    }
+                }
+                TargetEvent::NavigationRequest(id, request) => {
+                    if request.session_id.as_deref() != Some(session_id.as_ref()) {
+                        surviving_events.push_back(TargetEvent::NavigationRequest(id, request));
+                    }
+                }
+                TargetEvent::NavigationResult(result) => {
+                    surviving_events.push_back(TargetEvent::NavigationResult(result));
+                }
+                TargetEvent::Command(command) => {
+                    if command.session_id.as_ref() == Some(session_id) {
+                        let _ = command.sender.send(Err(CdpError::FrameNotReady));
+                    } else {
+                        surviving_events.push_back(TargetEvent::Command(command));
+                    }
+                }
+                TargetEvent::RegisterChildSession(child_session_id) => {
+                    surviving_events.push_back(TargetEvent::RegisterChildSession(child_session_id))
+                }
+                TargetEvent::UnregisterChildSession(child_session_id) => surviving_events
+                    .push_back(TargetEvent::UnregisterChildSession(child_session_id)),
+                TargetEvent::SessionDraining(child_session_id) => {
+                    surviving_events.push_back(TargetEvent::SessionDraining(child_session_id))
+                }
+                TargetEvent::FrameNavigate {
+                    session_id: event_session_id,
+                    frame_id,
+                    req,
+                    tx,
+                } => {
+                    if event_session_id == *session_id {
+                        let _ = tx.send(Err(CdpError::FrameNotReady));
+                    } else {
+                        surviving_events.push_back(TargetEvent::FrameNavigate {
+                            session_id: event_session_id,
+                            frame_id,
+                            req,
+                            tx,
+                        });
+                    }
+                }
+                TargetEvent::FrameWaitForNavigation {
+                    session_id: event_session_id,
+                    frame_id,
+                    tx,
+                } => {
+                    if event_session_id == *session_id {
+                        let _ = tx.send(Err(FrameWaitError::FrameSwappedOrDetached));
+                    } else {
+                        surviving_events.push_back(TargetEvent::FrameWaitForNavigation {
+                            session_id: event_session_id,
+                            frame_id,
+                            tx,
+                        });
+                    }
+                }
+                TargetEvent::QueuePreloadScript {
+                    request,
+                    preload_key,
+                } => {
+                    if request.session_id.as_deref() != Some(session_id.as_ref()) {
+                        surviving_events.push_back(TargetEvent::QueuePreloadScript {
+                            request,
+                            preload_key,
+                        });
+                    }
+                }
+                TargetEvent::AddPreloadScript { params, tx } => {
+                    surviving_events.push_back(TargetEvent::AddPreloadScript { params, tx })
+                }
+                TargetEvent::FanOutAckBatch(batch) => {
+                    if let Some(batch) = self.filter_fan_out_batch(batch, session_id) {
+                        surviving_events.push_back(TargetEvent::FanOutAckBatch(batch));
+                    }
+                }
+            }
+        }
+
+        self.queued_events = surviving_events;
+    }
+
+    /// Settle all queued senders when the entire target is gone.
+    ///
+    /// This is deliberately separate from per-session filtering: no queued
+    /// event may survive target teardown, including a fan-out group that has
+    /// not yet been registered by the handler.
+    pub(crate) fn fail_all_queued_events(&mut self) {
+        for event in mem::take(&mut self.queued_events) {
+            match event {
+                TargetEvent::Request(_) => {}
+                TargetEvent::NavigationRequest(_, _) => {}
+                TargetEvent::NavigationResult(_) => {}
+                TargetEvent::Command(command) => {
+                    let _ = command.sender.send(Err(CdpError::NoResponse));
+                }
+                TargetEvent::RegisterChildSession(_) => {}
+                TargetEvent::UnregisterChildSession(_) => {}
+                TargetEvent::SessionDraining(_) => {}
+                TargetEvent::FrameNavigate { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                TargetEvent::FrameWaitForNavigation { tx, .. } => {
+                    let _ = tx.send(Err(FrameWaitError::FrameSwappedOrDetached));
+                }
+                TargetEvent::QueuePreloadScript { .. } => {}
+                TargetEvent::AddPreloadScript { tx, .. } => {
+                    let _ = tx.send(Err(CdpError::NoResponse));
+                }
+                TargetEvent::FanOutAckBatch(batch) => {
+                    let _ = batch.ack_tx.send(Err(CdpError::NoResponse));
+                }
+            }
+        }
+    }
+
+    fn settle_target_message_on_teardown(message: TargetMessage) {
+        match message {
+            TargetMessage::Command(command) => {
+                let _ = command.sender.send(Err(CdpError::NoResponse));
+            }
+            TargetMessage::MainFrame(tx) => {
+                let _ = tx.send(None);
+            }
+            TargetMessage::AllFrames(tx) => {
+                let _ = tx.send(Vec::new());
+            }
+            TargetMessage::Url(GetUrl { tx, .. }) => {
+                let _ = tx.send(None);
+            }
+            TargetMessage::Name(GetName { tx, .. }) => {
+                let _ = tx.send(None);
+            }
+            TargetMessage::Parent(GetParent { tx, .. }) => {
+                let _ = tx.send(None);
+            }
+            TargetMessage::WaitForNavigation(tx) => {
+                let _ = tx.send(None);
+            }
+            TargetMessage::AddEventListener(_) => {}
+            TargetMessage::GetExecutionContext(GetExecutionContext { tx, .. }) => {
+                let _ = tx.send(None);
+            }
+            TargetMessage::Authenticate(_) => {}
+        }
+    }
+
+    fn settle_internal_message_on_teardown(message: InternalTargetMessage) {
+        match message {
+            InternalTargetMessage::FrameCommand { command, .. }
+            | InternalTargetMessage::SessionCommand { command, .. } => {
+                let _ = command.sender.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::FrameNavigate { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::FrameWaitForNavigation { tx, .. } => {
+                let _ = tx.send(Err(FrameWaitError::FrameSwappedOrDetached));
+            }
+            InternalTargetMessage::WaitForNavigationResult { tx } => {
+                let _ = tx.send(Err(CdpError::FrameNotReady));
+            }
+            InternalTargetMessage::GetPinnedExecutionContext { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::GetFrameInfo { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::GetAllFrames { tx } => {
+                let _ = tx.send(Vec::new());
+            }
+            InternalTargetMessage::GetFrameBoundaryChain { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::RegisterPausedRequestStream { tx, .. } => {
+                // The event and command side channels close when this message
+                // is dropped after its acknowledgement is settled.
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::AddPreloadScript { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::RegisterEventListener { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::SetCredentials { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+            InternalTargetMessage::SetRequestInterception { tx, .. } => {
+                let _ = tx.send(Err(CdpError::NoResponse));
+            }
+        }
+    }
+
+    /// Close every page ingress before draining it, then settle each sender by
+    /// its actual result type. This method is only for teardown of the whole
+    /// target; child-session detach must leave the page creation waiter alive.
+    pub(crate) fn settle_whole_target_teardown(&mut self) {
+        if let Some(page) = self.page.as_mut() {
+            // Both receivers must be closed before either is drained so no
+            // caller can enqueue into the other channel during teardown.
+            page.rx.get_mut().close();
+            page.internal_rx.get_mut().close();
+
+            drain_closed_receiver(page.rx.get_mut(), Self::settle_target_message_on_teardown);
+            drain_closed_receiver(
+                page.internal_rx.get_mut(),
+                Self::settle_internal_message_on_teardown,
+            );
+        }
+
+        for tx in mem::take(&mut self.wait_for_frame_navigation) {
+            let _ = tx.send(None);
+        }
+        for tx in mem::take(&mut self.wait_for_navigation_results) {
+            let _ = tx.send(Err(CdpError::FrameNotReady));
+        }
+        self.frame_manager.clear_isolated_world_registrations();
+        if let Some(initiator) = self.initiator.take() {
+            let _ = initiator.send(Err(CdpError::NoResponse));
+        }
+    }
+
     pub fn event_listeners_mut(&mut self) -> &mut EventListeners {
         &mut self.event_listeners
     }
 
     /// Received a response to a command issued by this target
     pub fn on_response(&mut self, resp: Response, method: &str) {
-        if let Some(cmds) = self.init_state.commands_mut() {
-            cmds.received_response(method);
+        self.on_response_in_session(resp, method, None)
+    }
+
+    pub(crate) fn on_response_in_session(
+        &mut self,
+        resp: Response,
+        method: &str,
+        session_id: Option<SessionId>,
+    ) {
+        if session_id
+            .as_ref()
+            .is_some_and(|session_id| self.is_session_draining(session_id))
+        {
+            return;
         }
-        #[allow(clippy::single_match)] // allow for now
-        match method {
-            GetFrameTreeParams::IDENTIFIER => {
-                if let Some(resp) = resp
-                    .result
-                    .and_then(|val| GetFrameTreeParams::response_from_value(val).ok())
-                {
-                    self.frame_manager.on_frame_tree(resp.frame_tree);
+
+        let main_session_id = self.frame_manager.main_session_id().cloned();
+        let is_main = session_id
+            .as_ref()
+            .is_none_or(|session_id| main_session_id.as_ref() == Some(session_id));
+        let is_known_child = session_id
+            .as_ref()
+            .is_some_and(|session_id| self.frame_manager.is_child_session(session_id));
+        if is_main {
+            let matched = self
+                .init_state
+                .commands_mut()
+                .is_some_and(|cmds| cmds.received_response(method));
+            if matched && method == AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER {
+                if let Some(main_session_id) = main_session_id.as_ref() {
+                    self.frame_manager.settle_isolated_world_registration(
+                        main_session_id,
+                        UTILITY_WORLD_NAME,
+                        resp.error.is_none(),
+                    );
                 }
             }
-            // requests originated from the network manager all return an empty response, hence they
-            // can be ignored here
-            _ => {}
+        } else if is_known_child {
+            let matched_phase = session_id.as_ref().and_then(|session_id| {
+                let state = self.iframe_init_states.get_mut(session_id)?;
+                let IframeInitState::Chaining { chain, phase } = state else {
+                    return None;
+                };
+                chain.received_response(method).then_some(*phase)
+            });
+            if matches!(matched_phase, Some(InitPhase::IsolatedWorld)) {
+                if let Some(session_id) = session_id.as_ref() {
+                    self.frame_manager.settle_isolated_world_registration(
+                        session_id,
+                        UTILITY_WORLD_NAME,
+                        resp.error.is_none(),
+                    );
+                }
+            }
+            if resp.error.is_some() {
+                if let (Some(session_id), Some(phase)) = (session_id.clone(), matched_phase) {
+                    match phase {
+                        InitPhase::Frame | InitPhase::AutoAttach => {
+                            self.transition_iframe_to_failed_and_unpause(session_id);
+                        }
+                        InitPhase::IsolatedWorld | InitPhase::Bindings => {
+                            self.advance_to_next_iframe_phase(session_id, phase);
+                        }
+                    }
+                }
+            }
+        } else {
+            // A response for a detached child must not mutate the main target
+            // or recreate frames through a late getFrameTree result.
+            return;
+        }
+
+        let process_side_effects = is_main
+            || session_id
+                .as_ref()
+                .and_then(|session_id| self.iframe_init_states.get(session_id))
+                .is_some_and(|state| matches!(state, IframeInitState::Chaining { .. }));
+        if !process_side_effects {
+            return;
+        }
+
+        if method == GetFrameTreeParams::IDENTIFIER {
+            if let Some(frame_tree) = resp
+                .result
+                .and_then(|value| GetFrameTreeParams::response_from_value(value).ok())
+                .map(|response| response.frame_tree)
+            {
+                if let Some(session_id) = session_id.or(main_session_id) {
+                    for old_session_id in self
+                        .frame_manager
+                        .on_frame_tree_in_session(frame_tree, session_id)
+                    {
+                        self.enter_draining_session(old_session_id);
+                    }
+                } else {
+                    self.frame_manager.on_frame_tree(frame_tree);
+                }
+            }
         }
     }
 
     pub fn on_event(&mut self, event: CdpEventMessage) {
-        let CdpEventMessage { params, method, .. } = event;
+        let CdpEventMessage {
+            params,
+            method,
+            session_id,
+        } = event;
+        let event_session_id = session_id
+            .map(SessionId::new)
+            .or_else(|| self.frame_manager.main_session_id().cloned());
+
+        if event_session_id
+            .as_ref()
+            .is_some_and(|session_id| self.is_session_draining(session_id))
+            && !matches!(&params, CdpEvent::TargetDetachedFromTarget(_))
+        {
+            return;
+        }
+
         match &params {
             // `FrameManager` events
-            CdpEvent::PageFrameAttached(ev) => self
-                .frame_manager
-                .on_frame_attached(ev.frame_id.clone(), Some(ev.parent_frame_id.clone())),
+            CdpEvent::PageFrameAttached(ev) => {
+                if let Some(session_id) = event_session_id.clone() {
+                    if let Some(old_session_id) = self.frame_manager.on_frame_attached_in_session(
+                        ev.frame_id.clone(),
+                        Some(ev.parent_frame_id.clone()),
+                        session_id,
+                    ) {
+                        self.enter_draining_session(old_session_id);
+                    }
+                } else {
+                    self.frame_manager
+                        .on_frame_attached(ev.frame_id.clone(), Some(ev.parent_frame_id.clone()));
+                }
+            }
             CdpEvent::PageFrameDetached(ev) => self.frame_manager.on_frame_detached(ev),
-            CdpEvent::PageFrameNavigated(ev) => self.frame_manager.on_frame_navigated(&ev.frame),
+            CdpEvent::PageFrameNavigated(ev) => {
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_frame_navigated_in_session(&ev.frame, session_id);
+                } else {
+                    self.frame_manager.on_frame_navigated(&ev.frame);
+                }
+            }
             CdpEvent::PageNavigatedWithinDocument(ev) => {
-                self.frame_manager.on_frame_navigated_within_document(ev)
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_frame_navigated_within_document_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_frame_navigated_within_document(ev);
+                }
             }
             CdpEvent::RuntimeExecutionContextCreated(ev) => {
-                self.frame_manager.on_frame_execution_context_created(ev)
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_frame_execution_context_created_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_frame_execution_context_created(ev);
+                }
             }
             CdpEvent::RuntimeExecutionContextDestroyed(ev) => {
-                self.frame_manager.on_frame_execution_context_destroyed(ev)
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_frame_execution_context_destroyed_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_frame_execution_context_destroyed(ev);
+                }
             }
             CdpEvent::RuntimeExecutionContextsCleared(_) => {
-                self.frame_manager.on_execution_contexts_cleared()
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_execution_contexts_cleared_in_session(session_id);
+                } else {
+                    self.frame_manager.on_execution_contexts_cleared();
+                }
             }
             CdpEvent::RuntimeBindingCalled(ev) => {
-                // TODO check if binding registered and payload is json
-                self.frame_manager.on_runtime_binding_called(ev)
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_runtime_binding_called_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_runtime_binding_called(ev);
+                }
             }
-            CdpEvent::PageLifecycleEvent(ev) => self.frame_manager.on_page_lifecycle_event(ev),
+            CdpEvent::PageLifecycleEvent(ev) => {
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_page_lifecycle_event_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_page_lifecycle_event(ev);
+                }
+            }
             CdpEvent::PageFrameStartedLoading(ev) => {
-                self.frame_manager.on_frame_started_loading(ev);
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_frame_started_loading_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_frame_started_loading(ev);
+                }
+            }
+            CdpEvent::PageFrameStoppedLoading(ev) => {
+                if let Some(session_id) = event_session_id.clone() {
+                    self.frame_manager
+                        .on_frame_stopped_loading_in_session(ev, session_id);
+                } else {
+                    self.frame_manager.on_frame_stopped_loading(ev);
+                }
             }
 
             // `Target` events
             CdpEvent::TargetAttachedToTarget(ev) => {
-                if ev.waiting_for_debugger {
+                let is_iframe = ev.target_info.r#type == "iframe";
+                if is_iframe {
+                    self.queued_events
+                        .push_back(TargetEvent::RegisterChildSession(ev.session_id.clone()));
+                    self.frame_manager
+                        .on_attached_to_target_in_session(ev, ev.session_id.clone());
+                    self.start_iframe_init(ev.session_id.clone());
+                }
+                if ev.waiting_for_debugger && !is_iframe {
                     let runtime_cmd = RunIfWaitingForDebuggerParams::default();
 
                     self.queued_events.push_back(TargetEvent::Request(Request {
@@ -279,12 +1366,62 @@ impl Target {
                     }));
                 }
             }
+            CdpEvent::TargetDetachedFromTarget(ev) => {
+                if let Some(parent_session_id) = event_session_id.clone() {
+                    self.handle_detached_from_target(ev, parent_session_id);
+                }
+            }
 
             // `NetworkManager` events
-            CdpEvent::FetchRequestPaused(ev) => self.network_manager.on_fetch_request_paused(ev),
-            CdpEvent::FetchAuthRequired(ev) => self.network_manager.on_fetch_auth_required(ev),
+            CdpEvent::FetchRequestPaused(ev) => {
+                if let Some(session_id) = event_session_id.as_ref() {
+                    let disposition = self
+                        .network_manager
+                        .on_fetch_request_paused_in_session(ev, session_id);
+                    if disposition == PauseDisposition::UserIntercept {
+                        let pushed = self.paused_request_sink.take().is_some_and(|sink| {
+                            let paused = PausedRequest::new(
+                                Arc::new((**ev).clone()),
+                                session_id.clone(),
+                                sink.commands.clone(),
+                            );
+                            if sink.events.unbounded_send(paused).is_ok() {
+                                self.paused_request_sink = Some(sink);
+                                true
+                            } else {
+                                false
+                            }
+                        });
+                        let is_main_session = self
+                            .frame_manager
+                            .main_session_id()
+                            .is_some_and(|main_session_id| main_session_id == session_id);
+                        if !pushed && (!is_main_session || !self.page_exposed) {
+                            self.network_manager.push_cdp_request_session(
+                                ContinueRequestParams::new(ev.request_id.clone()),
+                                session_id.clone(),
+                            );
+                        }
+                    }
+                } else {
+                    self.network_manager.on_fetch_request_paused(ev);
+                }
+            }
+            CdpEvent::FetchAuthRequired(ev) => {
+                if let Some(session_id) = event_session_id.as_ref() {
+                    self.network_manager
+                        .on_fetch_auth_required_in_session(ev, session_id);
+                } else {
+                    self.network_manager.on_fetch_auth_required(ev);
+                }
+            }
             CdpEvent::NetworkRequestWillBeSent(ev) => {
-                self.network_manager.on_request_will_be_sent(ev)
+                if let Some(session_id) = event_session_id.as_ref() {
+                    self.network_manager
+                        .on_request_will_be_sent_in_session(ev, session_id);
+                } else {
+                    self.network_manager.on_request_will_be_sent(ev);
+                }
             }
             CdpEvent::NetworkRequestServedFromCache(ev) => {
                 self.network_manager.on_request_served_from_cache(ev)
@@ -296,12 +1433,33 @@ impl Target {
             CdpEvent::NetworkLoadingFailed(ev) => {
                 self.network_manager.on_network_loading_failed(ev)
             }
+            // This matches Chrome's full `CdpEvent` set (not the internal
+            // `TargetEvent` queue, whose match is intentionally exhaustive). We
+            // only consume the events above and silently ignore the rest.
             _ => {}
+        }
+        while let Some(request) = self.network_manager.poll_session_request() {
+            self.queued_events.push_back(TargetEvent::Request(request));
         }
         chromiumoxide_cdp::consume_event!(match params {
            |ev| self.event_listeners.start_send(ev),
            |json| { let _ = self.event_listeners.try_send_custom(&method, json);}
         });
+    }
+
+    fn handle_detached_from_target(
+        &mut self,
+        event: &EventDetachedFromTarget,
+        parent_session_id: SessionId,
+    ) {
+        self.enter_draining_session(event.session_id.clone());
+        self.frame_manager
+            .on_detached_from_target(&event.session_id, &parent_session_id);
+        self.network_manager.on_session_detached(&event.session_id);
+        self.queued_events
+            .push_back(TargetEvent::UnregisterChildSession(
+                event.session_id.clone(),
+            ));
     }
 
     /// Called when a init command timed out
@@ -345,14 +1503,21 @@ impl Target {
                 if let Poll::Ready(poll) = cmds.poll(now) {
                     return match poll {
                         None => {
-                            if let Some(isolated_world_cmds) =
-                                self.frame_manager.ensure_isolated_world(UTILITY_WORLD_NAME)
-                            {
-                                *cmds = isolated_world_cmds;
-                            } else {
+                            if self.main_isolated_world_attempted {
                                 self.init_state = TargetInit::InitializingNetwork(
                                     self.network_manager.init_commands(),
                                 );
+                            } else {
+                                self.main_isolated_world_attempted = true;
+                                if let Some(isolated_world_cmds) =
+                                    self.frame_manager.ensure_isolated_world(UTILITY_WORLD_NAME)
+                                {
+                                    *cmds = isolated_world_cmds;
+                                } else {
+                                    self.init_state = TargetInit::InitializingNetwork(
+                                        self.network_manager.init_commands(),
+                                    );
+                                }
                             }
                             self.poll(cx, now)
                         }
@@ -405,7 +1570,9 @@ impl Target {
                         .unwrap_or_default()
                     {
                         if let Some(page) = self.get_or_create_page() {
-                            let _ = initiator.send(Ok(page.clone().into()));
+                            let page = Page::from(page.clone());
+                            let delivered = initiator.send(Ok(page)).is_ok();
+                            self.mark_page_exposed_after_successful_send(delivered);
                         } else {
                             self.initiator = Some(initiator);
                         }
@@ -422,6 +1589,9 @@ impl Target {
                     while let Some(tx) = self.wait_for_frame_navigation.pop() {
                         let _ = tx.send(frame.http_request().cloned());
                     }
+                    while let Some(tx) = self.wait_for_navigation_results.pop() {
+                        let _ = tx.send(Ok(frame.http_request().cloned()));
+                    }
                 }
             }
 
@@ -430,96 +1600,287 @@ impl Target {
                 return Some(ev);
             }
 
-            if let Some(handle) = self.page.as_mut() {
-                while let Poll::Ready(Some(msg)) = Pin::new(&mut handle.rx).poll_next(cx) {
-                    match msg {
-                        TargetMessage::Command(cmd) => {
-                            self.queued_events.push_back(TargetEvent::Command(cmd));
-                        }
-                        TargetMessage::MainFrame(tx) => {
-                            let _ =
-                                tx.send(self.frame_manager.main_frame().map(|f| f.id().clone()));
-                        }
-                        TargetMessage::AllFrames(tx) => {
-                            let _ = tx.send(
-                                self.frame_manager
-                                    .frames()
-                                    .map(|f| f.id().clone())
-                                    .collect(),
-                            );
-                        }
-                        TargetMessage::Url(req) => {
-                            let GetUrl { frame_id, tx } = req;
-                            let frame = if let Some(frame_id) = frame_id {
-                                self.frame_manager.frame(&frame_id)
-                            } else {
-                                self.frame_manager.main_frame()
-                            };
-                            let _ = tx.send(frame.and_then(|f| f.url().map(str::to_string)));
-                        }
-                        TargetMessage::Name(req) => {
-                            let GetName { frame_id, tx } = req;
-                            let frame = if let Some(frame_id) = frame_id {
-                                self.frame_manager.frame(&frame_id)
-                            } else {
-                                self.frame_manager.main_frame()
-                            };
-                            let _ = tx.send(frame.and_then(|f| f.name().map(str::to_string)));
-                        }
-                        TargetMessage::Parent(req) => {
-                            let GetParent { frame_id, tx } = req;
-                            let frame = self.frame_manager.frame(&frame_id);
-                            let _ = tx.send(frame.and_then(|f| f.parent_id().cloned()));
-                        }
-                        TargetMessage::WaitForNavigation(tx) => {
-                            if let Some(frame) = self.frame_manager.main_frame() {
-                                // TODO submit a navigation watcher: waitForFrameNavigation
+            // Drain each channel into a local batch before mutating Target
+            // state. This releases the PageHandle borrow and keeps per-channel
+            // FIFO without inventing an ordering relation between channels.
+            let (target_messages, internal_messages) = if let Some(handle) = self.page.as_mut() {
+                let (target_messages, _) = poll_receiver_batch(&mut handle.rx, cx);
+                let (internal_messages, _) = poll_receiver_batch(&mut handle.internal_rx, cx);
+                (target_messages, internal_messages)
+            } else {
+                (Vec::new(), Vec::new())
+            };
 
-                                // TODO return the watchers navigationResponse
-                                if frame.is_loaded() {
-                                    let _ = tx.send(frame.http_request().cloned());
-                                } else {
-                                    self.wait_for_frame_navigation.push(tx);
-                                }
+            for msg in target_messages {
+                match msg {
+                    TargetMessage::Command(cmd) => {
+                        self.queued_events.push_back(TargetEvent::Command(cmd));
+                    }
+                    TargetMessage::MainFrame(tx) => {
+                        let _ = tx.send(self.frame_manager.main_frame().map(|f| f.id().clone()));
+                    }
+                    TargetMessage::AllFrames(tx) => {
+                        let _ = tx.send(
+                            self.frame_manager
+                                .frames()
+                                .map(|f| f.id().clone())
+                                .collect(),
+                        );
+                    }
+                    TargetMessage::Url(req) => {
+                        let GetUrl { frame_id, tx } = req;
+                        let frame = if let Some(frame_id) = frame_id {
+                            self.frame_manager.frame(&frame_id)
+                        } else {
+                            self.frame_manager.main_frame()
+                        };
+                        let _ = tx.send(frame.and_then(|f| f.url().map(str::to_string)));
+                    }
+                    TargetMessage::Name(req) => {
+                        let GetName { frame_id, tx } = req;
+                        let frame = if let Some(frame_id) = frame_id {
+                            self.frame_manager.frame(&frame_id)
+                        } else {
+                            self.frame_manager.main_frame()
+                        };
+                        let _ = tx.send(frame.and_then(|f| f.name().map(str::to_string)));
+                    }
+                    TargetMessage::Parent(req) => {
+                        let GetParent { frame_id, tx } = req;
+                        let frame = self.frame_manager.frame(&frame_id);
+                        let _ = tx.send(frame.and_then(|f| f.parent_id().cloned()));
+                    }
+                    TargetMessage::WaitForNavigation(tx) => {
+                        if let Some(frame) = self.frame_manager.main_frame() {
+                            // This legacy waiter observes the main frame only;
+                            // frame-scoped navigation uses the internal channel.
+                            if frame.is_loaded() {
+                                let _ = tx.send(frame.http_request().cloned());
                             } else {
                                 self.wait_for_frame_navigation.push(tx);
                             }
-                        }
-                        TargetMessage::AddEventListener(req) => {
-                            // register a new listener
-                            self.event_listeners.add_listener(req);
-                        }
-                        TargetMessage::GetExecutionContext(ctx) => {
-                            let GetExecutionContext {
-                                dom_world,
-                                frame_id,
-                                tx,
-                            } = ctx;
-                            let frame = if let Some(frame_id) = frame_id {
-                                self.frame_manager.frame(&frame_id)
-                            } else {
-                                self.frame_manager.main_frame()
-                            };
-
-                            if let Some(frame) = frame {
-                                match dom_world {
-                                    DOMWorldKind::Main => {
-                                        let _ = tx.send(frame.main_world().execution_context());
-                                    }
-                                    DOMWorldKind::Secondary => {
-                                        let _ =
-                                            tx.send(frame.secondary_world().execution_context());
-                                    }
-                                }
-                            } else {
-                                let _ = tx.send(None);
-                            }
-                        }
-                        TargetMessage::Authenticate(credentials) => {
-                            self.network_manager.authenticate(credentials);
+                        } else {
+                            self.wait_for_frame_navigation.push(tx);
                         }
                     }
+                    TargetMessage::AddEventListener(req) => {
+                        self.event_listeners.add_listener(req);
+                    }
+                    TargetMessage::GetExecutionContext(ctx) => {
+                        let GetExecutionContext {
+                            dom_world,
+                            frame_id,
+                            tx,
+                        } = ctx;
+                        let frame = if let Some(frame_id) = frame_id {
+                            self.frame_manager.frame(&frame_id)
+                        } else {
+                            self.frame_manager.main_frame()
+                        };
+
+                        let main_session_id = self.frame_manager.main_session_id();
+                        if let Some(frame) = frame.filter(|frame| {
+                            main_session_id.is_some_and(|main_session_id| {
+                                frame.session_id() == Some(main_session_id)
+                            })
+                        }) {
+                            match dom_world {
+                                DOMWorldKind::Main => {
+                                    let _ = tx.send(frame.main_world().execution_context());
+                                }
+                                DOMWorldKind::Secondary => {
+                                    let _ = tx.send(frame.secondary_world().execution_context());
+                                }
+                            }
+                        } else {
+                            let _ = tx.send(None);
+                        }
+                    }
+                    TargetMessage::Authenticate(credentials) => {
+                        self.network_manager.authenticate(credentials);
+                    }
                 }
+            }
+
+            for msg in internal_messages {
+                match msg {
+                    InternalTargetMessage::FrameCommand {
+                        frame_id,
+                        expected_session_id,
+                        mut command,
+                    } => {
+                        // Defense in depth: `Frame::execute` already rejects
+                        // navigation before it reaches this channel, so this arm
+                        // guards only a future internal caller that constructs a
+                        // FrameCommand directly. Routing a navigation through the
+                        // generic command path would drop the frame identity and
+                        // misroute to the main frame; navigation must use
+                        // FrameNavigate.
+                        if command.is_navigation() {
+                            let _ = command.sender.send(Err(CdpError::NotAllowed(
+                                "Page.navigate is not supported through Frame::execute; use Frame::goto instead"
+                                    .to_owned(),
+                            )));
+                            continue;
+                        }
+                        if !self.frame_ready(&frame_id, &expected_session_id) {
+                            let _ = command.sender.send(Err(CdpError::FrameNotReady));
+                            continue;
+                        }
+                        command.session_id = Some(expected_session_id);
+                        self.queued_events.push_back(TargetEvent::Command(command));
+                    }
+                    InternalTargetMessage::SessionCommand {
+                        session_id,
+                        mut command,
+                    } => {
+                        // A captured session does not carry the frame identity
+                        // needed to route Page.navigate safely across OOP swaps.
+                        if command.is_navigation() {
+                            let _ = command.sender.send(Err(CdpError::NotAllowed(
+                                "Page.navigate is not supported through a captured session; use Frame::goto instead"
+                                    .to_owned(),
+                            )));
+                            continue;
+                        }
+                        command.session_id = Some(session_id);
+                        self.queued_events.push_back(TargetEvent::Command(command));
+                    }
+                    InternalTargetMessage::FrameNavigate {
+                        frame_id,
+                        session_id,
+                        req,
+                        tx,
+                    } => {
+                        if !self.frame_ready(&frame_id, &session_id) {
+                            let _ = tx.send(Err(CdpError::FrameNotReady));
+                            continue;
+                        }
+                        self.queued_events.push_back(TargetEvent::FrameNavigate {
+                            session_id,
+                            frame_id,
+                            req,
+                            tx,
+                        });
+                    }
+                    InternalTargetMessage::FrameWaitForNavigation {
+                        frame_id,
+                        session_id,
+                        tx,
+                    } => {
+                        if !self.frame_ready(&frame_id, &session_id) {
+                            let _ = tx.send(Err(FrameWaitError::FrameSwappedOrDetached));
+                            continue;
+                        }
+                        self.queued_events
+                            .push_back(TargetEvent::FrameWaitForNavigation {
+                                session_id,
+                                frame_id,
+                                tx,
+                            });
+                    }
+                    InternalTargetMessage::WaitForNavigationResult { tx } => {
+                        if let Some(frame) = self.frame_manager.main_frame() {
+                            if frame.is_loaded() {
+                                let _ = tx.send(Ok(frame.http_request().cloned()));
+                            } else {
+                                self.wait_for_navigation_results.push(tx);
+                            }
+                        } else {
+                            self.wait_for_navigation_results.push(tx);
+                        }
+                    }
+                    InternalTargetMessage::GetPinnedExecutionContext {
+                        dom_world,
+                        frame_id,
+                        expected_session_id,
+                        tx,
+                    } => {
+                        if !self.frame_ready(&frame_id, &expected_session_id) {
+                            let _ = tx.send(Err(CdpError::FrameNotReady));
+                            continue;
+                        }
+                        let context_id =
+                            self.frame_manager
+                                .frame(&frame_id)
+                                .and_then(|frame| match dom_world {
+                                    DOMWorldKind::Main => frame.main_world().execution_context(),
+                                    DOMWorldKind::Secondary => {
+                                        frame.secondary_world().execution_context()
+                                    }
+                                });
+                        let _ = tx.send(Ok(context_id.map(|context_id| ExecutionContextInfo {
+                            context_id,
+                            session_id: expected_session_id,
+                        })));
+                    }
+                    InternalTargetMessage::GetFrameInfo { frame_id, tx } => {
+                        let info = self
+                            .frame_manager
+                            .frame(&frame_id)
+                            .map(|frame| self.build_frame_info(frame))
+                            .transpose();
+                        let _ = tx.send(info);
+                    }
+                    InternalTargetMessage::GetAllFrames { tx } => {
+                        let mut frames = self
+                            .frame_manager
+                            .frames()
+                            .filter_map(|frame| self.build_frame_info(frame).ok())
+                            .collect::<Vec<_>>();
+                        frames.sort_by(|left, right| {
+                            left.frame_id.as_ref().cmp(right.frame_id.as_ref())
+                        });
+                        let _ = tx.send(frames);
+                    }
+                    InternalTargetMessage::GetFrameBoundaryChain {
+                        frame_id,
+                        expected_session_id,
+                        tx,
+                    } => {
+                        let _ = tx.send(self.build_boundary_chain(&frame_id, &expected_session_id));
+                    }
+                    InternalTargetMessage::RegisterPausedRequestStream {
+                        events,
+                        commands,
+                        tx,
+                    } => {
+                        let occupied = self
+                            .paused_request_sink
+                            .as_ref()
+                            .is_some_and(|sink| !sink.events.is_closed());
+                        if occupied {
+                            let _ = tx.send(Err(CdpError::PausedRequestResponderAlreadyRegistered));
+                        } else {
+                            self.paused_request_sink = Some(PausedRequestSink { events, commands });
+                            let _ = tx.send(Ok(()));
+                        }
+                    }
+                    InternalTargetMessage::AddPreloadScript { params, tx } => {
+                        self.queued_events
+                            .push_back(TargetEvent::AddPreloadScript { params, tx });
+                    }
+                    InternalTargetMessage::RegisterEventListener { request, tx } => {
+                        self.event_listeners.add_listener(request);
+                        let _ = tx.send(Ok(()));
+                    }
+                    InternalTargetMessage::SetCredentials { credentials, tx } => {
+                        let commands = self.network_manager.authenticate_core(credentials);
+                        self.enqueue_network_fan_out(commands, tx);
+                    }
+                    InternalTargetMessage::SetRequestInterception { enabled, tx } => {
+                        let commands = self.network_manager.set_request_interception_core(enabled);
+                        self.enqueue_network_fan_out(commands, tx);
+                    }
+                }
+            }
+
+            if self.poll_iframe_init(now) {
+                continue;
+            }
+
+            while let Some(request) = self.network_manager.poll_session_request() {
+                self.queued_events.push_back(TargetEvent::Request(request));
             }
 
             while let Some(event) = self.network_manager.poll() {
@@ -608,7 +1969,7 @@ impl Default for TargetConfig {
     fn default() -> Self {
         Self {
             ignore_https_errors: true,
-            request_timeout: Duration::from_secs(REQUEST_TIMEOUT),
+            request_timeout: Duration::from_millis(REQUEST_TIMEOUT),
             viewport: Default::default(),
             request_intercept: false,
             cache_enabled: true,
@@ -626,6 +1987,51 @@ pub enum TargetType {
     Browser,
     Webview,
     Unknown(String),
+}
+
+#[derive(Debug)]
+enum IframeInitState {
+    Chaining {
+        chain: CommandChain,
+        phase: InitPhase,
+    },
+    PostChainPreload,
+    PostChainNetwork,
+    PostChainUnpause,
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum InitPhase {
+    Frame,
+    IsolatedWorld,
+    AutoAttach,
+    Bindings,
+}
+
+impl InitPhase {
+    fn next(self) -> Option<Self> {
+        match self {
+            Self::Frame => Some(Self::IsolatedWorld),
+            Self::IsolatedWorld => Some(Self::AutoAttach),
+            Self::AutoAttach => Some(Self::Bindings),
+            Self::Bindings => None,
+        }
+    }
+}
+
+enum IframeInitAction {
+    Send {
+        method: MethodId,
+        params: serde_json::Value,
+    },
+    Timeout,
+    PhaseComplete(InitPhase),
+    EnqueueNetwork,
+    EnqueueUnpause,
+    MarkDone,
+    RemoveDone,
 }
 
 impl TargetType {
@@ -671,7 +2077,130 @@ impl TargetType {
     }
 }
 
+/// A response-confirmed multi-session command batch waiting to be registered
+/// by the handler.
+///
+/// The two request bags are disjoint: `ack_reqs` contribute responses to the
+/// caller's acknowledgement, while `send_only_reqs` only receive the latest
+/// state. Keeping them in one queue item preserves ordering against later
+/// navigation commands.
 #[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) struct FanOutAckBatch {
+    pub(crate) ack_reqs: Vec<Request>,
+    pub(crate) send_only_reqs: Vec<Request>,
+    pub(crate) ack_tx: Sender<Result<()>>,
+    pub(crate) main_session_id: SessionId,
+}
+
+/// Session-qualified execution context returned to frame-pinned callers.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ExecutionContextInfo {
+    pub(crate) context_id: ExecutionContextId,
+    pub(crate) session_id: SessionId,
+}
+
+/// Immutable frame metadata used to construct a public session-pinned handle.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct FrameInfo {
+    pub(crate) frame_id: FrameId,
+    pub(crate) session_id: SessionId,
+    pub(crate) main_session_id: SessionId,
+    pub(crate) parent_id: Option<FrameId>,
+    pub(crate) url: Option<String>,
+    pub(crate) security_origin: String,
+}
+
+/// One cross-session edge in a frame's ancestor chain.
+///
+/// All topology fields are captured so geometry code can re-query the chain
+/// before dispatching input and reject mixed pre/post-swap coordinates.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct FrameBoundary {
+    pub(crate) child_frame_id: FrameId,
+    pub(crate) child_session_id: SessionId,
+    pub(crate) parent_frame_id: FrameId,
+    pub(crate) parent_session_id: SessionId,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct PausedRequestSink {
+    events: UnboundedSender<PausedRequest>,
+    commands: futures::channel::mpsc::Sender<TargetMessage>,
+}
+
+/// Private page-to-target operations that need stronger identity or ordering
+/// guarantees than the legacy public message contract can express.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) enum InternalTargetMessage {
+    FrameCommand {
+        frame_id: FrameId,
+        expected_session_id: SessionId,
+        command: CommandMessage,
+    },
+    SessionCommand {
+        session_id: SessionId,
+        command: CommandMessage,
+    },
+    FrameNavigate {
+        frame_id: FrameId,
+        session_id: SessionId,
+        req: Request,
+        tx: Sender<Result<Response>>,
+    },
+    FrameWaitForNavigation {
+        frame_id: FrameId,
+        session_id: SessionId,
+        tx: Sender<std::result::Result<(), FrameWaitError>>,
+    },
+    WaitForNavigationResult {
+        tx: Sender<Result<ArcHttpRequest>>,
+    },
+    GetPinnedExecutionContext {
+        dom_world: DOMWorldKind,
+        frame_id: FrameId,
+        expected_session_id: SessionId,
+        tx: Sender<Result<Option<ExecutionContextInfo>>>,
+    },
+    GetFrameInfo {
+        frame_id: FrameId,
+        tx: Sender<Result<Option<FrameInfo>>>,
+    },
+    GetAllFrames {
+        tx: Sender<Vec<FrameInfo>>,
+    },
+    GetFrameBoundaryChain {
+        frame_id: FrameId,
+        expected_session_id: SessionId,
+        tx: Sender<Result<Vec<FrameBoundary>>>,
+    },
+    RegisterPausedRequestStream {
+        events: UnboundedSender<PausedRequest>,
+        commands: futures::channel::mpsc::Sender<TargetMessage>,
+        tx: Sender<Result<()>>,
+    },
+    AddPreloadScript {
+        params: AddScriptToEvaluateOnNewDocumentParams,
+        tx: Sender<Result<ScriptIdentifier>>,
+    },
+    RegisterEventListener {
+        request: EventListenerRequest,
+        tx: Sender<Result<()>>,
+    },
+    SetCredentials {
+        credentials: Credentials,
+        tx: Sender<Result<()>>,
+    },
+    SetRequestInterception {
+        enabled: bool,
+        tx: Sender<Result<()>>,
+    },
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) enum TargetEvent {
     /// An internal request
     Request(Request),
@@ -681,6 +2210,37 @@ pub(crate) enum TargetEvent {
     NavigationResult(Result<NavigationOk, NavigationError>),
     /// A new command arrived via a channel
     Command(CommandMessage),
+    /// Register a child session for event-envelope routing.
+    RegisterChildSession(SessionId),
+    /// Remove a child session after all session-scoped pending work is settled.
+    UnregisterChildSession(SessionId),
+    /// Proactively settle submitted work before Chrome's detach event arrives.
+    SessionDraining(SessionId),
+    /// Navigate a frame on the immutable session captured by its public handle.
+    FrameNavigate {
+        session_id: SessionId,
+        frame_id: FrameId,
+        req: Request,
+        tx: Sender<Result<Response>>,
+    },
+    /// Wait for the next navigation on a frame/session pair.
+    FrameWaitForNavigation {
+        session_id: SessionId,
+        frame_id: FrameId,
+        tx: Sender<std::result::Result<(), FrameWaitError>>,
+    },
+    /// Submit one tracked preload script to a child session.
+    QueuePreloadScript {
+        request: Request,
+        preload_key: PreloadId,
+    },
+    /// Add and track a preload script on the main session before child replay.
+    AddPreloadScript {
+        params: AddScriptToEvaluateOnNewDocumentParams,
+        tx: Sender<Result<ScriptIdentifier>>,
+    },
+    /// Submit one response-confirmed dynamic-state update across live sessions.
+    FanOutAckBatch(FanOutAckBatch),
 }
 
 // TODO this can be moved into the classes?
@@ -781,4 +2341,2637 @@ pub enum TargetMessage {
     /// Get the `ExecutionContext` if available
     GetExecutionContext(GetExecutionContext),
     Authenticate(Credentials),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use futures::channel::mpsc;
+    use futures::channel::oneshot;
+    use futures::executor::block_on;
+    use futures::task::{ArcWake, noop_waker_ref, waker_ref};
+    use futures::{SinkExt, StreamExt};
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    use chromiumoxide_cdp::cdp::browser_protocol::fetch::{EventAuthRequired, EventRequestPaused};
+    use chromiumoxide_cdp::cdp::browser_protocol::page::{
+        CrossOriginIsolatedContextType, Frame as CdpFrame, FrameTree, GatedApiFeatures,
+        GetFrameTreeReturns, NavigateParams, SecureContextType,
+    };
+    use chromiumoxide_cdp::cdp::browser_protocol::target::EventAttachedToTarget;
+    use chromiumoxide_cdp::cdp::js_protocol::runtime::{
+        EventExecutionContextCreated, ExecutionContextDescription,
+    };
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct WakeCounter(AtomicUsize);
+
+    impl ArcWake for WakeCounter {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn session(id: &str) -> SessionId {
+        SessionId::new(id)
+    }
+
+    fn test_target() -> Target {
+        let info = TargetInfo::builder()
+            .target_id("target".to_owned())
+            .r#type("page")
+            .title("test")
+            .url("about:blank")
+            .attached(true)
+            .can_access_opener(false)
+            .build()
+            .expect("test TargetInfo has all mandatory fields");
+        Target::new(info, TargetConfig::default(), BrowserContext::default())
+    }
+
+    fn initialized_target() -> (Target, SessionId) {
+        let mut target = test_target();
+        let main_session = session("main");
+        target.set_session_id(main_session.clone());
+        target.init_state = TargetInit::Initialized;
+        target
+            .frame_manager
+            .on_frame_navigated_in_session(&cdp_frame("main-frame", None), main_session.clone());
+        (target, main_session)
+    }
+
+    fn cdp_frame(id: &str, parent_id: Option<&str>) -> CdpFrame {
+        let mut builder = CdpFrame::builder()
+            .id(FrameId::new(id))
+            .loader_id(format!("{id}-loader"))
+            .url(format!("https://{id}.example/"))
+            .domain_and_registry("example")
+            .security_origin(format!("https://{id}.example"))
+            .mime_type("text/html")
+            .secure_context_type(SecureContextType::Secure)
+            .cross_origin_isolated_context_type(CrossOriginIsolatedContextType::NotIsolated)
+            .gated_api_features(Vec::<GatedApiFeatures>::new());
+        if let Some(parent_id) = parent_id {
+            builder = builder.parent_id(FrameId::new(parent_id));
+        }
+        builder
+            .build()
+            .expect("frame fixture has all mandatory fields")
+    }
+
+    fn child_target_info(frame_id: &str, parent_id: &str) -> TargetInfo {
+        TargetInfo::builder()
+            .target_id(TargetId::new(frame_id))
+            .r#type("iframe")
+            .title("iframe")
+            .url(format!("https://{frame_id}.example/"))
+            .attached(true)
+            .can_access_opener(false)
+            .parent_frame_id(FrameId::new(parent_id))
+            .build()
+            .expect("target fixture has all mandatory fields")
+    }
+
+    fn attached_event_with_parent(
+        frame_id: &str,
+        parent_id: &str,
+        child_session: &SessionId,
+    ) -> EventAttachedToTarget {
+        EventAttachedToTarget {
+            session_id: child_session.clone(),
+            target_info: child_target_info(frame_id, parent_id),
+            waiting_for_debugger: true,
+        }
+    }
+
+    fn attached_event(frame_id: &str, child_session: &SessionId) -> EventAttachedToTarget {
+        attached_event_with_parent(frame_id, "main-frame", child_session)
+    }
+
+    fn attach_event_message(
+        main_session: &SessionId,
+        event: EventAttachedToTarget,
+    ) -> CdpEventMessage {
+        CdpEventMessage {
+            method: EventAttachedToTarget::IDENTIFIER.into(),
+            session_id: Some(main_session.as_ref().to_owned()),
+            params: CdpEvent::TargetAttachedToTarget(Box::new(event)),
+        }
+    }
+
+    fn paused_request(id: &str) -> EventRequestPaused {
+        serde_json::from_value(json!({
+            "requestId": id,
+            "request": {
+                "url": format!("https://{id}.example/"),
+                "method": "GET",
+                "headers": {},
+                "initialPriority": "High",
+                "referrerPolicy": "no-referrer"
+            },
+            "frameId": "frame",
+            "resourceType": "Document"
+        }))
+        .expect("requestPaused fixture is valid")
+    }
+
+    fn paused_event_message(session_id: &SessionId, id: &str) -> CdpEventMessage {
+        CdpEventMessage {
+            method: EventRequestPaused::IDENTIFIER.into(),
+            session_id: Some(session_id.as_ref().to_owned()),
+            params: CdpEvent::FetchRequestPaused(Box::new(paused_request(id))),
+        }
+    }
+
+    fn auth_required_event_message(session_id: &SessionId, id: &str) -> CdpEventMessage {
+        let event = serde_json::from_value(json!({
+            "requestId": id,
+            "request": {
+                "url": "https://auth.example/",
+                "method": "GET",
+                "headers": {},
+                "initialPriority": "High",
+                "referrerPolicy": "no-referrer"
+            },
+            "frameId": "frame",
+            "resourceType": "Document",
+            "authChallenge": {
+                "source": "Server",
+                "origin": "https://auth.example/",
+                "scheme": "basic",
+                "realm": "test"
+            }
+        }))
+        .expect("authRequired fixture is valid");
+        CdpEventMessage {
+            method: EventAuthRequired::IDENTIFIER.into(),
+            session_id: Some(session_id.as_ref().to_owned()),
+            params: CdpEvent::FetchAuthRequired(Box::new(event)),
+        }
+    }
+
+    fn enable_user_interception(target: &mut Target) {
+        let commands = target.network_manager.set_request_interception_core(true);
+        assert_eq!(commands.len(), 2);
+        while target.network_manager.poll().is_some() {}
+    }
+
+    fn continue_requests(target: &Target) -> Vec<&Request> {
+        target
+            .queued_events
+            .iter()
+            .filter_map(|event| match event {
+                TargetEvent::Request(request)
+                    if request.method.as_ref() == ContinueRequestParams::IDENTIFIER =>
+                {
+                    Some(request)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn install_child(target: &mut Target, frame_id: &str, child_session: &SessionId) {
+        let event = attached_event(frame_id, child_session);
+        target
+            .frame_manager
+            .on_attached_to_target_in_session(&event, child_session.clone());
+        target.start_iframe_init(child_session.clone());
+    }
+
+    fn install_nested_child(
+        target: &mut Target,
+        frame_id: &str,
+        parent_id: &str,
+        child_session: &SessionId,
+    ) {
+        let event = attached_event_with_parent(frame_id, parent_id, child_session);
+        target
+            .frame_manager
+            .on_attached_to_target_in_session(&event, child_session.clone());
+        target.start_iframe_init(child_session.clone());
+    }
+
+    fn poll_target(target: &mut Target, now: Instant) -> Option<TargetEvent> {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        target.poll(&mut cx, now)
+    }
+
+    fn poll_future_once<F: std::future::Future + ?Sized>(future: Pin<&mut F>) -> Poll<F::Output> {
+        let mut cx = Context::from_waker(noop_waker_ref());
+        future.poll(&mut cx)
+    }
+
+    fn ok_response(result: serde_json::Value) -> Response {
+        serde_json::from_value(json!({ "id": 1, "result": result }))
+            .expect("response fixture is valid")
+    }
+
+    fn error_response() -> Response {
+        serde_json::from_value(json!({
+            "id": 1,
+            "error": { "code": -32000, "message": "init failed" }
+        }))
+        .expect("response fixture is valid")
+    }
+
+    fn frame_tree_result(frame_id: &str) -> serde_json::Value {
+        let mut value = serde_json::to_value(GetFrameTreeReturns::new(FrameTree::new(cdp_frame(
+            frame_id,
+            Some("main-frame"),
+        ))))
+        .expect("frame tree fixture should serialize");
+        value["frameTree"]["frame"]["gatedAPIFeatures"] = json!([]);
+        value
+    }
+
+    fn frame_tree_with_child_result(frame_id: &str, child_id: &str) -> serde_json::Value {
+        let mut tree = FrameTree::new(cdp_frame(frame_id, Some("main-frame")));
+        tree.child_frames = Some(vec![FrameTree::new(cdp_frame(child_id, Some(frame_id)))]);
+        let mut value = serde_json::to_value(GetFrameTreeReturns::new(tree))
+            .expect("frame tree fixture should serialize");
+        value["frameTree"]["frame"]["gatedAPIFeatures"] = json!([]);
+        value["frameTree"]["childFrames"][0]["frame"]["gatedAPIFeatures"] = json!([]);
+        value
+    }
+
+    fn child_request(event: TargetEvent, session_id: &SessionId) -> Request {
+        let TargetEvent::Request(request) = event else {
+            panic!("expected child initialization request")
+        };
+        assert_eq!(request.session_id.as_deref(), Some(session_id.as_ref()));
+        request
+    }
+
+    fn advance_child_to_isolated_world(
+        target: &mut Target,
+        child_session: &SessionId,
+        now: Instant,
+    ) -> Request {
+        for expected in [
+            "Page.enable",
+            GetFrameTreeParams::IDENTIFIER,
+            "Page.setLifecycleEventsEnabled",
+            "Runtime.enable",
+        ] {
+            let request = child_request(
+                poll_target(target, now).expect("frame phase command is ready"),
+                child_session,
+            );
+            assert_eq!(request.method.as_ref(), expected);
+            let result = if expected == GetFrameTreeParams::IDENTIFIER {
+                frame_tree_result("child-frame")
+            } else {
+                json!({})
+            };
+            target.on_response_in_session(
+                ok_response(result),
+                request.method.as_ref(),
+                Some(child_session.clone()),
+            );
+        }
+
+        let request = child_request(
+            poll_target(target, now).expect("isolated-world phase starts"),
+            child_session,
+        );
+        assert_eq!(
+            request.method.as_ref(),
+            AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER
+        );
+        request
+    }
+
+    fn wire_request(id: usize, session_id: Option<&SessionId>) -> Request {
+        Request {
+            method: format!("Test.command{id}").into(),
+            session_id: session_id.map(|id| id.as_ref().to_owned()),
+            params: json!({ "id": id }),
+        }
+    }
+
+    fn wire_event_ids(target: &Target) -> Vec<usize> {
+        target
+            .queued_events
+            .iter()
+            .filter_map(|event| match event {
+                TargetEvent::Request(request) | TargetEvent::NavigationRequest(_, request) => {
+                    request.params["id"].as_u64().map(|id| id as usize)
+                }
+                TargetEvent::NavigationResult(_)
+                | TargetEvent::Command(_)
+                | TargetEvent::RegisterChildSession(_)
+                | TargetEvent::UnregisterChildSession(_)
+                | TargetEvent::SessionDraining(_)
+                | TargetEvent::FrameNavigate { .. }
+                | TargetEvent::FrameWaitForNavigation { .. }
+                | TargetEvent::QueuePreloadScript { .. }
+                | TargetEvent::AddPreloadScript { .. }
+                | TargetEvent::FanOutAckBatch(_) => None,
+            })
+            .collect()
+    }
+
+    fn assert_frame_not_ready(result: Result<Response>) {
+        assert!(matches!(result, Err(CdpError::FrameNotReady)));
+    }
+
+    fn execution_context(
+        frame_id: &str,
+        context_id: i64,
+        unique_id: &str,
+    ) -> EventExecutionContextCreated {
+        EventExecutionContextCreated {
+            context: ExecutionContextDescription::builder()
+                .id(ExecutionContextId::new(context_id))
+                .origin("https://example.test")
+                .name("")
+                .unique_id(unique_id)
+                .aux_data(json!({
+                    "frameId": frame_id,
+                    "isDefault": true,
+                    "type": "default"
+                }))
+                .build()
+                .expect("context fixture has all mandatory fields"),
+        }
+    }
+
+    fn isolated_execution_context(
+        frame_id: &str,
+        context_id: i64,
+        unique_id: &str,
+        name: &str,
+    ) -> EventExecutionContextCreated {
+        EventExecutionContextCreated {
+            context: ExecutionContextDescription::builder()
+                .id(ExecutionContextId::new(context_id))
+                .origin("https://example.test")
+                .name(name)
+                .unique_id(unique_id)
+                .aux_data(json!({
+                    "frameId": frame_id,
+                    "isDefault": false,
+                    "type": "isolated"
+                }))
+                .build()
+                .expect("isolated context fixture has all mandatory fields"),
+        }
+    }
+
+    fn send_internal(target: &mut Target, message: InternalTargetMessage) {
+        drain_target_events(target);
+        let mut sender = target
+            .get_or_create_page()
+            .expect("initialized target exposes a page")
+            .internal_sender()
+            .clone();
+        block_on(sender.send(message)).expect("internal receiver remains live");
+    }
+
+    fn send_public(target: &mut Target, message: TargetMessage) {
+        drain_target_events(target);
+        let mut sender = target
+            .get_or_create_page()
+            .expect("initialized target exposes a page")
+            .sender()
+            .clone();
+        block_on(sender.send(message)).expect("public receiver remains live");
+    }
+
+    fn drain_target_events(target: &mut Target) {
+        for _ in 0..128 {
+            if poll_target(target, Instant::now()).is_none() {
+                return;
+            }
+        }
+        panic!("test target did not become idle");
+    }
+
+    #[test]
+    fn paused_request_registration_rejects_a_live_stream_and_replaces_a_closed_one() {
+        let (mut target, _) = initialized_target();
+        drain_target_events(&mut target);
+        let commands = target
+            .get_or_create_page()
+            .expect("initialized target exposes a page")
+            .sender()
+            .clone();
+
+        let (first_tx, first_rx) = mpsc::unbounded();
+        let (first_ack_tx, first_ack_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::RegisterPausedRequestStream {
+                events: first_tx,
+                commands: commands.clone(),
+                tx: first_ack_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert!(
+            block_on(first_ack_rx)
+                .expect("first registration resolves")
+                .is_ok()
+        );
+
+        let (second_tx, _second_rx) = mpsc::unbounded();
+        let (second_ack_tx, second_ack_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::RegisterPausedRequestStream {
+                events: second_tx,
+                commands: commands.clone(),
+                tx: second_ack_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert!(matches!(
+            block_on(second_ack_rx).expect("second registration resolves"),
+            Err(CdpError::PausedRequestResponderAlreadyRegistered)
+        ));
+
+        drop(first_rx);
+        let (third_tx, _third_rx) = mpsc::unbounded();
+        let (third_ack_tx, third_ack_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::RegisterPausedRequestStream {
+                events: third_tx,
+                commands,
+                tx: third_ack_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert!(
+            block_on(third_ack_rx)
+                .expect("replacement resolves")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn concurrent_paused_request_registrations_have_one_winner() {
+        let (mut target, _) = initialized_target();
+        drain_target_events(&mut target);
+        let page = target
+            .get_or_create_page()
+            .expect("initialized target exposes a page")
+            .clone();
+        let commands = page.sender().clone();
+        let mut first_sender = page.internal_sender().clone();
+        let mut second_sender = page.internal_sender().clone();
+        let (first_events, _first_receiver) = mpsc::unbounded();
+        let (second_events, _second_receiver) = mpsc::unbounded();
+        let (first_ack_tx, first_ack_rx) = oneshot::channel();
+        let (second_ack_tx, second_ack_rx) = oneshot::channel();
+
+        first_sender
+            .try_send(InternalTargetMessage::RegisterPausedRequestStream {
+                events: first_events,
+                commands: commands.clone(),
+                tx: first_ack_tx,
+            })
+            .expect("first sender has its reserved slot");
+        second_sender
+            .try_send(InternalTargetMessage::RegisterPausedRequestStream {
+                events: second_events,
+                commands,
+                tx: second_ack_tx,
+            })
+            .expect("cloned sender has its reserved slot");
+        let _ = poll_target(&mut target, Instant::now());
+
+        assert!(
+            block_on(first_ack_rx)
+                .expect("first registration resolves")
+                .is_ok()
+        );
+        assert!(matches!(
+            block_on(second_ack_rx).expect("second registration resolves"),
+            Err(CdpError::PausedRequestResponderAlreadyRegistered)
+        ));
+    }
+
+    #[test]
+    fn create_page_marks_exposure_only_after_successful_initiator_delivery() {
+        fn loaded_target() -> Target {
+            let (mut target, main_session) = initialized_target();
+            drain_target_events(&mut target);
+            target.frame_manager.on_frame_stopped_loading_in_session(
+                &chromiumoxide_cdp::cdp::browser_protocol::page::EventFrameStoppedLoading {
+                    frame_id: FrameId::new("main-frame"),
+                },
+                main_session,
+            );
+            target
+        }
+
+        let mut delivered_target = loaded_target();
+        let (tx, rx) = oneshot::channel();
+        delivered_target.set_initiator(tx);
+        let _ = poll_target(&mut delivered_target, Instant::now());
+        assert!(block_on(rx).expect("initiator receives a result").is_ok());
+        assert!(delivered_target.page_exposed);
+
+        let mut canceled_target = loaded_target();
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        canceled_target.set_initiator(tx);
+        let _ = poll_target(&mut canceled_target, Instant::now());
+        assert!(!canceled_target.page_exposed);
+    }
+
+    #[test]
+    fn paused_request_delivery_restores_sink_and_drop_has_no_protocol_side_effect() {
+        let (mut target, main_session) = initialized_target();
+        drain_target_events(&mut target);
+        enable_user_interception(&mut target);
+        let commands = target
+            .get_or_create_page()
+            .expect("initialized target exposes a page")
+            .sender()
+            .clone();
+        let (events, mut receiver) = mpsc::unbounded();
+        target.paused_request_sink = Some(PausedRequestSink { events, commands });
+
+        target.on_event(paused_event_message(&main_session, "main-request"));
+        let paused = block_on(receiver.next()).expect("managed request is delivered");
+        assert_eq!(paused.event().request_id.as_ref(), "main-request");
+        assert_eq!(paused.session_id, main_session);
+        assert!(target.paused_request_sink.is_some());
+        assert!(continue_requests(&target).is_empty());
+
+        drop(paused);
+        assert!(continue_requests(&target).is_empty());
+    }
+
+    #[test]
+    fn paused_request_pre_delivery_fallback_matrix_uses_the_captured_session() {
+        let (mut target, main_session) = initialized_target();
+        drain_target_events(&mut target);
+        enable_user_interception(&mut target);
+
+        target.on_event(paused_event_message(&main_session, "bootstrap-main"));
+        let requests = continue_requests(&target);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].session_id.as_deref(),
+            Some(main_session.as_ref())
+        );
+        assert_eq!(requests[0].params["requestId"], "bootstrap-main");
+
+        target.queued_events.clear();
+        target.page_exposed = true;
+        target.on_event(paused_event_message(&main_session, "legacy-main"));
+        assert!(continue_requests(&target).is_empty());
+
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        target
+            .iframe_init_states
+            .insert(child_session.clone(), IframeInitState::Done);
+        target.on_event(paused_event_message(&child_session, "child-request"));
+        let requests = continue_requests(&target);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].session_id.as_deref(),
+            Some(child_session.as_ref())
+        );
+        assert_eq!(requests[0].params["requestId"], "child-request");
+    }
+
+    #[test]
+    fn paused_request_push_failure_clears_sink_and_auto_continues_child() {
+        let (mut target, _) = initialized_target();
+        drain_target_events(&mut target);
+        enable_user_interception(&mut target);
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        target
+            .iframe_init_states
+            .insert(child_session.clone(), IframeInitState::Done);
+
+        let commands = target
+            .get_or_create_page()
+            .expect("initialized target exposes a page")
+            .sender()
+            .clone();
+        let (events, receiver) = mpsc::unbounded();
+        drop(receiver);
+        target.paused_request_sink = Some(PausedRequestSink { events, commands });
+
+        target.on_event(paused_event_message(&child_session, "failed-push"));
+        assert!(target.paused_request_sink.is_none());
+        let requests = continue_requests(&target);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].session_id.as_deref(),
+            Some(child_session.as_ref())
+        );
+        assert_eq!(requests[0].params["requestId"], "failed-push");
+    }
+
+    #[test]
+    fn auth_auto_response_is_queued_before_typed_listener_delivery() {
+        let (mut target, main_session) = initialized_target();
+        drain_target_events(&mut target);
+        let (events, receiver) = mpsc::unbounded();
+        target
+            .event_listeners
+            .add_listener(EventListenerRequest::new::<EventAuthRequired>(events));
+        let mut stream = crate::listeners::EventStream::<EventAuthRequired>::new(receiver);
+
+        target.on_event(auth_required_event_message(&main_session, "auth-request"));
+
+        let request = target
+            .queued_events
+            .front()
+            .and_then(|event| match event {
+                TargetEvent::Request(request) => Some(request),
+                _ => None,
+            })
+            .expect("auth response is queued before listener wakeup");
+        assert_eq!(request.method.as_ref(), "Fetch.continueWithAuth");
+        assert_eq!(request.session_id.as_deref(), Some(main_session.as_ref()));
+        assert_eq!(request.params["requestId"], "auth-request");
+
+        let mut cx = Context::from_waker(noop_waker_ref());
+        target.event_listeners.poll(&mut cx);
+        let observed = block_on(stream.next()).expect("typed auth event remains observable");
+        assert_eq!(observed.request_id.as_ref(), "auth-request");
+    }
+
+    #[test]
+    fn dynamic_network_fan_out_partitions_ack_send_only_and_excluded_sessions() {
+        let (mut target, main_session) = initialized_target();
+        drain_target_events(&mut target);
+        let sessions = [
+            ("done", Some(IframeInitState::Done)),
+            ("absent", None),
+            ("network", Some(IframeInitState::PostChainNetwork)),
+            ("unpause", Some(IframeInitState::PostChainUnpause)),
+            ("preload", Some(IframeInitState::PostChainPreload)),
+            ("failed", Some(IframeInitState::Failed)),
+        ];
+        for (name, state) in sessions {
+            let session_id = session(name);
+            install_child(&mut target, &format!("{name}-frame"), &session_id);
+            if let Some(state) = state {
+                target.iframe_init_states.insert(session_id, state);
+            } else {
+                target.iframe_init_states.remove(&session_id);
+            }
+        }
+        let chaining = session("chaining");
+        install_child(&mut target, "chaining-frame", &chaining);
+        let draining = session("draining");
+        install_child(&mut target, "draining-frame", &draining);
+        target
+            .iframe_init_states
+            .insert(draining.clone(), IframeInitState::Done);
+        target.draining_sessions.insert(draining);
+
+        let commands = target.network_manager.set_request_interception_core(true);
+        let (ack_tx, _ack_rx) = oneshot::channel();
+        target.enqueue_network_fan_out(commands, ack_tx);
+
+        let batch = match target.queued_events.pop_front() {
+            Some(TargetEvent::FanOutAckBatch(batch)) => batch,
+            other => panic!("expected one fan-out batch, got {other:?}"),
+        };
+        assert!(target.queued_events.is_empty());
+        assert_eq!(batch.main_session_id, main_session);
+
+        let session_methods = |requests: &[Request]| {
+            let mut values = requests
+                .iter()
+                .map(|request| {
+                    (
+                        request
+                            .session_id
+                            .clone()
+                            .expect("request is session scoped"),
+                        request.method.as_ref().to_owned(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            values.sort();
+            values
+        };
+        assert_eq!(
+            session_methods(&batch.ack_reqs),
+            vec![
+                ("absent".to_owned(), "Fetch.enable".to_owned()),
+                ("absent".to_owned(), "Network.setCacheDisabled".to_owned()),
+                ("done".to_owned(), "Fetch.enable".to_owned()),
+                ("done".to_owned(), "Network.setCacheDisabled".to_owned()),
+                ("main".to_owned(), "Fetch.enable".to_owned()),
+                ("main".to_owned(), "Network.setCacheDisabled".to_owned()),
+            ]
+        );
+        assert_eq!(
+            session_methods(&batch.send_only_reqs),
+            vec![
+                ("network".to_owned(), "Fetch.enable".to_owned()),
+                ("network".to_owned(), "Network.setCacheDisabled".to_owned()),
+                ("unpause".to_owned(), "Fetch.enable".to_owned()),
+                ("unpause".to_owned(), "Network.setCacheDisabled".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dynamic_network_internal_mutator_queues_only_one_fan_out_event() {
+        let (mut target, main_session) = initialized_target();
+        drain_target_events(&mut target);
+        let (ack_tx, _ack_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::SetRequestInterception {
+                enabled: true,
+                tx: ack_tx,
+            },
+        );
+
+        let batch = match poll_target(&mut target, Instant::now()) {
+            Some(TargetEvent::FanOutAckBatch(batch)) => batch,
+            other => panic!("expected the sole fan-out event, got {other:?}"),
+        };
+        assert_eq!(batch.ack_reqs.len(), 2);
+        assert!(batch.send_only_reqs.is_empty());
+        assert_eq!(batch.main_session_id, main_session);
+        assert!(target.queued_events.is_empty());
+        assert!(target.network_manager.poll().is_none());
+    }
+
+    #[test]
+    fn dynamic_interception_same_value_retry_re_fans_out_non_empty() {
+        // I-020: a same-value retry must re-emit a real (non-empty) fan-out
+        // batch. Under the old equality short-circuit the second call produced
+        // an empty batch, which `submit_fan_out_ack_batch` resolves `Ok(())`
+        // immediately (mod.rs) — a silent false success after a failed enable.
+        let (mut target, _main_session) = initialized_target();
+        drain_target_events(&mut target);
+
+        let (first_tx, _first_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::SetRequestInterception {
+                enabled: true,
+                tx: first_tx,
+            },
+        );
+        let first = match poll_target(&mut target, Instant::now()) {
+            Some(TargetEvent::FanOutAckBatch(batch)) => batch,
+            other => panic!("expected first fan-out batch, got {other:?}"),
+        };
+        assert!(!first.ack_reqs.is_empty(), "first enable fans out");
+
+        // Retry with the identical value: must still fan out a non-empty batch.
+        let (second_tx, _second_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::SetRequestInterception {
+                enabled: true,
+                tx: second_tx,
+            },
+        );
+        let second = match poll_target(&mut target, Instant::now()) {
+            Some(TargetEvent::FanOutAckBatch(batch)) => batch,
+            other => panic!("expected a re-emitted fan-out batch on retry, got {other:?}"),
+        };
+        assert_eq!(
+            second.ack_reqs.len(),
+            first.ack_reqs.len(),
+            "same-value retry re-fans-out the full idempotent batch, not an empty one"
+        );
+    }
+
+    #[test]
+    fn target_config_timeout_is_millis() {
+        assert_eq!(
+            TargetConfig::default().request_timeout,
+            Duration::from_millis(REQUEST_TIMEOUT)
+        );
+    }
+
+    #[test]
+    fn frame_info_distinguishes_gone_unbound_and_bound_frames() {
+        let mut target = test_target();
+        let main_session = session("main");
+        target
+            .frame_manager
+            .on_frame_navigated_in_session(&cdp_frame("main-frame", None), main_session.clone());
+        target.frame_manager.on_frame_attached(
+            FrameId::new("unbound-frame"),
+            Some(FrameId::new("main-frame")),
+        );
+        target.set_session_id(main_session.clone());
+        target.init_state = TargetInit::Initialized;
+
+        let (gone_tx, gone_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::GetFrameInfo {
+                frame_id: FrameId::new("gone"),
+                tx: gone_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert!(matches!(
+            block_on(gone_rx).expect("frame info resolves"),
+            Ok(None)
+        ));
+
+        let (unbound_tx, unbound_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::GetFrameInfo {
+                frame_id: FrameId::new("unbound-frame"),
+                tx: unbound_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert!(matches!(
+            block_on(unbound_rx).expect("frame info resolves"),
+            Err(CdpError::FrameNotReady)
+        ));
+
+        let (bound_tx, bound_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::GetFrameInfo {
+                frame_id: FrameId::new("main-frame"),
+                tx: bound_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        let info = block_on(bound_rx)
+            .expect("frame info resolves")
+            .expect("bound frame is ready")
+            .expect("bound frame exists");
+        assert_eq!(info.frame_id, FrameId::new("main-frame"));
+        assert_eq!(info.session_id, main_session);
+        assert_eq!(info.url.as_deref(), Some("https://main-frame.example/"));
+
+        let (all_tx, all_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::GetAllFrames { tx: all_tx },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        let all = block_on(all_rx).expect("all frames resolves");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].frame_id, FrameId::new("main-frame"));
+    }
+
+    #[test]
+    fn frame_boundary_chain_skips_same_session_ancestors_and_keeps_oop_edges() {
+        let (mut target, main_session) = initialized_target();
+        let first_session = session("child-1");
+        let second_session = session("child-2");
+        install_child(&mut target, "child-frame-1", &first_session);
+        install_nested_child(
+            &mut target,
+            "child-frame-2",
+            "child-frame-1",
+            &second_session,
+        );
+        target
+            .iframe_init_states
+            .insert(first_session.clone(), IframeInitState::Done);
+        target
+            .iframe_init_states
+            .insert(second_session.clone(), IframeInitState::Done);
+        target.frame_manager.on_frame_attached_in_session(
+            FrameId::new("same-session-descendant"),
+            Some(FrameId::new("child-frame-1")),
+            first_session.clone(),
+        );
+
+        assert!(
+            target
+                .build_boundary_chain(&FrameId::new("main-frame"), &main_session)
+                .expect("main frame chain is ready")
+                .is_empty()
+        );
+
+        let same_session_chain = target
+            .build_boundary_chain(&FrameId::new("same-session-descendant"), &first_session)
+            .expect("same-session descendant chain is ready");
+        assert_eq!(
+            same_session_chain,
+            vec![FrameBoundary {
+                child_frame_id: FrameId::new("child-frame-1"),
+                child_session_id: first_session.clone(),
+                parent_frame_id: FrameId::new("main-frame"),
+                parent_session_id: main_session.clone(),
+            }]
+        );
+
+        let nested_chain = target
+            .build_boundary_chain(&FrameId::new("child-frame-2"), &second_session)
+            .expect("nested OOP chain is ready");
+        assert_eq!(
+            nested_chain,
+            vec![
+                FrameBoundary {
+                    child_frame_id: FrameId::new("child-frame-2"),
+                    child_session_id: second_session,
+                    parent_frame_id: FrameId::new("child-frame-1"),
+                    parent_session_id: first_session.clone(),
+                },
+                FrameBoundary {
+                    child_frame_id: FrameId::new("child-frame-1"),
+                    child_session_id: first_session,
+                    parent_frame_id: FrameId::new("main-frame"),
+                    parent_session_id: main_session,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn frame_boundary_chain_distinguishes_missing_stale_and_draining_frames() {
+        let (mut target, main_session) = initialized_target();
+        assert!(matches!(
+            target.build_boundary_chain(&FrameId::new("missing"), &main_session),
+            Err(CdpError::FrameNotFound(frame)) if frame == FrameId::new("missing")
+        ));
+
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        target
+            .iframe_init_states
+            .insert(child_session.clone(), IframeInitState::Done);
+        assert!(matches!(
+            target.build_boundary_chain(&FrameId::new("child-frame"), &main_session),
+            Err(CdpError::FrameNotReady)
+        ));
+
+        target.enter_draining_session(child_session.clone());
+        assert!(matches!(
+            target.build_boundary_chain(&FrameId::new("child-frame"), &child_session),
+            Err(CdpError::FrameNotReady)
+        ));
+    }
+
+    #[test]
+    fn frame_boundary_chain_rejects_unbound_orphan_missing_ancestor_and_cycle() {
+        let (mut unbound, main_session) = initialized_target();
+        unbound.frame_manager.on_frame_attached_in_session(
+            FrameId::new("child"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        unbound
+            .frame_manager
+            .test_unbind_frame(&FrameId::new("child"));
+        assert!(matches!(
+            unbound.build_boundary_chain(&FrameId::new("child"), &main_session),
+            Err(CdpError::FrameNotReady)
+        ));
+
+        let (mut orphan, main_session) = initialized_target();
+        orphan.frame_manager.on_frame_attached_in_session(
+            FrameId::new("child"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        orphan
+            .frame_manager
+            .test_set_frame_parent(&FrameId::new("child"), None);
+        assert!(matches!(
+            orphan.build_boundary_chain(&FrameId::new("child"), &main_session),
+            Err(CdpError::FrameNotReady)
+        ));
+
+        let (mut missing_ancestor, main_session) = initialized_target();
+        missing_ancestor.frame_manager.on_frame_attached_in_session(
+            FrameId::new("child"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        missing_ancestor.frame_manager.on_frame_attached_in_session(
+            FrameId::new("grandchild"),
+            Some(FrameId::new("child")),
+            main_session.clone(),
+        );
+        missing_ancestor
+            .frame_manager
+            .test_remove_frame_without_descendants(&FrameId::new("child"));
+        assert!(matches!(
+            missing_ancestor.build_boundary_chain(&FrameId::new("grandchild"), &main_session),
+            Err(CdpError::FrameNotReady)
+        ));
+
+        let (mut cyclic, main_session) = initialized_target();
+        cyclic.frame_manager.on_frame_attached_in_session(
+            FrameId::new("child"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        cyclic.frame_manager.on_frame_attached_in_session(
+            FrameId::new("grandchild"),
+            Some(FrameId::new("child")),
+            main_session.clone(),
+        );
+        cyclic
+            .frame_manager
+            .test_set_frame_parent(&FrameId::new("child"), Some(FrameId::new("grandchild")));
+        assert!(matches!(
+            cyclic.build_boundary_chain(&FrameId::new("child"), &main_session),
+            Err(CdpError::FrameNotReady)
+        ));
+    }
+
+    #[test]
+    fn frame_command_passes_and_forces_the_expected_session() {
+        let (mut target, main_session) = initialized_target();
+        let (command_tx, command_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::FrameCommand {
+                frame_id: FrameId::new("main-frame"),
+                expected_session_id: main_session.clone(),
+                command: CommandMessage {
+                    method: "Runtime.evaluate".into(),
+                    session_id: Some(session("wrong")),
+                    params: json!({}),
+                    sender: command_tx,
+                },
+            },
+        );
+
+        let TargetEvent::Command(command) =
+            poll_target(&mut target, Instant::now()).expect("command is queued")
+        else {
+            panic!("expected a routed frame command")
+        };
+        assert_eq!(command.session_id, Some(main_session));
+        let _ = command.sender.send(Ok(ok_response(json!({}))));
+        assert!(
+            block_on(command_rx)
+                .expect("command sender resolves")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn frame_command_rejects_a_stale_session_without_queueing() {
+        let (mut target, main_session) = initialized_target();
+        target.frame_manager.on_frame_attached_in_session(
+            FrameId::new("child-frame"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        let child_session = session("child");
+        target.frame_manager.on_attached_to_target_in_session(
+            &attached_event("child-frame", &child_session),
+            child_session,
+        );
+
+        let (command_tx, command_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::FrameCommand {
+                frame_id: FrameId::new("child-frame"),
+                expected_session_id: main_session,
+                command: CommandMessage {
+                    method: "Runtime.evaluate".into(),
+                    session_id: None,
+                    params: json!({}),
+                    sender: command_tx,
+                },
+            },
+        );
+
+        assert!(!matches!(
+            poll_target(&mut target, Instant::now()),
+            Some(TargetEvent::Command(_))
+        ));
+        assert_frame_not_ready(block_on(command_rx).expect("command sender resolves"));
+    }
+
+    #[test]
+    fn frame_command_rejects_navigation_without_queueing() {
+        let (mut target, main_session) = initialized_target();
+        let (command_tx, command_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::FrameCommand {
+                frame_id: FrameId::new("main-frame"),
+                expected_session_id: main_session,
+                command: CommandMessage {
+                    method: NavigateParams::IDENTIFIER.into(),
+                    session_id: None,
+                    params: json!({ "url": "https://example/next" }),
+                    sender: command_tx,
+                },
+            },
+        );
+
+        // A navigation on the raw frame-command path must be rejected before it
+        // reaches the queue, so nothing is ever submitted to the target.
+        assert!(poll_target(&mut target, Instant::now()).is_none());
+        assert!(matches!(
+            block_on(command_rx).expect("command sender resolves"),
+            Err(CdpError::NotAllowed(_))
+        ));
+    }
+
+    #[test]
+    fn session_command_rejects_navigation_but_page_command_stays_supported() {
+        let (mut target, main_session) = initialized_target();
+        let (session_tx, session_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::SessionCommand {
+                session_id: main_session,
+                command: CommandMessage {
+                    method: NavigateParams::IDENTIFIER.into(),
+                    session_id: None,
+                    params: json!({ "url": "https://example/child" }),
+                    sender: session_tx,
+                },
+            },
+        );
+
+        assert!(poll_target(&mut target, Instant::now()).is_none());
+        assert!(matches!(
+            block_on(session_rx).expect("captured-session sender resolves"),
+            Err(CdpError::NotAllowed(message)) if message.contains("Frame::goto")
+        ));
+
+        let (page_tx, _page_rx) = oneshot::channel();
+        send_public(
+            &mut target,
+            TargetMessage::Command(CommandMessage {
+                method: NavigateParams::IDENTIFIER.into(),
+                session_id: None,
+                params: json!({ "url": "https://example/main" }),
+                sender: page_tx,
+            }),
+        );
+        assert!(matches!(
+            poll_target(&mut target, Instant::now()),
+            Some(TargetEvent::Command(command)) if command.is_navigation()
+        ));
+    }
+
+    #[test]
+    fn execution_context_queries_keep_child_ids_on_the_pinned_path() {
+        let (mut target, main_session) = initialized_target();
+        target.frame_manager.on_frame_attached_in_session(
+            FrameId::new("same-session-frame"),
+            Some(FrameId::new("main-frame")),
+            main_session.clone(),
+        );
+        let child_session = session("child");
+        target.frame_manager.on_frame_attached_in_session(
+            FrameId::new("oop-frame"),
+            Some(FrameId::new("main-frame")),
+            child_session.clone(),
+        );
+        target
+            .frame_manager
+            .on_frame_execution_context_created_in_session(
+                &execution_context("main-frame", 7, "main-context"),
+                main_session.clone(),
+            );
+        target
+            .frame_manager
+            .on_frame_execution_context_created_in_session(
+                &execution_context("same-session-frame", 8, "same-context"),
+                main_session.clone(),
+            );
+        target
+            .frame_manager
+            .on_frame_execution_context_created_in_session(
+                &execution_context("oop-frame", 7, "child-context"),
+                child_session.clone(),
+            );
+
+        let (main_tx, main_rx) = oneshot::channel();
+        send_public(
+            &mut target,
+            TargetMessage::GetExecutionContext(GetExecutionContext {
+                dom_world: DOMWorldKind::Main,
+                frame_id: Some(FrameId::new("main-frame")),
+                tx: main_tx,
+            }),
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert_eq!(
+            block_on(main_rx).expect("main context resolves"),
+            Some(ExecutionContextId::new(7))
+        );
+
+        let (same_tx, same_rx) = oneshot::channel();
+        send_public(
+            &mut target,
+            TargetMessage::GetExecutionContext(GetExecutionContext {
+                dom_world: DOMWorldKind::Main,
+                frame_id: Some(FrameId::new("same-session-frame")),
+                tx: same_tx,
+            }),
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert_eq!(
+            block_on(same_rx).expect("same-session context resolves"),
+            Some(ExecutionContextId::new(8))
+        );
+
+        let (oop_tx, oop_rx) = oneshot::channel();
+        send_public(
+            &mut target,
+            TargetMessage::GetExecutionContext(GetExecutionContext {
+                dom_world: DOMWorldKind::Main,
+                frame_id: Some(FrameId::new("oop-frame")),
+                tx: oop_tx,
+            }),
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        assert_eq!(block_on(oop_rx).expect("OOP context resolves"), None);
+
+        let (pinned_tx, pinned_rx) = oneshot::channel();
+        send_internal(
+            &mut target,
+            InternalTargetMessage::GetPinnedExecutionContext {
+                dom_world: DOMWorldKind::Main,
+                frame_id: FrameId::new("oop-frame"),
+                expected_session_id: child_session.clone(),
+                tx: pinned_tx,
+            },
+        );
+        let _ = poll_target(&mut target, Instant::now());
+        let pinned = block_on(pinned_rx)
+            .expect("pinned context resolves")
+            .expect("pinned frame is ready")
+            .expect("pinned context exists");
+        assert_eq!(pinned.context_id, ExecutionContextId::new(7));
+        assert_eq!(pinned.session_id, child_session);
+    }
+
+    #[test]
+    fn child_session_registration_precedes_iframe_init_and_attach_stays_paused() {
+        let (mut target, main_session) = initialized_target();
+        let child_session = session("child");
+
+        target.on_event(attach_event_message(
+            &main_session,
+            attached_event("child-frame", &child_session),
+        ));
+
+        assert!(matches!(
+            target.queued_events.front(),
+            Some(TargetEvent::RegisterChildSession(session_id)) if session_id == &child_session
+        ));
+        assert!(matches!(
+            target.iframe_init_states.get(&child_session),
+            Some(IframeInitState::Chaining {
+                phase: InitPhase::Frame,
+                ..
+            })
+        ));
+        assert!(!target.frame_session_ready(&child_session));
+        assert_eq!(
+            target
+                .frame_manager
+                .frame(&FrameId::new("child-frame"))
+                .and_then(|frame| frame.session_id()),
+            Some(&child_session)
+        );
+        assert!(!target.queued_events.iter().any(|event| matches!(
+            event,
+            TargetEvent::Request(request)
+                if request.method.as_ref() == RunIfWaitingForDebuggerParams::IDENTIFIER
+                    && request.session_id.as_deref() == Some(child_session.as_ref())
+        )));
+    }
+
+    #[test]
+    fn iframe_init_responses_with_colliding_methods_do_not_cross_sessions() {
+        let (mut target, _) = initialized_target();
+        let first = session("child-1");
+        let second = session("child-2");
+        install_child(&mut target, "child-frame-1", &first);
+        install_child(&mut target, "child-frame-2", &second);
+        let now = Instant::now();
+
+        let TargetEvent::Request(first_request) =
+            poll_target(&mut target, now).expect("one child starts initialization")
+        else {
+            panic!("expected child initialization request")
+        };
+        let actual_first = SessionId::new(
+            first_request
+                .session_id
+                .as_ref()
+                .expect("child request has a session")
+                .clone(),
+        );
+        let other = if actual_first == first {
+            second.clone()
+        } else {
+            first.clone()
+        };
+        assert_eq!(first_request.method.as_ref(), "Page.enable");
+
+        target.on_response_in_session(
+            ok_response(json!({})),
+            first_request.method.as_ref(),
+            Some(other.clone()),
+        );
+        let other_request = child_request(
+            poll_target(&mut target, now).expect("the other child starts independently"),
+            &other,
+        );
+        assert_eq!(other_request.method.as_ref(), "Page.enable");
+
+        target.on_response_in_session(
+            ok_response(json!({})),
+            first_request.method.as_ref(),
+            Some(actual_first.clone()),
+        );
+        let next_first = child_request(
+            poll_target(&mut target, now).expect("only the matching child advances"),
+            &actual_first,
+        );
+        assert_eq!(next_first.method.as_ref(), GetFrameTreeParams::IDENTIFIER);
+    }
+
+    #[test]
+    fn iframe_init_frame_tree_side_effects_use_the_response_session() {
+        let (mut target, _) = initialized_target();
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let now = Instant::now();
+
+        let enable = child_request(
+            poll_target(&mut target, now).expect("frame phase starts"),
+            &child_session,
+        );
+        target.on_response_in_session(
+            ok_response(json!({})),
+            enable.method.as_ref(),
+            Some(child_session.clone()),
+        );
+        let get_tree = child_request(
+            poll_target(&mut target, now).expect("frame tree command is ready"),
+            &child_session,
+        );
+        let tree_result = frame_tree_with_child_result("child-frame", "same-session-descendant");
+        assert!(GetFrameTreeParams::response_from_value(tree_result.clone()).is_ok());
+        target.on_response_in_session(
+            ok_response(tree_result),
+            get_tree.method.as_ref(),
+            Some(child_session.clone()),
+        );
+
+        let descendant = target
+            .frame_manager
+            .frame(&FrameId::new("same-session-descendant"))
+            .expect("frame-tree child should be created");
+        assert_eq!(descendant.session_id(), Some(&child_session));
+    }
+
+    #[test]
+    fn iframe_init_critical_error_fails_and_unpauses_exactly_once() {
+        let (mut target, _) = initialized_target();
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let now = Instant::now();
+        let request = child_request(
+            poll_target(&mut target, now).expect("frame phase starts"),
+            &child_session,
+        );
+
+        target.on_response_in_session(
+            error_response(),
+            request.method.as_ref(),
+            Some(child_session.clone()),
+        );
+        target.on_response_in_session(
+            error_response(),
+            request.method.as_ref(),
+            Some(child_session.clone()),
+        );
+
+        assert!(matches!(
+            target.iframe_init_states.get(&child_session),
+            Some(IframeInitState::Failed)
+        ));
+        assert!(!target.frame_session_ready(&child_session));
+        assert_eq!(
+            target
+                .queued_events
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    TargetEvent::Request(request)
+                        if request.method.as_ref()
+                            == RunIfWaitingForDebuggerParams::IDENTIFIER
+                            && request.session_id.as_deref() == Some(child_session.as_ref())
+                ))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn iframe_init_timeout_fails_and_unpauses_exactly_once() {
+        let (mut target, _) = initialized_target();
+        target.config.request_timeout = Duration::from_millis(1);
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let now = Instant::now();
+        let request = child_request(
+            poll_target(&mut target, now).expect("frame phase starts"),
+            &child_session,
+        );
+        assert_eq!(request.method.as_ref(), "Page.enable");
+
+        let unpause = child_request(
+            poll_target(&mut target, now + Duration::from_millis(2))
+                .expect("timeout unpauses the child"),
+            &child_session,
+        );
+        assert_eq!(
+            unpause.method.as_ref(),
+            RunIfWaitingForDebuggerParams::IDENTIFIER
+        );
+        target.transition_iframe_to_failed_and_unpause(child_session.clone());
+        assert!(!target.queued_events.iter().any(|event| matches!(
+            event,
+            TargetEvent::Request(request)
+                if request.method.as_ref() == RunIfWaitingForDebuggerParams::IDENTIFIER
+                    && request.session_id.as_deref() == Some(child_session.as_ref())
+        )));
+    }
+
+    #[test]
+    fn iframe_init_optional_error_skips_to_recursive_auto_attach() {
+        let (mut target, _) = initialized_target();
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let now = Instant::now();
+
+        let isolated_world = advance_child_to_isolated_world(&mut target, &child_session, now);
+        target.on_response_in_session(
+            error_response(),
+            isolated_world.method.as_ref(),
+            Some(child_session.clone()),
+        );
+        assert_eq!(
+            target
+                .frame_manager
+                .isolated_world_state(&child_session, UTILITY_WORLD_NAME),
+            None
+        );
+
+        let auto_attach = child_request(
+            poll_target(&mut target, now).expect("critical auto-attach still runs"),
+            &child_session,
+        );
+        assert_eq!(auto_attach.method.as_ref(), "Target.setAutoAttach");
+        assert!(matches!(
+            target.iframe_init_states.get(&child_session),
+            Some(IframeInitState::Chaining {
+                phase: InitPhase::AutoAttach,
+                ..
+            })
+        ));
+        assert!(
+            target
+                .frame_manager
+                .ensure_isolated_world_on_next_document_in_session(
+                    UTILITY_WORLD_NAME,
+                    child_session,
+                )
+                .is_some(),
+            "an explicit failure leaves no stale local registration marker"
+        );
+    }
+
+    #[test]
+    fn iframe_init_isolated_world_success_confirms_registration() {
+        let (mut target, _) = initialized_target();
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let now = Instant::now();
+        let isolated_world = advance_child_to_isolated_world(&mut target, &child_session, now);
+
+        target.on_response_in_session(
+            ok_response(json!({ "identifier": "utility-script" })),
+            isolated_world.method.as_ref(),
+            Some(child_session.clone()),
+        );
+
+        assert_eq!(
+            target
+                .frame_manager
+                .isolated_world_state(&child_session, UTILITY_WORLD_NAME),
+            Some(crate::handler::frame::IsolatedWorldState::Confirmed)
+        );
+        assert!(
+            target
+                .frame_manager
+                .ensure_isolated_world_on_next_document_in_session(
+                    UTILITY_WORLD_NAME,
+                    child_session.clone(),
+                )
+                .is_none()
+        );
+        let auto_attach = child_request(
+            poll_target(&mut target, now).expect("successful optional phase advances"),
+            &child_session,
+        );
+        assert_eq!(auto_attach.method.as_ref(), "Target.setAutoAttach");
+    }
+
+    #[test]
+    fn main_isolated_world_protocol_error_attempts_add_script_once_then_enters_network_init() {
+        let (mut target, main_session) = initialized_target();
+        let isolated_world_commands = target
+            .frame_manager
+            .ensure_isolated_world(UTILITY_WORLD_NAME)
+            .expect("main utility-world registration starts once");
+        target.main_isolated_world_attempted = true;
+        target.init_state = TargetInit::InitializingFrame(isolated_world_commands);
+        let now = Instant::now();
+
+        let request = match poll_target(&mut target, now) {
+            Some(TargetEvent::Request(request)) => request,
+            other => panic!("expected utility-world request, got {other:?}"),
+        };
+        assert_eq!(
+            request.method.as_ref(),
+            AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER
+        );
+        target.on_response_in_session(
+            error_response(),
+            request.method.as_ref(),
+            Some(main_session.clone()),
+        );
+        assert_eq!(
+            target
+                .frame_manager
+                .isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            None
+        );
+
+        let mut methods = vec![request.method.as_ref().to_owned()];
+        for _ in 0..8 {
+            let next = match poll_target(&mut target, now) {
+                Some(TargetEvent::Request(request)) => request,
+                other => {
+                    panic!("expected remaining utility-world or network request, got {other:?}")
+                }
+            };
+            methods.push(next.method.as_ref().to_owned());
+            if next.method.as_ref() == "Network.enable" {
+                break;
+            }
+            assert_eq!(
+                next.method.as_ref(),
+                chromiumoxide_cdp::cdp::browser_protocol::page::CreateIsolatedWorldParams::IDENTIFIER
+            );
+            target.on_response_in_session(
+                ok_response(json!({})),
+                next.method.as_ref(),
+                Some(main_session.clone()),
+            );
+        }
+
+        assert_eq!(
+            methods
+                .iter()
+                .filter(
+                    |method| method.as_str() == AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER
+                )
+                .count(),
+            1,
+            "main initialization must issue the named-world registration only once"
+        );
+        assert_eq!(methods.last().map(String::as_str), Some("Network.enable"));
+        assert!(matches!(
+            target.init_state,
+            TargetInit::InitializingNetwork(_)
+        ));
+    }
+
+    #[test]
+    fn iframe_init_isolated_world_timeout_stays_pending_and_unpauses() {
+        let timeout = Duration::from_millis(1);
+        let mut target = test_target();
+        target.config.request_timeout = timeout;
+        target.frame_manager = FrameManager::new(timeout);
+        let main_session = session("main");
+        target.set_session_id(main_session.clone());
+        target.init_state = TargetInit::Initialized;
+        target
+            .frame_manager
+            .on_frame_navigated_in_session(&cdp_frame("main-frame", None), main_session);
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let now = Instant::now();
+        let _isolated_world = advance_child_to_isolated_world(&mut target, &child_session, now);
+
+        assert!(target.poll_iframe_init(now + Duration::from_millis(2)));
+        assert!(target.queued_events.iter().any(|event| matches!(
+            event,
+            TargetEvent::Request(request)
+                if request.method.as_ref() == RunIfWaitingForDebuggerParams::IDENTIFIER
+                    && request.session_id.as_deref() == Some(child_session.as_ref())
+        )));
+        assert!(matches!(
+            target.iframe_init_states.get(&child_session),
+            Some(IframeInitState::Failed)
+        ));
+        assert_eq!(
+            target
+                .frame_manager
+                .isolated_world_state(&child_session, UTILITY_WORLD_NAME),
+            Some(crate::handler::frame::IsolatedWorldState::Pending)
+        );
+        assert!(
+            target
+                .frame_manager
+                .ensure_isolated_world_on_next_document_in_session(
+                    UTILITY_WORLD_NAME,
+                    child_session.clone(),
+                )
+                .is_none(),
+            "a timed-out request must not be duplicated"
+        );
+        assert!(!target.queued_events.iter().any(|event| matches!(
+            event,
+            TargetEvent::Request(request)
+                if request.method.as_ref() == "Target.setAutoAttach"
+                    && request.session_id.as_deref() == Some(child_session.as_ref())
+        )));
+
+        target
+            .frame_manager
+            .on_frame_execution_context_created_in_session(
+                &isolated_execution_context(
+                    "child-frame",
+                    91,
+                    "timeout-utility-context",
+                    UTILITY_WORLD_NAME,
+                ),
+                child_session.clone(),
+            );
+        assert_eq!(
+            target
+                .frame_manager
+                .isolated_world_state(&child_session, UTILITY_WORLD_NAME),
+            Some(crate::handler::frame::IsolatedWorldState::Confirmed),
+            "an observed utility context upgrades the Pending timeout marker"
+        );
+    }
+
+    #[test]
+    fn preload_chaining_snapshot_and_post_chain_fanout_are_exactly_once() {
+        let (mut target, _) = initialized_target();
+        drain_target_events(&mut target);
+        let first_key = target.frame_manager.add_preload_script(
+            AddScriptToEvaluateOnNewDocumentParams::new("globalThis.first = true"),
+            ScriptIdentifier::new("main-first"),
+        );
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+
+        target.enqueue_preload_fan_out(first_key);
+        assert!(
+            !target
+                .queued_events
+                .iter()
+                .any(|event| matches!(event, TargetEvent::QueuePreloadScript { .. }))
+        );
+
+        target.finish_iframe_init_phases(child_session.clone());
+        assert!(matches!(
+            target.iframe_init_states.get(&child_session),
+            Some(IframeInitState::PostChainPreload)
+        ));
+        let second_key = target.frame_manager.add_preload_script(
+            AddScriptToEvaluateOnNewDocumentParams::new("globalThis.second = true"),
+            ScriptIdentifier::new("main-second"),
+        );
+        target.enqueue_preload_fan_out(second_key);
+
+        let queued = target
+            .queued_events
+            .iter()
+            .filter_map(|event| match event {
+                TargetEvent::QueuePreloadScript {
+                    request,
+                    preload_key,
+                } => Some((
+                    *preload_key,
+                    request.session_id.as_deref(),
+                    request.params["source"].as_str(),
+                )),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            queued,
+            vec![
+                (
+                    first_key,
+                    Some(child_session.as_ref()),
+                    Some("globalThis.first = true")
+                ),
+                (
+                    second_key,
+                    Some(child_session.as_ref()),
+                    Some("globalThis.second = true")
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn preload_fanout_targets_only_children_past_the_snapshot_boundary() {
+        let (mut target, _) = initialized_target();
+        drain_target_events(&mut target);
+        let preload_key = target.frame_manager.add_preload_script(
+            AddScriptToEvaluateOnNewDocumentParams::new("globalThis.preloaded = true"),
+            ScriptIdentifier::new("main-script"),
+        );
+
+        let chaining = session("chaining");
+        install_child(&mut target, "chaining-frame", &chaining);
+
+        let post_preload = session("post-preload");
+        install_child(&mut target, "post-preload-frame", &post_preload);
+        target
+            .iframe_init_states
+            .insert(post_preload.clone(), IframeInitState::PostChainPreload);
+
+        let post_network = session("post-network");
+        install_child(&mut target, "post-network-frame", &post_network);
+        target
+            .iframe_init_states
+            .insert(post_network.clone(), IframeInitState::PostChainNetwork);
+
+        let post_unpause = session("post-unpause");
+        install_child(&mut target, "post-unpause-frame", &post_unpause);
+        target
+            .iframe_init_states
+            .insert(post_unpause.clone(), IframeInitState::PostChainUnpause);
+
+        let done = session("done");
+        install_child(&mut target, "done-frame", &done);
+        target
+            .iframe_init_states
+            .insert(done.clone(), IframeInitState::Done);
+
+        let completed = session("completed");
+        install_child(&mut target, "completed-frame", &completed);
+        target.iframe_init_states.remove(&completed);
+
+        let failed = session("failed");
+        install_child(&mut target, "failed-frame", &failed);
+        target
+            .iframe_init_states
+            .insert(failed.clone(), IframeInitState::Failed);
+
+        let draining = session("draining");
+        install_child(&mut target, "draining-frame", &draining);
+        target.enter_draining_session(draining);
+
+        target.enqueue_preload_fan_out(preload_key);
+
+        let mut actual = target
+            .queued_events
+            .iter()
+            .filter_map(|event| match event {
+                TargetEvent::QueuePreloadScript { request, .. } => {
+                    request.session_id.as_deref().map(str::to_owned)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        actual.sort();
+        assert_eq!(
+            actual,
+            vec![
+                "completed".to_owned(),
+                "done".to_owned(),
+                "post-network".to_owned(),
+                "post-preload".to_owned(),
+                "post-unpause".to_owned(),
+            ]
+        );
+        assert!(
+            !actual
+                .iter()
+                .any(|session_id| session_id == chaining.as_ref())
+        );
+        assert!(
+            !actual
+                .iter()
+                .any(|session_id| session_id == failed.as_ref())
+        );
+    }
+
+    #[test]
+    fn preload_snapshot_commands_precede_network_replay_and_unpause() {
+        let (mut target, _) = initialized_target();
+        drain_target_events(&mut target);
+        for (index, source) in ["globalThis.first = true", "globalThis.second = true"]
+            .into_iter()
+            .enumerate()
+        {
+            target.frame_manager.add_preload_script(
+                AddScriptToEvaluateOnNewDocumentParams::new(source),
+                ScriptIdentifier::new(format!("main-script-{index}")),
+            );
+        }
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        target.finish_iframe_init_phases(child_session.clone());
+
+        let now = Instant::now();
+        let mut methods = Vec::new();
+        for _ in 0..32 {
+            let Some(event) = poll_target(&mut target, now) else {
+                continue;
+            };
+            let request = match event {
+                TargetEvent::QueuePreloadScript { request, .. } | TargetEvent::Request(request) => {
+                    request
+                }
+                other => panic!("unexpected child init event: {other:?}"),
+            };
+            assert_eq!(request.session_id.as_deref(), Some(child_session.as_ref()));
+            methods.push(request.method.as_ref().to_owned());
+            if request.method.as_ref() == RunIfWaitingForDebuggerParams::IDENTIFIER {
+                break;
+            }
+        }
+
+        assert_eq!(
+            &methods[..2],
+            [
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER,
+                AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER,
+            ]
+        );
+        let network_index = methods
+            .iter()
+            .position(|method| method == "Network.enable")
+            .expect("network replay is emitted");
+        let unpause_index = methods
+            .iter()
+            .position(|method| method == RunIfWaitingForDebuggerParams::IDENTIFIER)
+            .expect("child is unpaused");
+        assert!(network_index >= 2);
+        assert!(network_index < unpause_index);
+        assert_eq!(
+            methods
+                .iter()
+                .filter(|method| {
+                    method.as_str() == AddScriptToEvaluateOnNewDocumentParams::IDENTIFIER
+                })
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn iframe_init_post_chain_replays_latest_state_before_unpause_and_becomes_ready() {
+        let (mut target, _) = initialized_target();
+        let child_session = session("child");
+        target.network_manager.set_request_interception(true);
+        target
+            .network_manager
+            .set_extra_headers(HashMap::from([("x-test".to_owned(), "latest".to_owned())]));
+        target.network_manager.set_offline_mode(true);
+        while target.network_manager.poll().is_some() {}
+        target.config.viewport = Some(Viewport::default());
+        install_child(&mut target, "child-frame", &child_session);
+
+        let now = Instant::now();
+        let mut methods = Vec::new();
+        for _ in 0..64 {
+            let Some(event) = poll_target(&mut target, now) else {
+                continue;
+            };
+            let request = child_request(event, &child_session);
+            let method = request.method.as_ref().to_owned();
+            methods.push(method.clone());
+            if method == RunIfWaitingForDebuggerParams::IDENTIFIER {
+                break;
+            }
+            if matches!(
+                target.iframe_init_states.get(&child_session),
+                Some(IframeInitState::Chaining { .. })
+            ) {
+                let result = if method == GetFrameTreeParams::IDENTIFIER {
+                    frame_tree_result("child-frame")
+                } else {
+                    json!({})
+                };
+                target.on_response_in_session(
+                    ok_response(result),
+                    &method,
+                    Some(child_session.clone()),
+                );
+            }
+        }
+
+        let index = |method: &str| {
+            methods
+                .iter()
+                .position(|candidate| candidate == method)
+                .unwrap_or_else(|| panic!("missing {method} in {methods:?}"))
+        };
+        assert!(index("Page.addScriptToEvaluateOnNewDocument") < index("Target.setAutoAttach"));
+        assert!(
+            !methods
+                .iter()
+                .any(|method| method == "Page.createIsolatedWorld")
+        );
+        assert!(index("Target.setAutoAttach") < index("Network.enable"));
+        assert!(index("Network.enable") < index("Fetch.enable"));
+        assert!(index("Fetch.enable") < index(RunIfWaitingForDebuggerParams::IDENTIFIER));
+        assert!(
+            index("Emulation.setDeviceMetricsOverride")
+                < index(RunIfWaitingForDebuggerParams::IDENTIFIER)
+        );
+        assert_eq!(
+            methods
+                .iter()
+                .filter(|method| method.as_str() == RunIfWaitingForDebuggerParams::IDENTIFIER)
+                .count(),
+            1
+        );
+        for method in [
+            "Network.enable",
+            "Security.setIgnoreCertificateErrors",
+            "Network.setCacheDisabled",
+            "Network.setExtraHTTPHeaders",
+            "Network.emulateNetworkConditions",
+            "Fetch.enable",
+            "Emulation.setDeviceMetricsOverride",
+            "Emulation.setTouchEmulationEnabled",
+        ] {
+            assert_eq!(
+                methods
+                    .iter()
+                    .filter(|candidate| candidate.as_str() == method)
+                    .count(),
+                1,
+                "{method} should be replayed once"
+            );
+        }
+
+        assert!(poll_target(&mut target, now).is_none());
+        assert!(!target.iframe_init_states.contains_key(&child_session));
+        assert!(target.frame_session_ready(&child_session));
+    }
+
+    #[test]
+    fn child_session_draining_cleans_init_network_and_frame_state() {
+        let (mut target, main_session) = initialized_target();
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        let (wait_tx, wait_rx) = oneshot::channel();
+        target.frame_manager.wait_for_navigation(
+            child_session.clone(),
+            FrameId::new("child-frame"),
+            wait_tx,
+        );
+        target.network_manager.push_cdp_request_session(
+            RunIfWaitingForDebuggerParams::default(),
+            child_session.clone(),
+        );
+        target
+            .queued_events
+            .push_back(TargetEvent::Request(wire_request(1, Some(&child_session))));
+
+        target.enter_draining_session(child_session.clone());
+
+        assert!(!target.iframe_init_states.contains_key(&child_session));
+        assert!(target.network_manager.poll_session_request().is_none());
+        assert!(!target.frame_session_ready(&child_session));
+        assert_eq!(
+            block_on(wait_rx).expect("draining settles the promoted frame waiter"),
+            Err(FrameWaitError::FrameSwappedOrDetached)
+        );
+        assert!(!target.queued_events.iter().any(|event| matches!(
+            event,
+            TargetEvent::Request(request)
+                if request.session_id.as_deref() == Some(child_session.as_ref())
+        )));
+
+        target.handle_detached_from_target(
+            &EventDetachedFromTarget {
+                session_id: child_session.clone(),
+            },
+            main_session.clone(),
+        );
+        assert!(!target.frame_manager.is_child_session(&child_session));
+        assert_eq!(
+            target
+                .frame_manager
+                .frame(&FrameId::new("child-frame"))
+                .and_then(|frame| frame.session_id()),
+            Some(&main_session)
+        );
+        assert!(target.queued_events.iter().any(|event| matches!(
+            event,
+            TargetEvent::UnregisterChildSession(session_id) if session_id == &child_session
+        )));
+    }
+
+    #[test]
+    fn child_session_nested_children_first_detach_rebinds_each_level_to_its_parent() {
+        let (mut target, main_session) = initialized_target();
+        let first_session = session("child-1");
+        let second_session = session("child-2");
+        install_child(&mut target, "child-frame-1", &first_session);
+        install_nested_child(
+            &mut target,
+            "child-frame-2",
+            "child-frame-1",
+            &second_session,
+        );
+
+        target.handle_detached_from_target(
+            &EventDetachedFromTarget {
+                session_id: second_session.clone(),
+            },
+            first_session.clone(),
+        );
+        assert_eq!(
+            target
+                .frame_manager
+                .frame(&FrameId::new("child-frame-2"))
+                .and_then(|frame| frame.session_id()),
+            Some(&first_session)
+        );
+        assert!(!target.frame_manager.is_child_session(&second_session));
+
+        target.handle_detached_from_target(
+            &EventDetachedFromTarget {
+                session_id: first_session.clone(),
+            },
+            main_session.clone(),
+        );
+        for frame_id in ["child-frame-1", "child-frame-2"] {
+            assert_eq!(
+                target
+                    .frame_manager
+                    .frame(&FrameId::new(frame_id))
+                    .and_then(|frame| frame.session_id()),
+                Some(&main_session)
+            );
+        }
+        assert!(!target.frame_manager.is_child_session(&first_session));
+        assert!(!target.iframe_init_states.contains_key(&first_session));
+        assert!(!target.iframe_init_states.contains_key(&second_session));
+    }
+
+    #[test]
+    fn iframe_init_unknown_or_terminal_child_response_has_no_frame_tree_side_effect() {
+        let (mut target, _) = initialized_target();
+        let ghost = session("ghost");
+        target.on_response_in_session(
+            ok_response(frame_tree_result("ghost-frame")),
+            GetFrameTreeParams::IDENTIFIER,
+            Some(ghost),
+        );
+        assert!(
+            target
+                .frame_manager
+                .frame(&FrameId::new("ghost-frame"))
+                .is_none()
+        );
+
+        let child_session = session("child");
+        install_child(&mut target, "child-frame", &child_session);
+        target
+            .iframe_init_states
+            .insert(child_session.clone(), IframeInitState::Failed);
+        target.on_response_in_session(
+            ok_response(frame_tree_result("late-frame")),
+            GetFrameTreeParams::IDENTIFIER,
+            Some(child_session),
+        );
+        assert!(
+            target
+                .frame_manager
+                .frame(&FrameId::new("late-frame"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn page_receiver_poll_budget_is_bounded_and_self_wakes() {
+        let (sender, receiver) = mpsc::unbounded();
+        for value in 0..(PAGE_MESSAGE_POLL_BUDGET + 4) {
+            sender
+                .unbounded_send(value)
+                .expect("test receiver remains open");
+        }
+        let mut receiver = receiver.fuse();
+        let wake_counter = Arc::new(WakeCounter::default());
+        let waker = waker_ref(&wake_counter);
+        let mut cx = Context::from_waker(&waker);
+
+        let (first_batch, exhausted) = poll_receiver_batch(&mut receiver, &mut cx);
+        assert_eq!(first_batch.len(), PAGE_MESSAGE_POLL_BUDGET);
+        assert!(exhausted);
+        assert_eq!(wake_counter.0.load(Ordering::Relaxed), 1);
+
+        let (second_batch, exhausted) = poll_receiver_batch(&mut receiver, &mut cx);
+        assert_eq!(
+            second_batch,
+            (PAGE_MESSAGE_POLL_BUDGET..PAGE_MESSAGE_POLL_BUDGET + 4).collect::<Vec<_>>()
+        );
+        assert!(!exhausted);
+    }
+
+    #[test]
+    fn whole_target_teardown_settles_ingress_storage_and_initiator() {
+        let (mut target, main_session) = initialized_target();
+        let page = target
+            .get_or_create_page()
+            .expect("initialized target creates a page handle")
+            .clone();
+
+        let mut wait = page.wait_for_navigation();
+        assert!(poll_future_once(wait.as_mut()).is_pending());
+
+        let (command_tx, command_rx) = oneshot::channel();
+        block_on(
+            page.sender()
+                .clone()
+                .send(TargetMessage::Command(CommandMessage {
+                    method: "Runtime.evaluate".into(),
+                    session_id: None,
+                    params: json!({}),
+                    sender: command_tx,
+                })),
+        )
+        .expect("page ingress remains open before teardown");
+
+        let (legacy_tx, legacy_rx) = oneshot::channel();
+        target.wait_for_frame_navigation.push(legacy_tx);
+        let (promoted_tx, promoted_rx) = oneshot::channel();
+        target.wait_for_navigation_results.push(promoted_tx);
+        let (initiator_tx, initiator_rx) = oneshot::channel();
+        target.set_initiator(initiator_tx);
+        assert!(
+            target
+                .frame_manager
+                .ensure_isolated_world_in_session(UTILITY_WORLD_NAME, main_session.clone(),)
+                .is_some()
+        );
+
+        target.settle_whole_target_teardown();
+
+        assert!(matches!(block_on(wait), Err(CdpError::FrameNotReady)));
+        assert!(matches!(
+            block_on(command_rx).expect("command sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(
+            block_on(legacy_rx)
+                .expect("legacy waiter resolves")
+                .is_none()
+        );
+        assert!(matches!(
+            block_on(promoted_rx).expect("promoted waiter resolves"),
+            Err(CdpError::FrameNotReady)
+        ));
+        assert!(matches!(
+            block_on(initiator_rx).expect("initiator resolves"),
+            Err(CdpError::NoResponse)
+        ));
+        assert_eq!(
+            target
+                .frame_manager
+                .isolated_world_state(&main_session, UTILITY_WORLD_NAME),
+            None
+        );
+
+        let (late_tx, _late_rx) = oneshot::channel();
+        assert!(
+            block_on(
+                page.internal_sender()
+                    .clone()
+                    .send(InternalTargetMessage::WaitForNavigationResult { tx: late_tx })
+            )
+            .is_err(),
+            "a send that starts after teardown must fail at the closed ingress"
+        );
+    }
+
+    #[test]
+    fn initiator_already_resolved_does_not_double_settle_on_teardown() {
+        let (mut target, main_session) = initialized_target();
+        drain_target_events(&mut target);
+        target.frame_manager.on_frame_stopped_loading_in_session(
+            &chromiumoxide_cdp::cdp::browser_protocol::page::EventFrameStoppedLoading {
+                frame_id: FrameId::new("main-frame"),
+            },
+            main_session,
+        );
+        let (initiator_tx, initiator_rx) = oneshot::channel();
+        target.set_initiator(initiator_tx);
+
+        let _ = poll_target(&mut target, Instant::now());
+        assert!(
+            block_on(initiator_rx)
+                .expect("initiator sender resolves")
+                .is_ok()
+        );
+        assert!(target.initiator.is_none());
+
+        target.settle_whole_target_teardown();
+        target.settle_whole_target_teardown();
+        assert!(target.initiator.is_none());
+    }
+
+    #[test]
+    fn promoted_page_wait_and_http_future_keep_typed_teardown_errors() {
+        let (mut target, _) = initialized_target();
+        let page = target
+            .get_or_create_page()
+            .expect("initialized target creates a page handle")
+            .clone();
+
+        let mut page_wait = page.wait_for_navigation();
+        assert!(poll_future_once(page_wait.as_mut()).is_pending());
+        let _ = poll_target(&mut target, Instant::now());
+        assert_eq!(target.wait_for_navigation_results.len(), 1);
+
+        target.settle_whole_target_teardown();
+        assert!(matches!(block_on(page_wait), Err(CdpError::FrameNotReady)));
+
+        let (mut target, _) = initialized_target();
+        let page = target
+            .get_or_create_page()
+            .expect("initialized target creates a page handle")
+            .clone();
+        let mut http_future = Box::pin(
+            page.http_future(RunIfWaitingForDebuggerParams::default())
+                .expect("command serializes"),
+        );
+        assert!(poll_future_once(http_future.as_mut()).is_pending());
+        let command = loop {
+            match poll_target(&mut target, Instant::now()) {
+                Some(TargetEvent::Command(command)) => break command,
+                Some(_) => continue,
+                None => panic!("command event was not emitted"),
+            }
+        };
+        let _ = command.sender.send(Ok(ok_response(json!({}))));
+        assert!(poll_future_once(http_future.as_mut()).is_pending());
+        assert!(poll_future_once(http_future.as_mut()).is_pending());
+        for _ in 0..32 {
+            let _ = poll_target(&mut target, Instant::now());
+            if !target.wait_for_navigation_results.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(target.wait_for_navigation_results.len(), 1);
+
+        target.settle_whole_target_teardown();
+        assert!(matches!(
+            block_on(http_future),
+            Err(CdpError::FrameNotReady)
+        ));
+    }
+
+    #[test]
+    fn teardown_message_matrix_uses_each_senders_natural_error_shape() {
+        let (all_frames_tx, all_frames_rx) = oneshot::channel();
+        Target::settle_target_message_on_teardown(TargetMessage::AllFrames(all_frames_tx));
+        assert!(
+            block_on(all_frames_rx)
+                .expect("all-frames sender resolves")
+                .is_empty()
+        );
+
+        let (main_frame_tx, main_frame_rx) = oneshot::channel();
+        Target::settle_target_message_on_teardown(TargetMessage::MainFrame(main_frame_tx));
+        assert_eq!(
+            block_on(main_frame_rx).expect("main-frame sender resolves"),
+            None
+        );
+
+        let (legacy_tx, legacy_rx) = oneshot::channel();
+        Target::settle_target_message_on_teardown(TargetMessage::WaitForNavigation(legacy_tx));
+        assert!(
+            block_on(legacy_rx)
+                .expect("legacy wait sender resolves")
+                .is_none()
+        );
+
+        let (all_info_tx, all_info_rx) = oneshot::channel();
+        Target::settle_internal_message_on_teardown(InternalTargetMessage::GetAllFrames {
+            tx: all_info_tx,
+        });
+        assert!(
+            block_on(all_info_rx)
+                .expect("all-frame-info sender resolves")
+                .is_empty()
+        );
+
+        let (frame_wait_tx, frame_wait_rx) = oneshot::channel();
+        Target::settle_internal_message_on_teardown(
+            InternalTargetMessage::FrameWaitForNavigation {
+                frame_id: FrameId::new("frame"),
+                session_id: session("session"),
+                tx: frame_wait_tx,
+            },
+        );
+        assert_eq!(
+            block_on(frame_wait_rx).expect("frame wait sender resolves"),
+            Err(FrameWaitError::FrameSwappedOrDetached)
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn queued_event_drain_removes_dead_wires_and_preserves_survivor_fifo(
+            entries in prop::collection::vec((0_u8..2, 0_u8..3), 0..80)
+        ) {
+            let dead = session("dead");
+            let live = session("live");
+            let mut target = test_target();
+            let mut expected = Vec::new();
+
+            for (id, (event_kind, session_kind)) in entries.into_iter().enumerate() {
+                let event_session = match session_kind {
+                    0 => Some(&dead),
+                    1 => Some(&live),
+                    2 => None,
+                    _ => unreachable!("generated session class is bounded"),
+                };
+                let request = wire_request(id, event_session);
+                let event = if event_kind == 0 {
+                    TargetEvent::Request(request)
+                } else {
+                    TargetEvent::NavigationRequest(NavigationId(id), request)
+                };
+                target.queued_events.push_back(event);
+                if session_kind != 0 {
+                    expected.push(id);
+                }
+            }
+
+            target.fail_queued_events(&dead);
+
+            let actual = wire_event_ids(&target);
+            prop_assert_eq!(&actual, &expected);
+            for id in expected {
+                prop_assert_eq!(actual.iter().filter(|actual_id| **actual_id == id).count(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn queued_event_drain_resolves_each_matching_sender_with_its_typed_error() {
+        let dead = session("dead");
+        let frame_id = FrameId::new("frame");
+        let mut target = test_target();
+
+        let (command_tx, command_rx) = oneshot::channel();
+        target
+            .queued_events
+            .push_back(TargetEvent::Command(CommandMessage {
+                method: "Runtime.evaluate".into(),
+                session_id: Some(dead.clone()),
+                params: json!({}),
+                sender: command_tx,
+            }));
+
+        let (navigate_tx, navigate_rx) = oneshot::channel();
+        target.queued_events.push_back(TargetEvent::FrameNavigate {
+            session_id: dead.clone(),
+            frame_id: frame_id.clone(),
+            req: wire_request(1, Some(&dead)),
+            tx: navigate_tx,
+        });
+
+        let (wait_tx, wait_rx) = oneshot::channel();
+        target
+            .queued_events
+            .push_back(TargetEvent::FrameWaitForNavigation {
+                session_id: dead.clone(),
+                frame_id,
+                tx: wait_tx,
+            });
+
+        target.fail_queued_events(&dead);
+
+        assert_frame_not_ready(block_on(command_rx).expect("command sender resolves"));
+        assert_frame_not_ready(block_on(navigate_rx).expect("navigation sender resolves"));
+        assert_eq!(
+            block_on(wait_rx).expect("wait sender resolves"),
+            Err(FrameWaitError::FrameSwappedOrDetached)
+        );
+        assert!(target.queued_events.is_empty());
+    }
+
+    #[test]
+    fn queued_event_enter_draining_is_idempotent_and_emits_one_control_event() {
+        let dead = session("dead");
+        let mut target = test_target();
+        target
+            .queued_events
+            .push_back(TargetEvent::Request(wire_request(0, Some(&dead))));
+
+        target.enter_draining_session(dead.clone());
+        target.enter_draining_session(dead.clone());
+
+        assert!(target.is_session_draining(&dead));
+        assert_eq!(target.queued_events.len(), 1);
+        assert!(matches!(
+            target.queued_events.front(),
+            Some(TargetEvent::SessionDraining(id)) if id == &dead
+        ));
+        target.clear_draining(&dead);
+        assert!(!target.is_session_draining(&dead));
+    }
+
+    #[test]
+    fn fan_out_batch_main_removal_fails_ack_and_drops_batch() {
+        let main = session("main");
+        let child = session("child");
+        let mut target = test_target();
+        let (ack_tx, ack_rx) = oneshot::channel();
+
+        target
+            .queued_events
+            .push_back(TargetEvent::FanOutAckBatch(FanOutAckBatch {
+                ack_reqs: vec![wire_request(0, Some(&main)), wire_request(1, Some(&child))],
+                send_only_reqs: vec![],
+                ack_tx,
+                main_session_id: main.clone(),
+            }));
+
+        target.fail_queued_events(&main);
+
+        assert!(target.queued_events.is_empty());
+        assert!(matches!(
+            block_on(ack_rx).expect("fan-out ack sender resolves"),
+            Err(CdpError::FrameNotReady)
+        ));
+    }
+
+    #[test]
+    fn fan_out_batch_child_removal_keeps_reduced_batch_in_place() {
+        let main = session("main");
+        let removed = session("removed");
+        let live = session("live");
+        let mut target = test_target();
+        let (ack_tx, _ack_rx) = oneshot::channel();
+
+        target
+            .queued_events
+            .push_back(TargetEvent::Request(wire_request(0, None)));
+        target
+            .queued_events
+            .push_back(TargetEvent::FanOutAckBatch(FanOutAckBatch {
+                ack_reqs: vec![
+                    wire_request(1, Some(&main)),
+                    wire_request(2, Some(&removed)),
+                    wire_request(3, Some(&live)),
+                ],
+                send_only_reqs: vec![
+                    wire_request(4, Some(&removed)),
+                    wire_request(5, Some(&live)),
+                ],
+                ack_tx,
+                main_session_id: main,
+            }));
+        target
+            .queued_events
+            .push_back(TargetEvent::NavigationRequest(
+                NavigationId(6),
+                wire_request(6, None),
+            ));
+
+        target.fail_queued_events(&removed);
+
+        assert_eq!(target.queued_events.len(), 3);
+        assert!(matches!(
+            target.queued_events.front(),
+            Some(TargetEvent::Request(request)) if request.params["id"] == 0
+        ));
+        let batch = match target.queued_events.get(1) {
+            Some(TargetEvent::FanOutAckBatch(batch)) => batch,
+            other => panic!("reduced batch moved from its queue position: {other:?}"),
+        };
+        assert_eq!(
+            batch
+                .ack_reqs
+                .iter()
+                .map(|request| request.params["id"].as_u64().expect("numeric id"))
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        assert_eq!(
+            batch
+                .send_only_reqs
+                .iter()
+                .map(|request| request.params["id"].as_u64().expect("numeric id"))
+                .collect::<Vec<_>>(),
+            vec![5]
+        );
+        assert!(matches!(
+            target.queued_events.back(),
+            Some(TargetEvent::NavigationRequest(_, request)) if request.params["id"] == 6
+        ));
+    }
+
+    #[test]
+    fn target_drain_all_settles_every_queued_sender() {
+        let main = session("main");
+        let frame_id = FrameId::new("frame");
+        let mut target = test_target();
+
+        let (command_tx, command_rx) = oneshot::channel();
+        target
+            .queued_events
+            .push_back(TargetEvent::Command(CommandMessage {
+                method: "Runtime.evaluate".into(),
+                session_id: Some(main.clone()),
+                params: json!({}),
+                sender: command_tx,
+            }));
+        let (navigate_tx, navigate_rx) = oneshot::channel();
+        target.queued_events.push_back(TargetEvent::FrameNavigate {
+            session_id: main.clone(),
+            frame_id: frame_id.clone(),
+            req: wire_request(0, Some(&main)),
+            tx: navigate_tx,
+        });
+        let (wait_tx, wait_rx) = oneshot::channel();
+        target
+            .queued_events
+            .push_back(TargetEvent::FrameWaitForNavigation {
+                session_id: main.clone(),
+                frame_id,
+                tx: wait_tx,
+            });
+        let (preload_tx, preload_rx) = oneshot::channel();
+        target
+            .queued_events
+            .push_back(TargetEvent::AddPreloadScript {
+                params: AddScriptToEvaluateOnNewDocumentParams::new("globalThis.ready = true"),
+                tx: preload_tx,
+            });
+        let (ack_tx, ack_rx) = oneshot::channel();
+        target
+            .queued_events
+            .push_back(TargetEvent::FanOutAckBatch(FanOutAckBatch {
+                ack_reqs: vec![wire_request(1, Some(&main))],
+                send_only_reqs: vec![],
+                ack_tx,
+                main_session_id: main,
+            }));
+
+        target.fail_all_queued_events();
+
+        assert!(target.queued_events.is_empty());
+        assert!(matches!(
+            block_on(command_rx).expect("command sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(matches!(
+            block_on(navigate_rx).expect("navigation sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+        assert_eq!(
+            block_on(wait_rx).expect("wait sender resolves"),
+            Err(FrameWaitError::FrameSwappedOrDetached)
+        );
+        assert!(matches!(
+            block_on(preload_rx).expect("preload sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+        assert!(matches!(
+            block_on(ack_rx).expect("fan-out ack sender resolves"),
+            Err(CdpError::NoResponse)
+        ));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,11 @@ pub use crate::element::Element;
 pub use crate::error::Result;
 #[cfg(feature = "fetcher")]
 pub use crate::fetcher::{BrowserFetcher, BrowserFetcherOptions};
+pub use crate::frame::Frame;
 pub use crate::handler::Handler;
-pub use crate::page::Page;
+pub use crate::page::{
+    ContinueRequestOverrides, FulfillResponse, Page, PausedRequest, PausedRequestStream,
+};
 
 pub mod auth;
 pub mod browser;
@@ -83,6 +86,7 @@ pub mod conn;
 pub mod detection;
 pub mod element;
 pub mod error;
+pub mod frame;
 #[cfg(feature = "fetcher")]
 pub mod fetcher {
     pub use chromiumoxide_fetcher::*;

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,17 +1,22 @@
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::channel::mpsc::unbounded;
+use futures::channel::mpsc::{UnboundedReceiver, unbounded};
 use futures::channel::oneshot::channel as oneshot_channel;
-use futures::{SinkExt, StreamExt, stream};
+use futures::{SinkExt, Stream, StreamExt, stream};
 
 use chromiumoxide_cdp::cdp::browser_protocol::dom::*;
 use chromiumoxide_cdp::cdp::browser_protocol::emulation::{
     MediaFeature, SetEmulatedMediaParams, SetGeolocationOverrideParams, SetLocaleOverrideParams,
     SetTimezoneOverrideParams,
 };
+use chromiumoxide_cdp::cdp::browser_protocol::fetch::{
+    ContinueRequestParams, EventRequestPaused, FailRequestParams, FulfillRequestParams, HeaderEntry,
+};
 use chromiumoxide_cdp::cdp::browser_protocol::network::{
-    Cookie, CookieParam, DeleteCookiesParams, GetCookiesParams, SetCookiesParams,
+    Cookie, CookieParam, DeleteCookiesParams, ErrorReason, GetCookiesParams, SetCookiesParams,
     SetUserAgentOverrideParams,
 };
 use chromiumoxide_cdp::cdp::browser_protocol::page::*;
@@ -29,11 +34,13 @@ use chromiumoxide_types::*;
 use crate::auth::Credentials;
 use crate::element::Element;
 use crate::error::{CdpError, Result};
+use crate::frame::Frame;
 use crate::handler::PageInner;
 use crate::handler::commandfuture::CommandFuture;
 use crate::handler::domworld::DOMWorldKind;
+use crate::handler::frame::HTTP_RESPONSE_CODE_FAILURE;
 use crate::handler::httpfuture::HttpFuture;
-use crate::handler::target::{GetName, GetParent, GetUrl, TargetMessage};
+use crate::handler::target::{GetName, GetParent, GetUrl, InternalTargetMessage, TargetMessage};
 use crate::js::{Evaluation, EvaluationResult};
 use crate::layout::Point;
 use crate::listeners::{EventListenerRequest, EventStream};
@@ -42,6 +49,222 @@ use crate::{ArcHttpRequest, utils};
 #[derive(Debug, Clone)]
 pub struct Page {
     inner: Arc<PageInner>,
+}
+
+/// A Fetch-intercepted request and its at-most-once response capability.
+///
+/// Each response method consumes the handle and always addresses the request
+/// id and CDP session captured when Chrome emitted the pause. Dropping a handle
+/// does not continue the request; callers must explicitly continue, fulfill,
+/// or fail every delivered request they want to release.
+#[derive(Debug)]
+#[must_use = "an unanswered paused request blocks the page; call continue_request, fulfill, or fail to release it"]
+pub struct PausedRequest {
+    pub(crate) event: Arc<EventRequestPaused>,
+    pub(crate) session_id: SessionId,
+    pub(crate) commands: futures::channel::mpsc::Sender<TargetMessage>,
+}
+
+impl PausedRequest {
+    pub(crate) fn new(
+        event: Arc<EventRequestPaused>,
+        session_id: SessionId,
+        commands: futures::channel::mpsc::Sender<TargetMessage>,
+    ) -> Self {
+        Self {
+            event,
+            session_id,
+            commands,
+        }
+    }
+
+    /// Returns the original Fetch pause event for request inspection.
+    pub fn event(&self) -> &EventRequestPaused {
+        self.event.as_ref()
+    }
+
+    /// Continues the request without overriding any request fields.
+    pub async fn continue_request(self) -> Result<()> {
+        self.continue_with(ContinueRequestOverrides::default())
+            .await
+    }
+
+    /// Continues the request with optional URL, method, body, header, or
+    /// response-stage overrides.
+    pub async fn continue_with(self, overrides: ContinueRequestOverrides) -> Result<()> {
+        let ContinueRequestOverrides {
+            url,
+            method,
+            post_data,
+            headers,
+            intercept_response,
+        } = overrides;
+        let request_id = self.event.request_id.clone();
+        self.respond(ContinueRequestParams {
+            request_id,
+            url,
+            method,
+            post_data,
+            headers,
+            intercept_response,
+        })
+        .await
+    }
+
+    /// Completes the request with a synthetic response.
+    pub async fn fulfill(self, response: FulfillResponse) -> Result<()> {
+        let FulfillResponse {
+            response_code,
+            response_headers,
+            binary_response_headers,
+            body,
+            response_phrase,
+        } = response;
+        let request_id = self.event.request_id.clone();
+        self.respond(FulfillRequestParams {
+            request_id,
+            response_code,
+            response_headers,
+            binary_response_headers,
+            body,
+            response_phrase,
+        })
+        .await
+    }
+
+    /// Fails the request with the supplied network error reason.
+    pub async fn fail(self, reason: ErrorReason) -> Result<()> {
+        let request_id = self.event.request_id.clone();
+        self.respond(FailRequestParams::new(request_id, reason))
+            .await
+    }
+
+    async fn respond<T: Command>(self, command: T) -> Result<()> {
+        CommandFuture::new(command, self.commands, Some(self.session_id))?.await?;
+        Ok(())
+    }
+}
+
+/// Optional request-field replacements for [`PausedRequest::continue_with`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ContinueRequestOverrides {
+    /// Replaces the request URL without exposing the replacement to page code.
+    pub url: Option<String>,
+    /// Replaces the HTTP method.
+    pub method: Option<String>,
+    /// Replaces the request body. The value is base64 encoded for CDP.
+    pub post_data: Option<Binary>,
+    /// Replaces the complete request header list.
+    pub headers: Option<Vec<HeaderEntry>>,
+    /// Overrides whether the response stage should also be intercepted.
+    pub intercept_response: Option<bool>,
+}
+
+/// A synthetic response for [`PausedRequest::fulfill`].
+///
+/// Header fields are private so callers cannot set both text and binary header
+/// representations. Use [`FulfillResponse::builder`] when supplying headers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FulfillResponse {
+    response_code: i64,
+    response_headers: Option<Vec<HeaderEntry>>,
+    binary_response_headers: Option<Binary>,
+    body: Option<Binary>,
+    response_phrase: Option<String>,
+}
+
+impl FulfillResponse {
+    /// Creates a response containing only its required status code.
+    pub fn new(response_code: i64) -> Self {
+        Self {
+            response_code,
+            response_headers: None,
+            binary_response_headers: None,
+            body: None,
+            response_phrase: None,
+        }
+    }
+
+    /// Creates a builder for an optional body, phrase, and one header format.
+    pub fn builder(response_code: i64) -> FulfillResponseBuilder {
+        FulfillResponseBuilder {
+            response_code,
+            response_headers: None,
+            binary_response_headers: None,
+            body: None,
+            response_phrase: None,
+        }
+    }
+}
+
+/// Builder for a [`FulfillResponse`] with mutually exclusive header formats.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FulfillResponseBuilder {
+    response_code: i64,
+    response_headers: Option<Vec<HeaderEntry>>,
+    binary_response_headers: Option<Binary>,
+    body: Option<Binary>,
+    response_phrase: Option<String>,
+}
+
+impl FulfillResponseBuilder {
+    /// Supplies UTF-8 response headers.
+    pub fn response_headers(mut self, headers: Vec<HeaderEntry>) -> Self {
+        self.response_headers = Some(headers);
+        self
+    }
+
+    /// Supplies NUL-separated binary response headers.
+    pub fn binary_response_headers(mut self, headers: Binary) -> Self {
+        self.binary_response_headers = Some(headers);
+        self
+    }
+
+    /// Supplies a base64-encoded response body.
+    pub fn body(mut self, body: Binary) -> Self {
+        self.body = Some(body);
+        self
+    }
+
+    /// Supplies a textual HTTP status phrase.
+    pub fn response_phrase(mut self, phrase: String) -> Self {
+        self.response_phrase = Some(phrase);
+        self
+    }
+
+    /// Validates the header representation and builds the response.
+    pub fn build(self) -> Result<FulfillResponse> {
+        if self.response_headers.is_some() && self.binary_response_headers.is_some() {
+            return Err(CdpError::msg(
+                "response_headers and binary_response_headers are mutually exclusive",
+            ));
+        }
+        Ok(FulfillResponse {
+            response_code: self.response_code,
+            response_headers: self.response_headers,
+            binary_response_headers: self.binary_response_headers,
+            body: self.body,
+            response_phrase: self.response_phrase,
+        })
+    }
+}
+
+/// The single managed stream of paused requests for a page.
+///
+/// Dropping the stream closes registration for future replacement but does not
+/// implicitly respond to requests already delivered into its buffer.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct PausedRequestStream {
+    inner: UnboundedReceiver<PausedRequest>,
+}
+
+impl Stream for PausedRequestStream {
+    type Item = PausedRequest;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
 }
 
 impl Page {
@@ -312,15 +535,42 @@ impl Page {
     /// ```
     pub async fn event_listener<T: IntoEventKind>(&self) -> Result<EventStream<T>> {
         let (tx, rx) = unbounded();
+        let (ack_tx, ack_rx) = oneshot_channel();
         self.inner
-            .sender()
+            .internal_sender()
             .clone()
-            .send(TargetMessage::AddEventListener(
-                EventListenerRequest::new::<T>(tx),
-            ))
+            .send(InternalTargetMessage::RegisterEventListener {
+                request: EventListenerRequest::new::<T>(tx),
+                tx: ack_tx,
+            })
             .await?;
+        ack_rx.await??;
 
         Ok(EventStream::new(rx))
+    }
+
+    /// Registers the page's single managed Fetch interception responder.
+    ///
+    /// Register the stream before enabling request interception when the first
+    /// navigation request must be observed. A second live stream is rejected;
+    /// after a stream is dropped, a later registration may replace it. Dropping
+    /// the stream or a delivered [`PausedRequest`] does not implicitly release
+    /// requests that have already been delivered.
+    pub async fn paused_requests(&self) -> Result<PausedRequestStream> {
+        let (events, inner) = unbounded();
+        let (tx, rx) = oneshot_channel();
+        self.inner
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::RegisterPausedRequestStream {
+                events,
+                commands: self.inner.sender().clone(),
+                tx,
+            })
+            .await?;
+        rx.await??;
+
+        Ok(PausedRequestStream { inner })
     }
 
     pub async fn expose_function(
@@ -364,7 +614,9 @@ impl Page {
     pub async fn goto(&self, params: impl Into<NavigateParams>) -> Result<&Self> {
         let res = self.execute(params.into()).await?;
         if let Some(err) = res.result.error_text {
-            return Err(CdpError::ChromeMessage(err));
+            if !err.is_empty() && err != HTTP_RESPONSE_CODE_FAILURE {
+                return Err(CdpError::ChromeMessage(err));
+            }
         }
 
         Ok(self)
@@ -399,12 +651,41 @@ impl Page {
         Ok(rx.await?)
     }
 
+    /// Sets credentials used to answer Fetch authentication challenges.
+    ///
+    /// On return, any required Fetch state change has been confirmed for the
+    /// main session and fully initialized child sessions visible at call time.
+    /// Await this before navigating a page or frame that requires credentials.
     pub async fn authenticate(&self, credentials: Credentials) -> Result<()> {
+        let (tx, rx) = oneshot_channel();
         self.inner
-            .sender()
+            .internal_sender()
             .clone()
-            .send(TargetMessage::Authenticate(credentials))
+            .send(InternalTargetMessage::SetCredentials { credentials, tx })
             .await?;
+        rx.await??;
+
+        Ok(())
+    }
+
+    /// Enables or disables managed Fetch request interception.
+    ///
+    /// On return, the setting has been confirmed by Chrome for the main
+    /// session and every fully initialized child session visible at call time.
+    ///
+    /// Response-confirmed, not deduplicated: every call re-emits and awaits a
+    /// real Chrome ACK, even when the value is unchanged. This is deliberate (a
+    /// short-circuit on an unchanged value could report success without Chrome
+    /// re-applying it after a prior failure), so avoid calling it redundantly in
+    /// a hot loop — each redundant call costs one CDP round-trip per session.
+    pub async fn set_request_interception(&self, enabled: bool) -> Result<()> {
+        let (tx, rx) = oneshot_channel();
+        self.inner
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::SetRequestInterception { enabled, tx })
+            .await?;
+        rx.await??;
 
         Ok(())
     }
@@ -467,6 +748,27 @@ impl Page {
         Ok(rx.await?)
     }
 
+    /// Return a session-pinned handle for the current main frame.
+    pub async fn main_frame(&self) -> Result<Option<Frame>> {
+        self.inner.main_frame().await
+    }
+
+    /// Return session-pinned handles for all currently bound frames.
+    ///
+    /// The returned list is a snapshot. Re-enumerate after frame attachment,
+    /// detachment, or a process swap before retrying a `FrameNotReady` operation.
+    pub async fn all_frames(&self) -> Result<Vec<Frame>> {
+        self.inner.all_frames().await
+    }
+
+    /// Return a fresh session-pinned handle for a frame identifier.
+    ///
+    /// A missing frame returns `Ok(None)`. A tracked frame that is temporarily
+    /// unbound returns [`CdpError::FrameNotReady`].
+    pub async fn frame_by_id(&self, frame_id: FrameId) -> Result<Option<Frame>> {
+        self.inner.frame_by_id(frame_id).await
+    }
+
     /// Allows overriding user agent with the given string.
     pub async fn set_user_agent(
         &self,
@@ -495,16 +797,28 @@ impl Page {
     ///
     /// Execute a query selector on the document's node.
     pub async fn find_element(&self, selector: impl Into<String>) -> Result<Element> {
+        let frame_id = self
+            .main_frame()
+            .await?
+            .ok_or(CdpError::FrameNotReady)?
+            .id()
+            .clone();
         let root = self.get_document().await?.node_id;
         let node_id = self.inner.find_element(selector, root).await?;
-        Element::new(Arc::clone(&self.inner), node_id).await
+        Element::new(Arc::clone(&self.inner), node_id, frame_id).await
     }
 
     /// Return all `Element`s in the document that match the given selector
     pub async fn find_elements(&self, selector: impl Into<String>) -> Result<Vec<Element>> {
+        let frame_id = self
+            .main_frame()
+            .await?
+            .ok_or(CdpError::FrameNotReady)?
+            .id()
+            .clone();
         let root = self.get_document().await?.node_id;
         let node_ids = self.inner.find_elements(selector, root).await?;
-        Element::from_nodes(&self.inner, &node_ids).await
+        Element::from_nodes(&self.inner, &node_ids, frame_id).await
     }
 
     /// Returns the first element in the document which matches the given xpath
@@ -512,16 +826,34 @@ impl Page {
     ///
     /// Execute a xpath selector on the document's node.
     pub async fn find_xpath(&self, selector: impl Into<String>) -> Result<Element> {
+        let frame_id = self
+            .main_frame()
+            .await?
+            .ok_or(CdpError::FrameNotReady)?
+            .id()
+            .clone();
         self.get_document().await?;
-        let node_id = self.inner.find_xpaths(selector).await?[0];
-        Element::new(Arc::clone(&self.inner), node_id).await
+        let node_id = self
+            .inner
+            .find_xpaths(selector)
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(CdpError::NotFound)?;
+        Element::new(Arc::clone(&self.inner), node_id, frame_id).await
     }
 
     /// Return all `Element`s in the document that match the given xpath selector
     pub async fn find_xpaths(&self, selector: impl Into<String>) -> Result<Vec<Element>> {
+        let frame_id = self
+            .main_frame()
+            .await?
+            .ok_or(CdpError::FrameNotReady)?
+            .id()
+            .clone();
         self.get_document().await?;
         let node_ids = self.inner.find_xpaths(selector).await?;
-        Element::from_nodes(&self.inner, &node_ids).await
+        Element::from_nodes(&self.inner, &node_ids, frame_id).await
     }
 
     /// Describes node given its id
@@ -1258,6 +1590,15 @@ impl Page {
     /// - Injecting polyfills
     /// - Setting up global variables
     ///
+    /// The default CDP behavior is preserved: the script runs in future document
+    /// contexts and is not evaluated immediately in already-loaded frames. The
+    /// returned future completes after the main-session registration succeeds and
+    /// registrations for known child sessions have been queued.
+    ///
+    /// A timeout is inherently ambiguous because Chrome may have applied the main
+    /// command without delivering its response. In that rare case the script can
+    /// exist in the main session without being tracked for child-session replay.
+    ///
     /// # Example
     /// ```
     /// # use chromiumoxide::page::Page;
@@ -1275,7 +1616,16 @@ impl Page {
         &self,
         script: impl Into<AddScriptToEvaluateOnNewDocumentParams>,
     ) -> Result<ScriptIdentifier> {
-        Ok(self.execute(script.into()).await?.result.identifier)
+        let (tx, rx) = oneshot_channel();
+        self.inner
+            .internal_sender()
+            .clone()
+            .send(InternalTargetMessage::AddPreloadScript {
+                params: script.into(),
+                tx,
+            })
+            .await?;
+        rx.await?
     }
 
     /// Alias for `evaluate_on_new_document` - familiar to Playwright users.
@@ -1513,5 +1863,133 @@ impl From<MediaTypeParams> for String {
             MediaTypeParams::Screen => "screen".to_string(),
             MediaTypeParams::Print => "print".to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+
+    use futures::StreamExt;
+    use futures::channel::mpsc;
+    use futures::executor::block_on;
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct CapturedCommand {
+        method: String,
+        session_id: Option<SessionId>,
+        params: serde_json::Value,
+    }
+
+    fn paused_request(id: &str) -> EventRequestPaused {
+        serde_json::from_value(json!({
+            "requestId": id,
+            "request": {
+                "url": "https://paused.example/",
+                "method": "POST",
+                "headers": {},
+                "initialPriority": "High",
+                "referrerPolicy": "no-referrer"
+            },
+            "frameId": "frame",
+            "resourceType": "Document"
+        }))
+        .expect("requestPaused fixture is valid")
+    }
+
+    fn response_handle(
+        request_id: &str,
+        session_id: &str,
+    ) -> (PausedRequest, mpsc::Receiver<TargetMessage>) {
+        let (commands, receiver) = mpsc::channel(1);
+        (
+            PausedRequest::new(
+                Arc::new(paused_request(request_id)),
+                SessionId::new(session_id),
+                commands,
+            ),
+            receiver,
+        )
+    }
+
+    fn capture_response<F>(
+        future: F,
+        mut receiver: mpsc::Receiver<TargetMessage>,
+    ) -> CapturedCommand
+    where
+        F: Future<Output = Result<()>>,
+    {
+        let (result, command) = block_on(async {
+            futures::join!(future, async {
+                let message = receiver.next().await.expect("response command is sent");
+                let TargetMessage::Command(command) = message else {
+                    panic!("paused response uses the command path")
+                };
+                let captured = CapturedCommand {
+                    method: command.method.as_ref().to_owned(),
+                    session_id: command.session_id.clone(),
+                    params: command.params.clone(),
+                };
+                let _ = command.sender.send(Err(CdpError::FrameNotReady));
+                captured
+            })
+        });
+        assert!(matches!(result, Err(CdpError::FrameNotReady)));
+        command
+    }
+
+    #[test]
+    fn paused_request_response_methods_force_captured_request_and_session() {
+        let (paused, receiver) = response_handle("continue-id", "continue-session");
+        let command = capture_response(
+            paused.continue_with(ContinueRequestOverrides {
+                url: Some("https://override.example/".to_owned()),
+                method: Some("PUT".to_owned()),
+                post_data: Some(Binary::from("cGF5bG9hZA==".to_owned())),
+                headers: Some(vec![HeaderEntry::new("x-test", "continue")]),
+                intercept_response: Some(true),
+            }),
+            receiver,
+        );
+        assert_eq!(command.method, "Fetch.continueRequest");
+        assert_eq!(command.session_id, Some(SessionId::new("continue-session")));
+        assert_eq!(command.params["requestId"], "continue-id");
+        assert_eq!(command.params["method"], "PUT");
+        assert_eq!(command.params["interceptResponse"], true);
+
+        let (paused, receiver) = response_handle("fulfill-id", "fulfill-session");
+        let response = FulfillResponse::builder(201)
+            .response_headers(vec![HeaderEntry::new("content-type", "text/plain")])
+            .body(Binary::from("b2s=".to_owned()))
+            .response_phrase("Created".to_owned())
+            .build()
+            .expect("one header representation is valid");
+        let command = capture_response(paused.fulfill(response), receiver);
+        assert_eq!(command.method, "Fetch.fulfillRequest");
+        assert_eq!(command.session_id, Some(SessionId::new("fulfill-session")));
+        assert_eq!(command.params["requestId"], "fulfill-id");
+        assert_eq!(command.params["responseCode"], 201);
+        assert_eq!(command.params["body"], "b2s=");
+
+        let (paused, receiver) = response_handle("fail-id", "fail-session");
+        let command = capture_response(paused.fail(ErrorReason::Aborted), receiver);
+        assert_eq!(command.method, "Fetch.failRequest");
+        assert_eq!(command.session_id, Some(SessionId::new("fail-session")));
+        assert_eq!(command.params["requestId"], "fail-id");
+        assert_eq!(command.params["errorReason"], "Aborted");
+    }
+
+    #[test]
+    fn fulfill_response_rejects_both_header_representations() {
+        let result = FulfillResponse::builder(200)
+            .response_headers(vec![HeaderEntry::new("x-test", "text")])
+            .binary_response_headers(Binary::from("eC10ZXN0OiBiaW5hcnkA".to_owned()))
+            .build();
+        assert!(
+            matches!(result, Err(CdpError::ChromeMessage(message)) if message.contains("mutually exclusive"))
+        );
     }
 }

--- a/tests/compatibility.rs
+++ b/tests/compatibility.rs
@@ -1,0 +1,193 @@
+use std::time::Duration;
+
+use chromiumoxide::auth::Credentials;
+use chromiumoxide::cdp::browser_protocol::dom::NodeId;
+use chromiumoxide::cdp::browser_protocol::fetch::{EventAuthRequired, EventRequestPaused};
+use chromiumoxide::cdp::browser_protocol::network::{
+    EventLoadingFailed, EventLoadingFinished, EventRequestServedFromCache, EventRequestWillBeSent,
+    EventResponseReceived, InterceptionId, LoaderId, RequestId,
+};
+use chromiumoxide::cdp::browser_protocol::page::{
+    CrossOriginIsolatedContextType, EventFrameStartedLoading, EventFrameStoppedLoading,
+    EventLifecycleEvent, EventNavigatedWithinDocument, Frame as CdpFrame, FrameId, FrameTree,
+    GatedApiFeatures, SecureContextType,
+};
+use chromiumoxide::cdp::browser_protocol::target::{EventAttachedToTarget, TargetId, TargetInfo};
+use chromiumoxide::cdp::js_protocol::runtime::{
+    EventBindingCalled, EventExecutionContextCreated, EventExecutionContextDestroyed,
+    ExecutionContextId,
+};
+use chromiumoxide::cmd::{CommandChain, CommandMessage};
+use chromiumoxide::error::Result;
+use chromiumoxide::handler::browser::BrowserContext;
+use chromiumoxide::handler::domworld::DOMWorldKind;
+use chromiumoxide::handler::frame::{
+    FrameManager, FrameNavigationRequest, NavigationId, NavigationWatcher,
+};
+use chromiumoxide::handler::http::HttpRequest;
+use chromiumoxide::handler::network::{NetworkEvent, NetworkManager};
+use chromiumoxide::handler::target::{GetExecutionContext, Target, TargetConfig, TargetMessage};
+use chromiumoxide::types::{CallId, Request, Response};
+use chromiumoxide::{ContinueRequestOverrides, Element, FulfillResponse, PausedRequest};
+use futures::channel::oneshot;
+use serde_json::json;
+use static_assertions::assert_not_impl_any;
+
+assert_not_impl_any!(PausedRequest: Clone);
+
+// Kept as one alias because the exact five-argument constructor signature is
+// the compatibility contract being checked here.
+#[allow(clippy::type_complexity)]
+type HttpRequestConstructor =
+    fn(RequestId, Option<FrameId>, Option<InterceptionId>, bool, Vec<HttpRequest>) -> HttpRequest;
+
+fn assert_element_node_id_is_optional(element: &Element) {
+    let _: &Option<NodeId> = &element.node_id;
+}
+
+fn exhaustively_match_target_message(message: TargetMessage) {
+    match message {
+        TargetMessage::Command(_) => {}
+        TargetMessage::MainFrame(_) => {}
+        TargetMessage::AllFrames(_) => {}
+        TargetMessage::Url(_) => {}
+        TargetMessage::Name(_) => {}
+        TargetMessage::Parent(_) => {}
+        TargetMessage::WaitForNavigation(_) => {}
+        TargetMessage::AddEventListener(_) => {}
+        TargetMessage::GetExecutionContext(_) => {}
+        TargetMessage::Authenticate(_) => {}
+    }
+}
+
+fn exhaustively_match_network_event(event: NetworkEvent) {
+    match event {
+        NetworkEvent::SendCdpRequest(_) => {}
+        NetworkEvent::Request(_) => {}
+        NetworkEvent::Response(_) => {}
+        NetworkEvent::RequestFailed(_) => {}
+        NetworkEvent::RequestFinished(_) => {}
+    }
+}
+
+#[test]
+fn legacy_public_contracts_compile() {
+    let _continue_overrides = ContinueRequestOverrides::default();
+    let _fulfill_response = FulfillResponse::new(200);
+    let (context_tx, _context_rx) = oneshot::channel::<Option<ExecutionContextId>>();
+    let context = GetExecutionContext {
+        dom_world: DOMWorldKind::Main,
+        frame_id: None,
+        tx: context_tx,
+    };
+    let message = TargetMessage::GetExecutionContext(context);
+    exhaustively_match_target_message(message);
+
+    let _target_message_match: fn(TargetMessage) = exhaustively_match_target_message;
+    let _network_event_match: fn(NetworkEvent) = exhaustively_match_network_event;
+    let _element_node_id_contract: fn(&Element) = assert_element_node_id_is_optional;
+
+    let _navigate_frame: fn(&mut FrameManager, FrameId, FrameNavigationRequest) =
+        FrameManager::navigate_frame;
+    let _until_page_load: fn(NavigationId, FrameId, Option<LoaderId>) -> NavigationWatcher =
+        NavigationWatcher::until_page_load;
+    let _attached_to_target: fn(&mut FrameManager, &EventAttachedToTarget) =
+        FrameManager::on_attached_to_target;
+    let _frame_tree: fn(&mut FrameManager, FrameTree) = FrameManager::on_frame_tree;
+    let _frame_attached: fn(&mut FrameManager, FrameId, Option<FrameId>) =
+        FrameManager::on_frame_attached;
+    let _frame_navigated: fn(&mut FrameManager, &CdpFrame) = FrameManager::on_frame_navigated;
+    let _within_document: fn(&mut FrameManager, &EventNavigatedWithinDocument) =
+        FrameManager::on_frame_navigated_within_document;
+    let _frame_stopped: fn(&mut FrameManager, &EventFrameStoppedLoading) =
+        FrameManager::on_frame_stopped_loading;
+    let _frame_started: fn(&mut FrameManager, &EventFrameStartedLoading) =
+        FrameManager::on_frame_started_loading;
+    let _binding_called: fn(&mut FrameManager, &EventBindingCalled) =
+        FrameManager::on_runtime_binding_called;
+    let _context_created: fn(&mut FrameManager, &EventExecutionContextCreated) =
+        FrameManager::on_frame_execution_context_created;
+    let _context_destroyed: fn(&mut FrameManager, &EventExecutionContextDestroyed) =
+        FrameManager::on_frame_execution_context_destroyed;
+    let _contexts_cleared: fn(&mut FrameManager) = FrameManager::on_execution_contexts_cleared;
+    let _lifecycle: fn(&mut FrameManager, &EventLifecycleEvent) =
+        FrameManager::on_page_lifecycle_event;
+    let _isolated_world: fn(&mut FrameManager, &str) -> Option<CommandChain> =
+        FrameManager::ensure_isolated_world;
+
+    let _fetch_paused: fn(&mut NetworkManager, &EventRequestPaused) =
+        NetworkManager::on_fetch_request_paused;
+    let _auth_required: fn(&mut NetworkManager, &EventAuthRequired) =
+        NetworkManager::on_fetch_auth_required;
+    let _request_will_be_sent: fn(&mut NetworkManager, &EventRequestWillBeSent) =
+        NetworkManager::on_request_will_be_sent;
+    let _served_from_cache: fn(&mut NetworkManager, &EventRequestServedFromCache) =
+        NetworkManager::on_request_served_from_cache;
+    let _response_received: fn(&mut NetworkManager, &EventResponseReceived) =
+        NetworkManager::on_response_received;
+    let _loading_finished: fn(&mut NetworkManager, &EventLoadingFinished) =
+        NetworkManager::on_network_loading_finished;
+    let _loading_failed: fn(&mut NetworkManager, &EventLoadingFailed) =
+        NetworkManager::on_network_loading_failed;
+
+    let _target_response: fn(&mut Target, Response, &str) = Target::on_response;
+    let _http_request_new: HttpRequestConstructor = HttpRequest::new;
+
+    let (command_tx, _command_rx) = oneshot::channel::<Result<Response>>();
+    let command = CommandMessage {
+        method: "Runtime.evaluate".into(),
+        session_id: None,
+        params: json!({}),
+        sender: command_tx,
+    };
+    exhaustively_match_target_message(TargetMessage::Command(command));
+    exhaustively_match_target_message(TargetMessage::Authenticate(Credentials {
+        username: String::new(),
+        password: String::new(),
+    }));
+}
+
+#[test]
+fn legacy_standalone_handlers_do_not_require_session_binding() {
+    let mut frames = FrameManager::new(Duration::from_millis(100));
+    let cdp_frame = CdpFrame::builder()
+        .id(FrameId::new("frame"))
+        .loader_id(LoaderId::new("loader"))
+        .url("about:blank")
+        .domain_and_registry("")
+        .security_origin("://")
+        .mime_type("text/html")
+        .secure_context_type(SecureContextType::SecureLocalhost)
+        .cross_origin_isolated_context_type(CrossOriginIsolatedContextType::NotIsolated)
+        .gated_api_features(Vec::<GatedApiFeatures>::new())
+        .build()
+        .expect("frame fixture has all mandatory fields");
+    frames.on_frame_navigated(&cdp_frame);
+    frames.on_execution_contexts_cleared();
+    frames.navigate_frame(
+        FrameId::new("frame"),
+        FrameNavigationRequest::new(
+            chromiumoxide::handler::frame::NavigationId(1),
+            Request::new("Page.navigate".into(), json!({ "url": "about:blank" })),
+        ),
+    );
+
+    let info = TargetInfo::builder()
+        .target_id(TargetId::new("target"))
+        .r#type("page")
+        .title("test")
+        .url("about:blank")
+        .attached(true)
+        .can_access_opener(false)
+        .build()
+        .expect("target fixture has all mandatory fields");
+    let mut target = Target::new(info, TargetConfig::default(), BrowserContext::default());
+    target.on_response(
+        Response {
+            id: CallId::new(1),
+            result: None,
+            error: None,
+        },
+        "Runtime.enable",
+    );
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,7 +4,9 @@ use chromiumoxide::{Browser, BrowserConfig};
 use futures::{FutureExt, StreamExt};
 
 mod basic;
+mod compatibility;
 mod config;
+mod oopif;
 mod page;
 mod stealth;
 
@@ -15,10 +17,17 @@ where
     test_config(BrowserConfig::builder().build().unwrap(), test).await;
 }
 
-pub async fn test_config<T>(config: BrowserConfig, test: T)
+pub async fn test_config<T>(mut config: BrowserConfig, test: T)
 where
     T: for<'a> AsyncFnOnce(&'a mut Browser),
 {
+    let _profile = if config.user_data_dir.is_none() {
+        let profile = tempfile::tempdir().expect("temporary browser profile can be created");
+        config.user_data_dir = Some(profile.path().to_path_buf());
+        Some(profile)
+    } else {
+        None
+    };
     let (mut browser, mut handler) = Browser::launch(config).await.unwrap();
 
     let handle = tokio::spawn(async move {

--- a/tests/oopif.rs
+++ b/tests/oopif.rs
@@ -1,0 +1,1131 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, LazyLock, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use chromiumoxide::auth::Credentials;
+use chromiumoxide::cdp::browser_protocol::fetch::ContinueRequestParams;
+use chromiumoxide::cdp::browser_protocol::network::ErrorReason;
+use chromiumoxide::cdp::browser_protocol::page::{FrameId, GetFrameTreeParams};
+use chromiumoxide::error::CdpError;
+use chromiumoxide::{BrowserConfig, Element, Frame, Page};
+use futures::StreamExt;
+
+use crate::test_config;
+
+const FRAME_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_PARALLEL_OOPIF_BROWSERS: usize = 2;
+
+static OOPIF_BROWSER_SLOTS: LazyLock<(Mutex<usize>, Condvar)> =
+    LazyLock::new(|| (Mutex::new(0), Condvar::new()));
+
+struct OopifBrowserSlot;
+
+impl OopifBrowserSlot {
+    fn acquire() -> Self {
+        let (active, available) = &*OOPIF_BROWSER_SLOTS;
+        let mut active = active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while *active >= MAX_PARALLEL_OOPIF_BROWSERS {
+            active = available
+                .wait(active)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        *active += 1;
+        Self
+    }
+}
+
+impl Drop for OopifBrowserSlot {
+    fn drop(&mut self) {
+        let (active, available) = &*OOPIF_BROWSER_SLOTS;
+        let mut active = active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *active -= 1;
+        available.notify_one();
+    }
+}
+
+struct OopifProfile {
+    path: PathBuf,
+}
+
+impl OopifProfile {
+    fn create(port: u16) -> std::io::Result<Self> {
+        let path =
+            std::env::temp_dir().join(format!("chromiumoxide-oopif-{}-{port}", std::process::id()));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for OopifProfile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn oopif_config(profile: &OopifProfile) -> BrowserConfig {
+    BrowserConfig::builder()
+        .new_headless_mode()
+        .disable_https_first()
+        .request_timeout(FRAME_TIMEOUT)
+        .user_data_dir(profile.path())
+        .args(["--site-per-process", "--no-proxy-server"])
+        .build()
+        .expect("browser config is valid")
+}
+
+struct OopifServer {
+    _browser_slot: OopifBrowserSlot,
+    port: u16,
+    stop: Arc<AtomicBool>,
+    nested_served: Arc<AtomicBool>,
+    requests: Arc<Mutex<HashMap<(String, String), usize>>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl OopifServer {
+    fn start() -> std::io::Result<Self> {
+        let browser_slot = OopifBrowserSlot::acquire();
+        let listener = TcpListener::bind("0.0.0.0:0")?;
+        listener.set_nonblocking(true)?;
+        let port = listener.local_addr()?.port();
+        let stop = Arc::new(AtomicBool::new(false));
+        let nested_served = Arc::new(AtomicBool::new(false));
+        let requests = Arc::new(Mutex::new(HashMap::new()));
+        let thread_stop = Arc::clone(&stop);
+        let thread_nested_served = Arc::clone(&nested_served);
+        let thread_requests = Arc::clone(&requests);
+        let thread = std::thread::spawn(move || {
+            while !thread_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        serve_connection(stream, port, &thread_nested_served, &thread_requests);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Ok(Self {
+            _browser_slot: browser_slot,
+            port,
+            stop,
+            nested_served,
+            requests,
+            thread: Some(thread),
+        })
+    }
+
+    fn url(&self, host: &str, path: &str) -> String {
+        format!("http://{host}:{}{path}", self.port)
+    }
+
+    fn nested_served(&self) -> bool {
+        self.nested_served.load(Ordering::Acquire)
+    }
+
+    fn request_count(&self, host: &str, path: &str) -> usize {
+        self.requests
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&(host.to_owned(), path.to_owned()))
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for OopifServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn serve_connection(
+    mut stream: TcpStream,
+    port: u16,
+    nested_served: &AtomicBool,
+    requests: &Mutex<HashMap<(String, String), usize>>,
+) {
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    while request.len() < 16 * 1024 {
+        let Ok(read) = stream.read(&mut buffer) else {
+            return;
+        };
+        if read == 0 {
+            return;
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let request = String::from_utf8_lossy(&request);
+    let mut lines = request.lines();
+    let path = lines
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|target| target.split('?').next())
+        .unwrap_or("/");
+    let mut host = "";
+    let mut authorization = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("host") {
+            host = value.trim().split(':').next().unwrap_or_default();
+        } else if name.eq_ignore_ascii_case("authorization") {
+            authorization = Some(value.trim());
+        }
+    }
+    *requests
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .entry((host.to_owned(), path.to_owned()))
+        .or_default() += 1;
+
+    let authorized = authorization == Some("Basic dXNlcjpwYXNz");
+    let (status, body, delayed_nested) = route(host, path, port, authorized);
+    if delayed_nested {
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    let challenge = if status == "401 Unauthorized" {
+        "WWW-Authenticate: Basic realm=\"chromiumoxide\"\r\n"
+    } else {
+        ""
+    };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\n{challenge}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    if stream.write_all(response.as_bytes()).is_ok() && delayed_nested {
+        nested_served.store(true, Ordering::Release);
+    }
+}
+
+fn route(host: &str, path: &str, port: u16, authorized: bool) -> (&'static str, String, bool) {
+    match (host, path) {
+        ("localhost", "/main") => (
+            "200 OK",
+            format!(
+                r#"<!doctype html><style>
+                html, body {{ margin: 0; width: 100%; height: 100%; }}
+                #oop {{ position: absolute; left: 180px; top: 100px; width: 500px; height: 300px;
+                        border: 9px solid rgb(20, 30, 40); padding: 6px; }}
+                #swap {{ position: absolute; left: 10px; top: 470px; width: 120px; height: 80px; }}
+                </style><body data-role="main">
+                <iframe id="oop" src="http://127.0.0.1:{port}/child"></iframe>
+                <iframe id="swap" src="http://localhost:{port}/same"></iframe>
+                </body>"#
+            ),
+            false,
+        ),
+        ("localhost", "/same") => ("200 OK", page("same"), false),
+        ("localhost", "/same-waited") => ("200 OK", page("same-waited"), false),
+        ("localhost", "/same-return") => ("200 OK", page("same-return"), false),
+        ("localhost", "/auth-main") => (
+            "200 OK",
+            format!(
+                r#"<!doctype html><body data-role="auth-main">
+                <iframe id="auth" src="http://127.0.0.1:{port}/auth-child"></iframe>
+                </body>"#
+            ),
+            false,
+        ),
+        ("127.0.0.1", "/child") => (
+            "200 OK",
+            format!(
+                r#"<!doctype html><style>
+                html, body {{ margin: 0; width: 100%; height: 100%; }}
+                button {{ box-sizing: border-box; }}
+                #child-button {{ position: absolute; left: 20px; top: 20px; width: 100px; height: 40px; }}
+                #container {{ position: absolute; left: 20px; top: 75px; }}
+                #same-descendant {{ position: absolute; left: 20px; top: 130px; width: 180px; height: 120px;
+                                    border: 7px solid rgb(50, 60, 70); padding: 3px; }}
+                #nested {{ position: absolute; left: 250px; top: 130px; width: 180px; height: 120px;
+                           border: 8px solid rgb(80, 90, 100); padding: 4px; }}
+                </style><body data-role="oop-child">
+                <button id="child-button" onclick="document.body.dataset.clicked='child'">child</button>
+                <div id="container"><span class="item">first</span><span class="item">second</span></div>
+                <iframe id="same-descendant" src="http://127.0.0.1:{port}/same-descendant"></iframe>
+                <iframe id="nested" src="http://127.0.0.2:{port}/nested"></iframe>
+                </body>"#
+            ),
+            false,
+        ),
+        ("127.0.0.1", "/same-descendant") => (
+            "200 OK",
+            interactive_page("same-descendant", "same", 15, 12),
+            false,
+        ),
+        ("127.0.0.1", "/swap-cross") => ("200 OK", page("swap-cross"), false),
+        ("127.0.0.1", "/child-nav") => ("200 OK", page("child-nav"), false),
+        ("127.0.0.1", "/child-nav-2") => ("200 OK", page("child-nav-2"), false),
+        ("127.0.0.1", "/child-abort") => ("200 OK", page("child-abort"), false),
+        ("127.0.0.1", "/http-error") => ("404 Not Found", page("http-error"), false),
+        ("127.0.0.1", "/nested-return") => ("200 OK", page("nested-return"), false),
+        ("127.0.0.1", "/auth-child") if authorized => ("200 OK", page("auth-child"), false),
+        ("127.0.0.1", "/auth-child") => ("401 Unauthorized", page("auth-required"), false),
+        ("127.0.0.2", "/nested") => (
+            "200 OK",
+            interactive_page("nested-oop", "nested", 18, 14),
+            true,
+        ),
+        _ => ("404 Not Found", page("not-found"), false),
+    }
+}
+
+fn page(role: &str) -> String {
+    format!(r#"<!doctype html><body data-role="{role}">{role}</body>"#)
+}
+
+fn interactive_page(role: &str, clicked: &str, left: u32, top: u32) -> String {
+    format!(
+        r#"<!doctype html><style>
+        html, body {{ margin: 0; width: 100%; height: 100%; }}
+        #target {{ position: absolute; left: {left}px; top: {top}px; width: 90px; height: 36px;
+                   box-sizing: border-box; }}
+        </style><body data-role="{role}">
+        <button id="target"
+                onmouseover="document.body.dataset.hovered='{clicked}'"
+                onclick="document.body.dataset.clicked='{clicked}'">{role}</button>
+        </body>"#
+    )
+}
+
+async fn wait_for_frame(
+    page: &Page,
+    description: &str,
+    predicate: impl Fn(&Frame) -> bool,
+) -> Frame {
+    tokio::time::timeout(FRAME_TIMEOUT, async {
+        loop {
+            if let Some(frame) = page
+                .all_frames()
+                .await
+                .expect("frame enumeration succeeds")
+                .into_iter()
+                .find(|frame| predicate(frame))
+            {
+                return frame;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {description}"))
+}
+
+async fn wait_for_url(page: &Page, path: &str) -> Frame {
+    wait_for_frame(page, path, |frame| {
+        frame.url().is_some_and(|url| {
+            url::Url::parse(&url)
+                .map(|url| url.path() == path)
+                .unwrap_or(false)
+        })
+    })
+    .await
+}
+
+async fn wait_for_binding(
+    page: &Page,
+    frame_id: &FrameId,
+    description: &str,
+    predicate: impl Fn(&Frame) -> bool,
+) -> Frame {
+    wait_for_frame(page, description, |frame| {
+        frame.id() == frame_id && predicate(frame)
+    })
+    .await
+}
+
+async fn wait_for_gone(page: &Page, frame_id: &FrameId) {
+    tokio::time::timeout(FRAME_TIMEOUT, async {
+        loop {
+            match page.frame_by_id(frame_id.clone()).await {
+                Ok(None) => return,
+                Ok(Some(_)) | Err(CdpError::FrameNotReady) => {}
+                Err(error) => panic!("frame lookup failed: {error}"),
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for frame removal");
+}
+
+async fn eval_string(frame: &Frame, expression: &str) -> String {
+    tokio::time::timeout(FRAME_TIMEOUT, async {
+        loop {
+            match frame.eval(expression.to_owned()).await {
+                Ok(result) => {
+                    return result
+                        .into_value::<String>()
+                        .expect("evaluation returns a string");
+                }
+                Err(CdpError::FrameNotReady) => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("frame evaluation failed: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for a frame execution context")
+}
+
+async fn query_element(frame: &Frame, selector: &str) -> Element {
+    tokio::time::timeout(FRAME_TIMEOUT, async {
+        loop {
+            match frame.query_selector(selector).await {
+                Ok(Some(element)) => return element,
+                Ok(None) => panic!("selector {selector:?} did not match"),
+                Err(CdpError::FrameNotReady) => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("frame selector failed: {error}"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for selector {selector:?}"))
+}
+
+fn assert_near(actual: f64, expected: f64, label: &str) {
+    assert!(
+        (actual - expected).abs() < 1.0,
+        "{label}: expected {expected}, got {actual}"
+    );
+}
+
+async fn set_iframe_src(page: &Page, id: &str, url: &str) {
+    let id = serde_json::to_string(id).expect("iframe id serializes");
+    let url = serde_json::to_string(url).expect("URL serializes");
+    page.evaluate(format!("document.getElementById({id}).src = {url}; true"))
+        .await
+        .expect("iframe navigation script succeeds");
+}
+
+async fn assert_stale(frame: &Frame) {
+    assert!(matches!(
+        frame.eval("1 + 1").await,
+        Err(CdpError::FrameNotReady)
+    ));
+    assert!(matches!(
+        frame.query_selector("body").await,
+        Err(CdpError::FrameNotReady)
+    ));
+    assert!(matches!(
+        frame.execute(GetFrameTreeParams::default()).await,
+        Err(CdpError::FrameNotReady)
+    ));
+    assert!(matches!(
+        frame.goto("about:blank").await,
+        Err(CdpError::FrameNotReady)
+    ));
+    assert!(matches!(
+        frame.wait_for_navigation().await,
+        Err(CdpError::FrameNotReady)
+    ));
+}
+
+#[tokio::test]
+async fn preload_scripts_replay_once_before_and_after_oopif_attach() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = oopif_config(&profile);
+
+    test_config(config, async |browser| {
+        let page = browser
+            .new_page("about:blank")
+            .await
+            .expect("page creation succeeds");
+        page.evaluate_on_new_document(
+            "globalThis.__earlyPreloadRuns = (globalThis.__earlyPreloadRuns || 0) + 1;",
+        )
+        .await
+        .expect("pre-attach script registration succeeds");
+
+        page.goto(server.url("localhost", "/main"))
+            .await
+            .expect("main navigation succeeds");
+        let child = wait_for_url(&page, "/child").await;
+        assert!(child.is_out_of_process());
+        assert_eq!(
+            eval_string(&child, "String(globalThis.__earlyPreloadRuns)").await,
+            "1"
+        );
+
+        page.add_init_script(
+            "globalThis.__latePreloadRuns = (globalThis.__latePreloadRuns || 0) + 1;",
+        )
+        .await
+        .expect("post-attach script registration reaches the existing child");
+        assert_eq!(
+            eval_string(&child, "String(globalThis.__latePreloadRuns)").await,
+            "undefined",
+            "the public API preserves Chrome's non-immediate default"
+        );
+
+        child
+            .goto(server.url("127.0.0.1", "/child-nav"))
+            .await
+            .expect("first child navigation succeeds");
+        assert_eq!(
+            eval_string(&child, "String(globalThis.__earlyPreloadRuns)").await,
+            "1",
+            "the snapshot registration is not duplicated by later fan-out"
+        );
+        assert_eq!(
+            eval_string(&child, "String(globalThis.__latePreloadRuns)").await,
+            "1",
+            "the post-attach registration runs on the next child document"
+        );
+
+        child
+            .goto(server.url("127.0.0.1", "/child-nav-2"))
+            .await
+            .expect("second child navigation succeeds");
+        assert_eq!(
+            eval_string(&child, "String(globalThis.__earlyPreloadRuns)").await,
+            "1"
+        );
+        assert_eq!(
+            eval_string(&child, "String(globalThis.__latePreloadRuns)").await,
+            "1"
+        );
+        assert_eq!(server.request_count("127.0.0.1", "/child"), 1);
+        assert_eq!(server.request_count("127.0.0.1", "/child-nav"), 1);
+        assert_eq!(server.request_count("127.0.0.1", "/child-nav-2"), 1);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn interception_uses_captured_oop_session_and_child_fallback() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = oopif_config(&profile);
+
+    test_config(config, async |browser| {
+        let page = browser
+            .new_page("about:blank")
+            .await
+            .expect("page creation succeeds");
+        let mut paused_requests = page
+            .paused_requests()
+            .await
+            .expect("managed pause stream registers before Fetch enable");
+        page.set_request_interception(true)
+            .await
+            .expect("Fetch enable is response-confirmed");
+
+        let main_url = server.url("localhost", "/main");
+        let mut navigation = Box::pin(page.goto(main_url.clone()));
+        let mut saw_main_document = false;
+        loop {
+            tokio::select! {
+                result = &mut navigation => {
+                    result.expect("main navigation succeeds after managed responses");
+                    break;
+                }
+                paused = paused_requests.next() => {
+                    let paused = paused.expect("pause stream remains live");
+                    if paused.event().request.url == main_url {
+                        saw_main_document = true;
+                    }
+                    paused
+                        .continue_request()
+                        .await
+                        .expect("captured-session continuation succeeds");
+                }
+            }
+        }
+        assert!(
+            saw_main_document,
+            "the first awaited main navigation was intercepted"
+        );
+
+        let child = wait_for_url(&page, "/child").await;
+        assert!(child.is_out_of_process());
+        page.set_request_interception(false)
+            .await
+            .expect("dynamic Fetch disable is response-confirmed");
+        page.set_request_interception(true)
+            .await
+            .expect("dynamic Fetch enable reaches the existing Done child");
+        let child_url = server.url("127.0.0.1", "/child-nav");
+        let mut child_navigation = Box::pin(child.goto(child_url.clone()));
+        let paused_child = loop {
+            tokio::select! {
+                result = &mut child_navigation => {
+                    panic!("child navigation completed before its pause was answered: {result:?}");
+                }
+                paused = paused_requests.next() => {
+                    let paused = paused.expect("pause stream remains live");
+                    if paused.event().request.url == child_url {
+                        break paused;
+                    }
+                    paused
+                        .continue_request()
+                        .await
+                        .expect("unrelated request is released");
+                }
+            }
+        };
+
+        let request_id = paused_child.event().request_id.clone();
+        let _raw_main_response = page.execute(ContinueRequestParams::new(request_id)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), child_navigation.as_mut())
+                .await
+                .is_err(),
+            "a main-session raw response must not release an OOP child request"
+        );
+        paused_child
+            .continue_request()
+            .await
+            .expect("the captured child-session response releases the request");
+        tokio::time::timeout(FRAME_TIMEOUT, child_navigation)
+            .await
+            .expect("child navigation stays bounded")
+            .expect("child navigation succeeds");
+
+        let aborted_url = server.url("127.0.0.1", "/child-abort");
+        let mut aborted_navigation = Box::pin(child.goto(aborted_url.clone()));
+        let aborted_pause = loop {
+            tokio::select! {
+                result = &mut aborted_navigation => {
+                    panic!("child abort navigation completed before pause delivery: {result:?}");
+                }
+                paused = paused_requests.next() => {
+                    let paused = paused.expect("pause stream remains live");
+                    if paused.event().request.url == aborted_url {
+                        break paused;
+                    }
+                    paused
+                        .continue_request()
+                        .await
+                        .expect("unrelated request is released");
+                }
+            }
+        };
+        aborted_pause
+            .fail(ErrorReason::Aborted)
+            .await
+            .expect("captured child-session failure succeeds");
+        assert!(
+            tokio::time::timeout(FRAME_TIMEOUT, aborted_navigation)
+                .await
+                .expect("aborted child navigation settles promptly")
+                .is_err()
+        );
+
+        drop(paused_requests);
+        tokio::time::timeout(
+            FRAME_TIMEOUT,
+            child.goto(server.url("127.0.0.1", "/child-nav-2")),
+        )
+        .await
+        .expect("closed-stream child fallback stays bounded")
+        .expect("closed-stream child pause auto-continues");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn authentication_fanout_reaches_an_existing_oopif() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = oopif_config(&profile);
+
+    test_config(config, async |browser| {
+        let page = browser
+            .new_page(server.url("localhost", "/main"))
+            .await
+            .expect("page creation succeeds");
+        let child = wait_for_url(&page, "/child").await;
+        assert!(child.is_out_of_process());
+
+        page.authenticate(Credentials {
+            username: "user".to_owned(),
+            password: "pass".to_owned(),
+        })
+        .await
+        .expect("credentials reach the existing child before navigation");
+        child
+            .goto(server.url("127.0.0.1", "/auth-child"))
+            .await
+            .expect("authenticated child navigation succeeds");
+        assert_eq!(
+            eval_string(&child, "document.body.dataset.role").await,
+            "auth-child"
+        );
+        assert!(
+            server.request_count("127.0.0.1", "/auth-child") >= 2,
+            "the fixture observes the challenge and authenticated retry"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn bootstrap_interception_does_not_deadlock_page_creation() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = BrowserConfig::builder()
+        .new_headless_mode()
+        .disable_https_first()
+        .enable_request_intercept()
+        .request_timeout(FRAME_TIMEOUT)
+        .user_data_dir(profile.path())
+        .args(["--site-per-process", "--no-proxy-server"])
+        .build()
+        .expect("browser config is valid");
+
+    test_config(config, async |browser| {
+        let page = tokio::time::timeout(
+            FRAME_TIMEOUT,
+            browser.new_page(server.url("localhost", "/main")),
+        )
+        .await
+        .expect("bootstrap interception must not wait for an unavailable responder")
+        .expect("page creation succeeds");
+        assert!(wait_for_url(&page, "/child").await.is_out_of_process());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn closing_target_releases_a_delivered_unanswered_child_pause() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = oopif_config(&profile);
+
+    test_config(config, async |browser| {
+        let page = browser
+            .new_page(server.url("localhost", "/main"))
+            .await
+            .expect("page creation succeeds");
+        let child = wait_for_url(&page, "/child").await;
+        let mut paused_requests = page
+            .paused_requests()
+            .await
+            .expect("managed pause stream registers");
+        page.set_request_interception(true)
+            .await
+            .expect("dynamic Fetch enable reaches the child");
+
+        let child_url = server.url("127.0.0.1", "/child-nav");
+        let mut navigation = Box::pin(child.goto(child_url.clone()));
+        let paused = loop {
+            tokio::select! {
+                result = &mut navigation => {
+                    panic!("child navigation completed before pause delivery: {result:?}");
+                }
+                paused = paused_requests.next() => {
+                    let paused = paused.expect("pause stream remains live");
+                    if paused.event().request.url == child_url {
+                        break paused;
+                    }
+                    paused.continue_request().await.expect("unrelated request is released");
+                }
+            }
+        };
+
+        tokio::time::timeout(FRAME_TIMEOUT, page.clone().close())
+            .await
+            .expect("page close stays bounded")
+            .expect("page closes while the child request is paused");
+        assert!(
+            tokio::time::timeout(FRAME_TIMEOUT, navigation)
+                .await
+                .expect("pending child navigation settles on target close")
+                .is_err()
+        );
+        assert!(
+            tokio::time::timeout(FRAME_TIMEOUT, paused.continue_request())
+                .await
+                .expect("stale paused handle fails without timing out")
+                .is_err()
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn frame_api_supports_nested_oopif_navigation_and_stale_handles() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = oopif_config(&profile);
+
+    test_config(config, async |browser| {
+        let page = browser
+            .new_page("about:blank")
+            .await
+            .expect("page creation succeeds");
+        let main_navigation =
+            tokio::time::timeout(FRAME_TIMEOUT, page.goto(server.url("localhost", "/main"))).await;
+        if main_navigation.is_err() {
+            let frames = page
+                .all_frames()
+                .await
+                .map(|frames| {
+                    frames
+                        .into_iter()
+                        .map(|frame| (frame.id().clone(), frame.session_id().clone(), frame.url()))
+                        .collect::<Vec<_>>()
+                })
+                .ok();
+            panic!(
+                "main navigation timed out; nested_served={}, frames={frames:?}",
+                server.nested_served()
+            );
+        }
+        main_navigation
+            .expect("checked above")
+            .expect("main navigation succeeds");
+        assert!(
+            server.nested_served(),
+            "page navigation returned before the delayed nested OOP document loaded"
+        );
+
+        let main = page
+            .main_frame()
+            .await
+            .expect("main frame lookup succeeds")
+            .expect("main frame exists");
+        assert!(main.is_main_frame());
+        assert!(!main.is_out_of_process());
+        assert_eq!(main.session_id(), page.session_id());
+
+        let child = wait_for_url(&page, "/child").await;
+        let same = wait_for_url(&page, "/same").await;
+        let same_descendant = wait_for_url(&page, "/same-descendant").await;
+        let nested = wait_for_url(&page, "/nested").await;
+        assert!(child.is_out_of_process());
+        assert_ne!(child.session_id(), page.session_id());
+        assert_eq!(same.session_id(), page.session_id());
+        assert_eq!(same_descendant.session_id(), child.session_id());
+        assert_ne!(nested.session_id(), child.session_id());
+        assert_eq!(
+            child
+                .parent()
+                .await
+                .expect("child parent lookup succeeds")
+                .expect("child has a parent")
+                .id(),
+            main.id()
+        );
+        let child_frames = child
+            .child_frames()
+            .await
+            .expect("child frame lookup succeeds");
+        assert!(
+            child_frames
+                .iter()
+                .any(|frame| frame.id() == same_descendant.id())
+        );
+        assert!(child_frames.iter().any(|frame| frame.id() == nested.id()));
+        assert_eq!(
+            page.frame_by_id(child.id().clone())
+                .await
+                .expect("frame lookup succeeds")
+                .expect("child remains present")
+                .session_id(),
+            child.session_id()
+        );
+        assert_eq!(
+            eval_string(&child, "document.body.dataset.role").await,
+            "oop-child"
+        );
+        assert_eq!(
+            eval_string(&same_descendant, "document.body.dataset.role").await,
+            "same-descendant"
+        );
+        assert_eq!(
+            eval_string(&nested, "document.body.dataset.role").await,
+            "nested-oop"
+        );
+
+        let nested_id = nested.id().clone();
+        let nested_return_url = server.url("127.0.0.1", "/nested-return");
+        let nested_return_script = format!(
+            "document.getElementById('nested').src = {}; true",
+            serde_json::to_string(&nested_return_url).expect("URL serializes")
+        );
+        child
+            .eval(nested_return_script)
+            .await
+            .expect("nested child swap-back trigger succeeds");
+        let nested_return =
+            wait_for_binding(&page, &nested_id, "nested S2-to-S1 swap-back", |frame| {
+                frame.session_id() == child.session_id()
+                    && frame
+                        .url()
+                        .is_some_and(|url| url.contains("/nested-return"))
+            })
+            .await;
+        assert_stale(&nested).await;
+        assert_eq!(
+            eval_string(&nested_return, "document.body.dataset.role").await,
+            "nested-return"
+        );
+
+        let child_tree = child
+            .execute(GetFrameTreeParams::default())
+            .await
+            .expect("raw child-session command succeeds")
+            .result;
+        assert_eq!(child_tree.frame_tree.frame.id, *child.id());
+
+        let same_document = same
+            .goto(format!("{}#updated", server.url("localhost", "/same")))
+            .await
+            .expect("same-document frame navigation succeeds");
+        assert_eq!(same_document.frame_id, *same.id());
+        assert_eq!(eval_string(&same, "location.hash").await, "#updated");
+
+        let waited_url = server.url("localhost", "/same-waited");
+        let wait_script = format!(
+            "setTimeout(() => location.href = {}, 0); true",
+            serde_json::to_string(&waited_url).expect("URL serializes")
+        );
+        let (wait_result, trigger_result) = tokio::time::timeout(FRAME_TIMEOUT, async {
+            tokio::join!(same.wait_for_navigation(), same.eval(wait_script))
+        })
+        .await
+        .expect("anticipated frame navigation stays bounded");
+        wait_result.expect("frame navigation waiter succeeds");
+        trigger_result.expect("navigation trigger evaluates before commit");
+        let same_after_wait = wait_for_url(&page, "/same-waited").await;
+        assert_eq!(same_after_wait.id(), same.id());
+
+        let swap_id = same_after_wait.id().clone();
+        set_iframe_src(&page, "swap", &server.url("127.0.0.1", "/swap-cross")).await;
+        let cross_handle = wait_for_binding(&page, &swap_id, "same-to-OOP swap", |frame| {
+            frame.is_out_of_process() && frame.url().is_some_and(|url| url.contains("/swap-cross"))
+        })
+        .await;
+        assert_stale(&same_after_wait).await;
+        assert_eq!(
+            eval_string(&cross_handle, "document.body.dataset.role").await,
+            "swap-cross"
+        );
+
+        set_iframe_src(&page, "swap", &server.url("localhost", "/same-return")).await;
+        let returned_handle = wait_for_binding(&page, &swap_id, "OOP-to-parent swap", |frame| {
+            !frame.is_out_of_process()
+                && frame.url().is_some_and(|url| url.contains("/same-return"))
+        })
+        .await;
+        assert_stale(&cross_handle).await;
+        assert_eq!(
+            eval_string(&returned_handle, "document.body.dataset.role").await,
+            "same-return"
+        );
+
+        page.evaluate("document.getElementById('swap').remove(); true")
+            .await
+            .expect("frame removal script succeeds");
+        wait_for_gone(&page, &swap_id).await;
+        assert_stale(&returned_handle).await;
+
+        let same_descendant_id = same_descendant.id().clone();
+        let error_navigation = tokio::time::timeout(
+            FRAME_TIMEOUT,
+            child.goto(server.url("127.0.0.1", "/http-error")),
+        )
+        .await
+        .expect("HTTP error-page navigation stays bounded")
+        .expect("HTTP status failures still commit their document");
+        assert_eq!(error_navigation.frame_id, *child.id());
+        assert_eq!(
+            eval_string(&child, "document.body.dataset.role").await,
+            "http-error"
+        );
+        wait_for_gone(&page, &nested_id).await;
+        wait_for_gone(&page, &same_descendant_id).await;
+
+        let navigation = tokio::time::timeout(
+            FRAME_TIMEOUT,
+            child.goto(server.url("127.0.0.1", "/child-nav")),
+        )
+        .await
+        .expect("child navigation stays bounded")
+        .expect("child navigation succeeds");
+        assert_eq!(navigation.frame_id, *child.id());
+        assert_eq!(
+            child.fetch_url().await.expect("fresh child URL succeeds"),
+            Some(server.url("127.0.0.1", "/child-nav"))
+        );
+        assert_eq!(
+            eval_string(&child, "document.body.dataset.role").await,
+            "child-nav"
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn element_api_supports_frame_selection_subqueries_disposal_and_oop_geometry() {
+    let server = OopifServer::start().expect("local OOPIF server starts");
+    let profile = OopifProfile::create(server.port).expect("isolated Chrome profile is created");
+    let config = oopif_config(&profile);
+
+    test_config(config, async |browser| {
+        let page = browser
+            .new_page(server.url("localhost", "/main"))
+            .await
+            .expect("page creation and navigation succeed");
+        let child = wait_for_url(&page, "/child").await;
+        let same_descendant = wait_for_url(&page, "/same-descendant").await;
+        let nested = wait_for_url(&page, "/nested").await;
+
+        let page_element = page
+            .find_element("#oop")
+            .await
+            .expect("page selector succeeds");
+        assert!(page_element.node_id.is_some());
+
+        let child_button = query_element(&child, "#child-button").await;
+        assert!(child_button.node_id.is_none());
+        let child_box = child_button
+            .bounding_box()
+            .await
+            .expect("child bounding box succeeds");
+        assert_near(child_box.x, 215.0, "child x");
+        assert_near(child_box.y, 135.0, "child y");
+        assert_near(child_box.width, 100.0, "child width");
+        assert_near(child_box.height, 40.0, "child height");
+
+        let same_button = query_element(&same_descendant, "#target").await;
+        let same_box = same_button
+            .bounding_box()
+            .await
+            .expect("same-session descendant bounding box succeeds");
+        assert_near(same_box.x, 240.0, "same-session descendant x");
+        assert_near(same_box.y, 267.0, "same-session descendant y");
+
+        let nested_button = query_element(&nested, "#target").await;
+        let nested_box = nested_button
+            .bounding_box()
+            .await
+            .expect("nested OOP bounding box succeeds");
+        assert_near(nested_box.x, 475.0, "nested OOP x");
+        assert_near(nested_box.y, 271.0, "nested OOP y");
+
+        let container = query_element(&child, "#container").await;
+        let first = container
+            .find_element(".item")
+            .await
+            .expect("object-centric single subquery succeeds");
+        assert_eq!(
+            first.inner_text().await.expect("text succeeds").as_deref(),
+            Some("first")
+        );
+        assert!(matches!(
+            container.find_element(".missing").await,
+            Err(CdpError::NotFound)
+        ));
+        let items = container
+            .find_elements(".item")
+            .await
+            .expect("object-centric multi subquery succeeds");
+        let mut texts = Vec::new();
+        for item in &items {
+            texts.push(
+                item.inner_text()
+                    .await
+                    .expect("item text succeeds")
+                    .expect("item has text"),
+            );
+        }
+        assert_eq!(texts, ["first", "second"]);
+
+        assert!(
+            child
+                .query_selector("#does-not-exist")
+                .await
+                .expect("null frame selector succeeds")
+                .is_none()
+        );
+        assert!(matches!(
+            child.query_selector("[").await,
+            Err(CdpError::JavascriptException(_))
+        ));
+
+        child_button
+            .click()
+            .await
+            .expect("one-boundary child click succeeds");
+        assert_eq!(
+            eval_string(&child, "document.body.dataset.clicked").await,
+            "child"
+        );
+        same_button
+            .click()
+            .await
+            .expect("same-session descendant click succeeds");
+        assert_eq!(
+            eval_string(&same_descendant, "document.body.dataset.clicked").await,
+            "same"
+        );
+        nested_button
+            .hover()
+            .await
+            .expect("two-boundary nested hover succeeds");
+        assert_eq!(
+            eval_string(&nested, "document.body.dataset.hovered").await,
+            "nested"
+        );
+        nested_button
+            .click()
+            .await
+            .expect("two-boundary nested click succeeds");
+        assert_eq!(
+            eval_string(&nested, "document.body.dataset.clicked").await,
+            "nested"
+        );
+
+        let drop_probe = query_element(&child, "#child-button").await;
+        let drop_probe_clone = drop_probe.clone();
+        drop(drop_probe);
+        assert_eq!(
+            drop_probe_clone
+                .inner_text()
+                .await
+                .expect("Drop does not release the remote object")
+                .as_deref(),
+            Some("child")
+        );
+
+        let disposed_clone = drop_probe_clone.clone();
+        drop_probe_clone
+            .dispose()
+            .await
+            .expect("explicit remote-object disposal succeeds");
+        assert!(disposed_clone.inner_text().await.is_err());
+    })
+    .await;
+}


### PR DESCRIPTION
### Issue #

Closes [#280](https://github.com/mattsse/chromiumoxide/issues/280).

Related to [#296](https://github.com/mattsse/chromiumoxide/issues/296):
this adds frame-scoped element lookup, but not a public `Element` constructor
for arbitrary CDP identifiers.

### Description of changes

This adds first-class support for cross-origin, out-of-process iframes
(OOPIFs).

Previously, chromiumoxide could discover iframe targets, but their child CDP
sessions were not connected to the higher-level `Page`, `Frame`, `Element`,
navigation, execution-context, and interception APIs. Callers therefore had to
work with raw `SessionId` values and CDP commands.

The frame model follows the same core idea as Puppeteer's `Frame` abstraction:
a frame keeps a stable identity while its effective CDP session may change as
site isolation moves it between processes.

The attach sequence differs deliberately from Puppeteer's unpause-early
approach. Chromiumoxide registers the child session's initialization work while
the iframe target is still paused, then resumes it after that initialization
chain is in place.

#### Frames and sessions

- Add `Page::main_frame`, `Page::all_frames`, and `Page::frame_by_id`.
- Add session-pinned `Frame::execute`, `Frame::eval`,
  `Frame::query_selector`, `Frame::goto`, and
  `Frame::wait_for_navigation`.
- Recursively attach and initialize child iframe sessions.
- Route Runtime, DOM, Network, lifecycle, and navigation work through the
  session that currently owns the frame.
- Keep frame identity stable across site-isolation-induced process swaps,
  including swaps back to the main process.
- Scope execution contexts by session as well as execution-context identity.

#### Elements, interception, and lifecycle

- Make `Element` operations session-aware, including geometry accumulation
  across frame boundaries.
- Add explicit remote-object cleanup through `Element::dispose`.
- Capture the session that produced `Fetch.requestPaused`, so interception
  responses are sent through the same session.
- Replay preload scripts and relevant Network/Emulation state when child iframe
  sessions attach.
- Complete pending commands, navigation requests, and page-creation requests
  when a child session detaches, a target is destroyed, or the connection
  closes.

Fetch interception in this PR is session-local: a paused request is handled on
the session that produced it. Adopting an entire request lifecycle across
sessions remains follow-up work.

#### Breaking changes

- `Element::node_id` changes from `NodeId` to `Option<NodeId>`. Runtime-based
  frame queries can return valid elements without a frontend node id.
  Downstream code that reads this field directly will need to handle `None`.
- `CdpError` becomes `#[non_exhaustive]` and gains frame- and
  interception-specific variants. Downstream exhaustive matches will need a
  wildcard arm.

`Page.navigate` sent through `Frame::execute` is rejected immediately with
`CdpError::NotAllowed`. A raw navigation command would bypass the frame-aware
navigation watcher and routing checks. Use `Frame::goto`, which keeps the frame
and session binding intact.

#### Validation

- Library tests: 128 passed
- Compatibility tests: 2 passed
- Local OOPIF integration tests: 7 passed, run twice to exercise attach/detach
  stability
- `cargo check --workspace --all-targets`
- Examples compile
- Clippy with `-D warnings`
- Formatting and diff checks

The integration tests use local cross-site fixtures (`localhost` and
`127.0.0.1`) with site isolation enabled. They cover nested OOPIFs, process
swaps, JavaScript evaluation, elements, navigation, request interception,
authentication, preload replay, stale handles, detach, and teardown.

#### Follow-up work

This PR covers the core OOPIF interaction path. Broader state-management work
is intentionally kept separate:

- Reconciliation and fan-out for dynamically changed Network settings.
- Cross-frame `expose_function` and User-Agent replay.
- Preload removal, stealth-script replay, and isolated-world recovery.
- Explicit operation gating during the short `frameAttached` to
  `attachedToTarget` handoff.
- Full request-lifecycle adoption across sessions.

### Checklist

- [x] Added change to the changelog
- [x] Created unit tests for my feature (if needed)
- [x] Created a least one integration test
