### PR TITLE
handler: bound each Page command by HandlerConfig::request_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Derive `Clone` for `Element`, `ScreenshotParams` and `ScreenshotParamsBuilder`
+- `HandlerConfig::request_timeout` now also bounds each `Page` command future. Previously every command was cut off after a hard-coded 30 seconds (`handler::REQUEST_TIMEOUT`) regardless of the configured value, so a `Runtime.evaluate` awaiting a promise that settles later than that always failed with `CdpError::Timeout`.
 
 ## [0.9.1] 2026-02-25
 

--- a/src/handler/commandfuture.rs
+++ b/src/handler/commandfuture.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use crate::cmd::{CommandMessage, to_command_response};
 use crate::error::Result;
@@ -22,7 +23,8 @@ pin_project! {
         target_sender: mpsc::Sender<TargetMessage>,
         // We need delay to be pinned because it's a future
         // and we need to be able to poll it
-        // it is used to timeout the command if page was closed while waiting for response
+        // it is used to timeout the command if page was closed while waiting for response.
+        // The duration is the handler's configured `request_timeout`.
         #[pin]
         delay: futures_timer::Delay,
 
@@ -39,6 +41,7 @@ impl<T: Command> CommandFuture<T> {
         cmd: T,
         target_sender: mpsc::Sender<TargetMessage>,
         session: Option<SessionId>,
+        request_timeout: Duration,
     ) -> Result<Self> {
         let (tx, rx_command) = oneshot_channel::<Result<Response>>();
         let method = cmd.identifier();
@@ -47,9 +50,7 @@ impl<T: Command> CommandFuture<T> {
             cmd, tx, session,
         )?));
 
-        let delay = futures_timer::Delay::new(std::time::Duration::from_millis(
-            crate::handler::REQUEST_TIMEOUT,
-        ));
+        let delay = futures_timer::Delay::new(request_timeout);
 
         Ok(Self {
             target_sender,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -31,6 +31,7 @@ use crate::handler::viewport::Viewport;
 use crate::page::Page;
 
 /// Standard timeout in MS
+/// Default per-command timeout in milliseconds; see `HandlerConfig::request_timeout`.
 pub const REQUEST_TIMEOUT: u64 = 30_000;
 
 pub mod browser;

--- a/src/handler/page.rs
+++ b/src/handler/page.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::channel::mpsc::{Receiver, Sender, channel};
 use futures::channel::oneshot::channel as oneshot_channel;
@@ -46,13 +47,19 @@ pub struct PageHandle {
 }
 
 impl PageHandle {
-    pub fn new(target_id: TargetId, session_id: SessionId, opener_id: Option<TargetId>) -> Self {
+    pub fn new(
+        target_id: TargetId,
+        session_id: SessionId,
+        opener_id: Option<TargetId>,
+        request_timeout: Duration,
+    ) -> Self {
         let (commands, rx) = channel(1);
         let page = PageInner {
             target_id,
             session_id,
             opener_id,
             sender: commands,
+            request_timeout,
         };
         Self {
             rx: rx.fuse(),
@@ -71,6 +78,8 @@ pub(crate) struct PageInner {
     session_id: SessionId,
     opener_id: Option<TargetId>,
     sender: Sender<TargetMessage>,
+    /// How long a single command may wait for its response, from `HandlerConfig::request_timeout`.
+    request_timeout: Duration,
 }
 
 impl PageInner {
@@ -81,7 +90,12 @@ impl PageInner {
 
     /// Create a PDL command future
     pub(crate) fn command_future<T: Command>(&self, cmd: T) -> Result<CommandFuture<T>> {
-        CommandFuture::new(cmd, self.sender.clone(), Some(self.session_id.clone()))
+        CommandFuture::new(
+            cmd,
+            self.sender.clone(),
+            Some(self.session_id.clone()),
+            self.request_timeout,
+        )
     }
 
     /// This creates navigation future with the final http response when the page is loaded

--- a/src/handler/target.rs
+++ b/src/handler/target.rs
@@ -162,8 +162,12 @@ impl Target {
     fn create_page(&mut self) {
         if self.page.is_none() {
             if let Some(session) = self.session_id.clone() {
-                let handle =
-                    PageHandle::new(self.target_id().clone(), session, self.opener_id().cloned());
+                let handle = PageHandle::new(
+                    self.target_id().clone(),
+                    session,
+                    self.opener_id().cloned(),
+                    self.config.request_timeout,
+                );
                 self.page = Some(handle);
             }
         }


### PR DESCRIPTION
## Problem

`CommandFuture::new` starts its timer from the hard-coded `handler::REQUEST_TIMEOUT` (30 s) regardless of what the caller put in `HandlerConfig::request_timeout`. The configured value only drives the periodic eviction of unanswered commands, so a `Page::execute` that Chrome legitimately answers after 30 s always fails with `CdpError::Timeout` — for example a `Runtime.evaluate` with `awaitPromise: true` whose promise settles at 35 s, even with `request_timeout` set to minutes.

## Fix

Thread the per-target `request_timeout` (already carried in `TargetConfig`) through `PageHandle::new` → `PageInner` → `CommandFuture::new`, and use it for the `futures_timer::Delay`. `REQUEST_TIMEOUT` stays as the default, so behaviour is unchanged for callers who never touch the config.

- `src/handler/commandfuture.rs`: `CommandFuture::new` takes `request_timeout: Duration`.
- `src/handler/page.rs`: `PageHandle::new` takes it and stores it on `PageInner`; `command_future` passes it on.
- `src/handler/target.rs`: pass `self.config.request_timeout` when the page handle is created.
- CHANGELOG entry under Unreleased.

`Browser::execute` (browser-level commands) is untouched — it has no per-command timer today.

## Verification

`cargo check` / `cargo test -p chromiumoxide` on this branch. Exercised end to end from a daemon that sets `request_timeout` to 180 s: a `Runtime.evaluate` that takes 40 s now returns its value; on `main` the same call fails at 30 s with `Request timed out`.